### PR TITLE
feat: skills.json manifest generator for programmatic discovery

### DIFF
--- a/bitflow/SKILL.md
+++ b/bitflow/SKILL.md
@@ -3,6 +3,10 @@ name: bitflow
 description: Bitflow DEX on Stacks — token swaps with aggregated liquidity, market ticker data, swap routing, price impact analysis, and Keeper automation for scheduled orders. All operations are mainnet-only. No API key required (500 req/min public rate limit). Write operations require an unlocked wallet.
 user-invocable: false
 arguments: get-ticker | get-tokens | get-swap-targets | get-quote | get-routes | swap | get-keeper-contract | create-order | get-order | cancel-order | get-keeper-user
+category: defi
+requires: [wallet]
+tags: [requires-wallet, mainnet-only, has-read-ops, has-write-ops, requires-funds]
+entry-point: bitflow.ts
 ---
 
 # Bitflow Skill

--- a/bns/SKILL.md
+++ b/bns/SKILL.md
@@ -3,6 +3,10 @@ name: bns
 description: Bitcoin Name System (BNS) operations — lookup names, reverse-lookup addresses, check availability, get pricing, list domains, and register new .btc names using single-transaction claim or two-step preorder/register flow.
 user-invocable: false
 arguments: lookup | reverse-lookup | get-info | check-availability | get-price | list-user-domains | claim-fast | preorder | register
+category: assets
+requires: [wallet]
+tags: [requires-wallet, has-read-ops, has-write-ops, requires-funds]
+entry-point: bns.ts
 ---
 
 # BNS Skill

--- a/btc/SKILL.md
+++ b/btc/SKILL.md
@@ -3,6 +3,10 @@ name: btc
 description: Bitcoin L1 operations — check balances, estimate fees, list UTXOs, transfer BTC, and classify UTXOs as cardinal (safe to spend) or ordinal (contain inscriptions). Data sourced from mempool.space and the Hiro Ordinals API.
 user-invocable: false
 arguments: balance | fees | utxos | transfer | get-cardinal-utxos | get-ordinal-utxos | get-inscriptions
+category: bitcoin-l1
+requires: [wallet]
+tags: [requires-wallet, has-read-ops, has-write-ops, requires-funds]
+entry-point: btc.ts
 ---
 
 # BTC Skill

--- a/credentials/SKILL.md
+++ b/credentials/SKILL.md
@@ -3,6 +3,10 @@ name: credentials
 description: Encrypted credential store — add, retrieve, list, and delete named secrets (API keys, tokens, passwords) stored AES-256-GCM encrypted at ~/.aibtc/credentials.json. Each write operation requires the master password; listing metadata does not.
 user-invocable: false
 arguments: add | get | list | delete | rotate-password
+category: wallet-keys
+requires: []
+tags: [has-read-ops, has-write-ops]
+entry-point: cli.ts
 ---
 
 # Credentials Skill

--- a/defi/SKILL.md
+++ b/defi/SKILL.md
@@ -3,6 +3,10 @@ name: defi
 description: DeFi operations on Stacks — ALEX DEX token swaps and liquidity pool queries, plus Zest Protocol lending (supply, withdraw, borrow, repay, claim rewards). All operations are mainnet-only. Write operations require an unlocked wallet.
 user-invocable: false
 arguments: alex-get-swap-quote | alex-swap | alex-get-pool-info | alex-list-pools | zest-list-assets | zest-get-position | zest-supply | zest-withdraw | zest-borrow | zest-repay | zest-claim-rewards
+category: defi
+requires: [wallet]
+tags: [requires-wallet, mainnet-only, has-read-ops, has-write-ops, requires-funds]
+entry-point: defi.ts
 ---
 
 # DeFi Skill

--- a/identity/SKILL.md
+++ b/identity/SKILL.md
@@ -3,6 +3,10 @@ name: identity
 description: ERC-8004 on-chain agent identity and reputation management — register agent identities, query identity info, submit and retrieve reputation feedback, and manage third-party validation requests.
 user-invocable: false
 arguments: register | get | give-feedback | get-reputation | request-validation | get-validation-status | get-validation-summary
+category: identity
+requires: [wallet]
+tags: [requires-wallet, has-read-ops, has-write-ops]
+entry-point: identity.ts
 ---
 
 # Identity Skill

--- a/nft/SKILL.md
+++ b/nft/SKILL.md
@@ -3,6 +3,10 @@ name: nft
 description: SIP-009 NFT operations on Stacks L2 — list NFT holdings, get token metadata, transfer NFTs, get token owner, get collection information, and get transfer history. Transfer operations require an unlocked wallet.
 user-invocable: false
 arguments: get-holdings | get-metadata | transfer | get-owner | get-collection-info | get-history
+category: assets
+requires: [wallet]
+tags: [requires-wallet, has-read-ops, has-write-ops]
+entry-point: nft.ts
 ---
 
 # NFT Skill

--- a/ordinals/SKILL.md
+++ b/ordinals/SKILL.md
@@ -3,6 +3,10 @@ name: ordinals
 description: Bitcoin ordinals operations — get the Taproot receive address, estimate inscription fees, create inscriptions via the two-step commit/reveal pattern, and fetch existing inscription content from reveal transactions.
 user-invocable: false
 arguments: get-taproot-address | estimate-fee | inscribe | inscribe-reveal | get-inscription
+category: bitcoin-l1
+requires: [wallet]
+tags: [requires-wallet, has-read-ops, has-write-ops, requires-funds]
+entry-point: ordinals.ts
 ---
 
 # Ordinals Skill

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "type": "module",
   "scripts": {
     "build": "bun build src/lib/index.ts --outdir dist",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "generate-manifest": "bun run scripts/generate-skills-json.ts",
+    "check-manifest": "bun run scripts/generate-skills-json.ts --check"
   },
   "keywords": [
     "claude",

--- a/pillar/SKILL.md
+++ b/pillar/SKILL.md
@@ -3,6 +3,10 @@ name: pillar
 description: Pillar smart wallet operations in two modes — browser-handoff (pillar.ts) opens the Pillar frontend for user signing, and agent-signed direct (pillar-direct.ts) signs locally with a secp256k1 keypair and submits directly to the Pillar API (no browser required, gas sponsored). Supports sBTC send/supply/boost/unwind, DCA programs, stacking, key management, wallet creation, and position queries.
 user-invocable: false
 arguments: connect | disconnect | status | send | fund | add-admin | supply | auto-compound | unwind | boost | position | create-wallet | invite | dca-invite | dca-partners | dca-leaderboard | dca-status | key-generate | key-unlock | key-lock | key-info | direct-boost | direct-unwind | direct-supply | direct-send | direct-auto-compound | direct-position | direct-withdraw-collateral | direct-add-admin | direct-create-wallet | direct-dca-invite | direct-dca-partners | direct-dca-leaderboard | direct-dca-status | direct-quote | direct-resolve-recipient | direct-stack-stx | direct-revoke-fast-pool | direct-stacking-status
+category: smart-wallets
+requires: [wallet]
+tags: [requires-wallet, mainnet-only, has-read-ops, has-write-ops, requires-funds]
+entry-point: pillar.ts
 ---
 
 # Pillar Skill

--- a/query/SKILL.md
+++ b/query/SKILL.md
@@ -3,6 +3,10 @@ name: query
 description: Stacks network and blockchain query operations — get STX fees, account info, transaction history, block info, mempool transactions, contract info and events, network status, and call read-only contract functions. All queries use the Hiro API.
 user-invocable: false
 arguments: get-stx-fees | get-account-info | get-account-transactions | get-block-info | get-mempool-info | get-contract-info | get-contract-events | get-network-status | call-read-only
+category: stacks-l2
+requires: []
+tags: [read-only, has-read-ops]
+entry-point: query.ts
 ---
 
 # Query Skill

--- a/sbtc/SKILL.md
+++ b/sbtc/SKILL.md
@@ -3,6 +3,10 @@ name: sbtc
 description: sBTC token operations on Stacks L2 — check balances, transfer sBTC, get deposit info, check peg statistics, deposit BTC to receive sBTC, and track deposit status. Transfer and deposit operations require an unlocked wallet.
 user-invocable: false
 arguments: get-balance | transfer | get-deposit-info | get-peg-info | deposit | deposit-status
+category: assets
+requires: [wallet]
+tags: [requires-wallet, has-read-ops, has-write-ops, requires-funds]
+entry-point: sbtc.ts
 ---
 
 # sBTC Skill

--- a/scripts/generate-skills-json.ts
+++ b/scripts/generate-skills-json.ts
@@ -1,0 +1,219 @@
+#!/usr/bin/env bun
+/**
+ * Generate skills.json manifest from SKILL.md and AGENT.md frontmatter.
+ *
+ * Scans all skill directories, parses YAML frontmatter, validates against
+ * the Zod schema, and writes a machine-readable skills.json to the repo root.
+ *
+ * Usage:
+ *   bun run scripts/generate-skills-json.ts
+ *   bun run scripts/generate-skills-json.ts --check   # validate only, exit 1 if out of date
+ */
+
+import { readdir, readFile, writeFile, stat } from "node:fs/promises";
+import { join, resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  SkillFrontmatterSchema,
+  AgentFrontmatterSchema,
+  type SkillsManifest,
+  type SkillManifestEntry,
+} from "./schema.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, "..");
+
+// Directories that are not skills
+const SKIP_DIRS = new Set([
+  "node_modules",
+  "dist",
+  "src",
+  "scripts",
+  ".git",
+  ".github",
+  "what-to-do",
+  "aibtc-agents",
+]);
+
+/** Parse YAML frontmatter from a markdown file (between --- delimiters). */
+function parseFrontmatter(content: string): Record<string, unknown> {
+  const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!match) return {};
+
+  const yaml = match[1];
+  const result: Record<string, unknown> = {};
+
+  for (const line of yaml.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+
+    const colonIdx = trimmed.indexOf(":");
+    if (colonIdx === -1) continue;
+
+    const key = trimmed.slice(0, colonIdx).trim();
+    let value: unknown = trimmed.slice(colonIdx + 1).trim();
+
+    // Parse arrays: [item1, item2] or [item1]
+    if (typeof value === "string" && value.startsWith("[") && value.endsWith("]")) {
+      const inner = value.slice(1, -1).trim();
+      value = inner ? inner.split(",").map((s) => s.trim()) : [];
+    }
+    // Parse booleans
+    else if (value === "true") value = true;
+    else if (value === "false") value = false;
+
+    result[key] = value;
+  }
+
+  return result;
+}
+
+async function isDirectory(path: string): Promise<boolean> {
+  try {
+    return (await stat(path)).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+async function fileExists(path: string): Promise<boolean> {
+  try {
+    await stat(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function main() {
+  const checkMode = process.argv.includes("--check");
+  const entries = await readdir(ROOT);
+  const skills: SkillManifestEntry[] = [];
+  const errors: string[] = [];
+
+  for (const entry of entries.sort()) {
+    if (SKIP_DIRS.has(entry) || entry.startsWith(".")) continue;
+
+    const dirPath = join(ROOT, entry);
+    if (!(await isDirectory(dirPath))) continue;
+
+    const skillMdPath = join(dirPath, "SKILL.md");
+    if (!(await fileExists(skillMdPath))) continue;
+
+    // Parse SKILL.md
+    const skillContent = await readFile(skillMdPath, "utf-8");
+    const raw = parseFrontmatter(skillContent);
+
+    const parsed = SkillFrontmatterSchema.safeParse(raw);
+    if (!parsed.success) {
+      const issues = parsed.error.issues
+        .map((i) => `  ${i.path.join(".")}: ${i.message}`)
+        .join("\n");
+      errors.push(`${entry}/SKILL.md frontmatter validation failed:\n${issues}`);
+      continue;
+    }
+
+    const fm = parsed.data;
+
+    // Parse AGENT.md if present
+    let agent: { name: string; description: string } | undefined;
+    const agentMdPath = join(dirPath, "AGENT.md");
+    if (await fileExists(agentMdPath)) {
+      const agentContent = await readFile(agentMdPath, "utf-8");
+      const agentRaw = parseFrontmatter(agentContent);
+      const agentParsed = AgentFrontmatterSchema.safeParse(agentRaw);
+      if (agentParsed.success) {
+        agent = {
+          name: agentParsed.data.name,
+          description: agentParsed.data.description,
+        };
+      }
+    }
+
+    // Build manifest entry
+    const args = fm.arguments
+      .split("|")
+      .map((s) => s.trim())
+      .filter(Boolean);
+
+    skills.push({
+      name: fm.name,
+      description: fm.description,
+      category: fm.category,
+      "user-invocable": fm["user-invocable"],
+      "entry-point": fm["entry-point"],
+      arguments: args,
+      requires: fm.requires,
+      tags: fm.tags,
+      ...(agent && { agent }),
+    });
+  }
+
+  if (errors.length > 0) {
+    console.error("Validation errors:\n");
+    for (const err of errors) {
+      console.error(err);
+      console.error();
+    }
+    process.exit(1);
+  }
+
+  const manifest: SkillsManifest = {
+    $schema: "./scripts/skills-manifest-schema.json",
+    version: "1.0.0",
+    generated: new Date().toISOString(),
+    skills,
+  };
+
+  const json = JSON.stringify(manifest, null, 2) + "\n";
+
+  if (checkMode) {
+    // Compare with existing skills.json
+    const existingPath = join(ROOT, "skills.json");
+    let existing = "";
+    try {
+      existing = await readFile(existingPath, "utf-8");
+    } catch {
+      console.error("skills.json does not exist. Run without --check to generate.");
+      process.exit(1);
+    }
+
+    // Compare ignoring the generated timestamp
+    const normalize = (s: string) =>
+      JSON.parse(s, (key, val) => (key === "generated" ? "<timestamp>" : val));
+    const existingNorm = JSON.stringify(normalize(existing));
+    const newNorm = JSON.stringify(normalize(json));
+
+    if (existingNorm !== newNorm) {
+      console.error(
+        "skills.json is out of date. Run `bun run scripts/generate-skills-json.ts` to regenerate."
+      );
+      process.exit(1);
+    }
+
+    console.log(`skills.json is up to date (${skills.length} skills).`);
+    process.exit(0);
+  }
+
+  // Write manifest
+  const outPath = join(ROOT, "skills.json");
+  await writeFile(outPath, json);
+  console.log(`Generated skills.json with ${skills.length} skills.`);
+
+  // Summary table
+  console.log("\nSkills by category:");
+  const byCategory = new Map<string, string[]>();
+  for (const s of skills) {
+    const list = byCategory.get(s.category) ?? [];
+    list.push(s.name);
+    byCategory.set(s.category, list);
+  }
+  for (const [cat, names] of [...byCategory.entries()].sort()) {
+    console.log(`  ${cat}: ${names.join(", ")}`);
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/schema.ts
+++ b/scripts/schema.ts
@@ -1,0 +1,94 @@
+/**
+ * Zod schemas for SKILL.md and AGENT.md frontmatter validation.
+ *
+ * Used by:
+ *   - generate-skills-json.ts to validate parsed frontmatter
+ *   - CI to catch malformed skills before merge
+ */
+
+import { z } from "zod";
+
+// --- SKILL.md frontmatter ---
+
+export const SkillFrontmatterSchema = z.object({
+  name: z.string().min(1).describe("Skill identifier (directory name)"),
+  description: z.string().min(1).describe("One-line description"),
+  "user-invocable": z.boolean().describe("Whether users can invoke directly"),
+  arguments: z.string().min(1).describe("Pipe-separated subcommands"),
+  category: z
+    .enum([
+      "wallet-keys",
+      "bitcoin-l1",
+      "stacks-l2",
+      "assets",
+      "defi",
+      "identity",
+      "payments",
+      "smart-wallets",
+    ])
+    .describe("Skill category for grouping"),
+  requires: z
+    .array(z.string())
+    .default([])
+    .describe("Skills that must be available (e.g. wallet unlock)"),
+  tags: z
+    .array(
+      z.enum([
+        "read-only",
+        "mainnet-only",
+        "requires-funds",
+        "requires-wallet",
+        "has-write-ops",
+        "has-read-ops",
+      ])
+    )
+    .default([])
+    .describe("Capability tags for filtering"),
+  "entry-point": z
+    .string()
+    .min(1)
+    .describe("CLI entry point relative to skill directory"),
+});
+
+export type SkillFrontmatter = z.infer<typeof SkillFrontmatterSchema>;
+
+// --- AGENT.md frontmatter ---
+
+export const AgentFrontmatterSchema = z.object({
+  name: z.string().min(1).describe("Agent identifier"),
+  skill: z.string().min(1).describe("Associated skill name"),
+  description: z.string().min(1).describe("Agent capability summary"),
+});
+
+export type AgentFrontmatter = z.infer<typeof AgentFrontmatterSchema>;
+
+// --- skills.json manifest ---
+
+export const SkillManifestEntrySchema = z.object({
+  name: z.string(),
+  description: z.string(),
+  category: SkillFrontmatterSchema.shape.category,
+  "user-invocable": z.boolean(),
+  "entry-point": z.string(),
+  arguments: z.array(z.string()).describe("Parsed subcommand list"),
+  requires: z.array(z.string()),
+  tags: z.array(z.string()),
+  agent: z
+    .object({
+      name: z.string(),
+      description: z.string(),
+    })
+    .optional()
+    .describe("From colocated AGENT.md if present"),
+});
+
+export type SkillManifestEntry = z.infer<typeof SkillManifestEntrySchema>;
+
+export const SkillsManifestSchema = z.object({
+  $schema: z.string().optional(),
+  version: z.string().describe("Manifest schema version"),
+  generated: z.string().describe("ISO 8601 generation timestamp"),
+  skills: z.array(SkillManifestEntrySchema),
+});
+
+export type SkillsManifest = z.infer<typeof SkillsManifestSchema>;

--- a/settings/SKILL.md
+++ b/settings/SKILL.md
@@ -3,6 +3,10 @@ name: settings
 description: Manage AIBTC skill settings stored at ~/.aibtc/config.json. Configure the Hiro API key for authenticated rate limits, set a custom Stacks API node URL, and check the current package version.
 user-invocable: false
 arguments: set-hiro-api-key | get-hiro-api-key | delete-hiro-api-key | set-stacks-api-url | get-stacks-api-url | delete-stacks-api-url | get-server-version
+category: stacks-l2
+requires: []
+tags: [has-read-ops, has-write-ops]
+entry-point: settings.ts
 ---
 
 # Settings Skill

--- a/signing/SKILL.md
+++ b/signing/SKILL.md
@@ -3,6 +3,10 @@ name: signing
 description: Message signing and verification — SIP-018 structured Clarity data signing (on-chain verifiable), Stacks plain-text message signing (SIWS-compatible), Bitcoin BIP-137 message signing, and BIP-340 Schnorr signing for Taproot multisig. All signing requires an unlocked wallet; hash and verify operations do not.
 user-invocable: false
 arguments: sip018-sign | sip018-verify | sip018-hash | stacks-sign | stacks-verify | btc-sign | btc-verify | schnorr-sign-digest | schnorr-verify-digest
+category: bitcoin-l1
+requires: [wallet]
+tags: [requires-wallet, has-read-ops, has-write-ops]
+entry-point: signing.ts
 ---
 
 # Signing Skill

--- a/skills.json
+++ b/skills.json
@@ -1,0 +1,581 @@
+{
+  "$schema": "./scripts/skills-manifest-schema.json",
+  "version": "1.0.0",
+  "generated": "2026-02-20T16:53:19.400Z",
+  "skills": [
+    {
+      "name": "bitflow",
+      "description": "Bitflow DEX on Stacks — token swaps with aggregated liquidity, market ticker data, swap routing, price impact analysis, and Keeper automation for scheduled orders. All operations are mainnet-only. No API key required (500 req/min public rate limit). Write operations require an unlocked wallet.",
+      "category": "defi",
+      "user-invocable": false,
+      "entry-point": "bitflow.ts",
+      "arguments": [
+        "get-ticker",
+        "get-tokens",
+        "get-swap-targets",
+        "get-quote",
+        "get-routes",
+        "swap",
+        "get-keeper-contract",
+        "create-order",
+        "get-order",
+        "cancel-order",
+        "get-keeper-user"
+      ],
+      "requires": [
+        "wallet"
+      ],
+      "tags": [
+        "requires-wallet",
+        "mainnet-only",
+        "has-read-ops",
+        "has-write-ops",
+        "requires-funds"
+      ],
+      "agent": {
+        "name": "bitflow-agent",
+        "description": "Bitflow DEX operations on Stacks mainnet — token swaps with aggregated liquidity, price quotes, route discovery, market ticker data, and Keeper automation for scheduled orders."
+      }
+    },
+    {
+      "name": "bns",
+      "description": "Bitcoin Name System (BNS) operations — lookup names, reverse-lookup addresses, check availability, get pricing, list domains, and register new .btc names using single-transaction claim or two-step preorder/register flow.",
+      "category": "assets",
+      "user-invocable": false,
+      "entry-point": "bns.ts",
+      "arguments": [
+        "lookup",
+        "reverse-lookup",
+        "get-info",
+        "check-availability",
+        "get-price",
+        "list-user-domains",
+        "claim-fast",
+        "preorder",
+        "register"
+      ],
+      "requires": [
+        "wallet"
+      ],
+      "tags": [
+        "requires-wallet",
+        "has-read-ops",
+        "has-write-ops",
+        "requires-funds"
+      ],
+      "agent": {
+        "name": "bns-agent",
+        "description": "Bitcoin Name System (BNS) operations — lookup and reverse-lookup .btc names, check availability, get pricing, list owned domains, and register new names via fast-claim or two-step preorder/register."
+      }
+    },
+    {
+      "name": "btc",
+      "description": "Bitcoin L1 operations — check balances, estimate fees, list UTXOs, transfer BTC, and classify UTXOs as cardinal (safe to spend) or ordinal (contain inscriptions). Data sourced from mempool.space and the Hiro Ordinals API.",
+      "category": "bitcoin-l1",
+      "user-invocable": false,
+      "entry-point": "btc.ts",
+      "arguments": [
+        "balance",
+        "fees",
+        "utxos",
+        "transfer",
+        "get-cardinal-utxos",
+        "get-ordinal-utxos",
+        "get-inscriptions"
+      ],
+      "requires": [
+        "wallet"
+      ],
+      "tags": [
+        "requires-wallet",
+        "has-read-ops",
+        "has-write-ops",
+        "requires-funds"
+      ],
+      "agent": {
+        "name": "btc-agent",
+        "description": "Bitcoin L1 operations — check balances, estimate fees, list UTXOs, transfer BTC, and classify UTXOs as cardinal or ordinal to avoid accidentally spending inscriptions."
+      }
+    },
+    {
+      "name": "credentials",
+      "description": "Encrypted credential store — add, retrieve, list, and delete named secrets (API keys, tokens, passwords) stored AES-256-GCM encrypted at ~/.aibtc/credentials.json. Each write operation requires the master password; listing metadata does not.",
+      "category": "wallet-keys",
+      "user-invocable": false,
+      "entry-point": "cli.ts",
+      "arguments": [
+        "add",
+        "get",
+        "list",
+        "delete",
+        "rotate-password"
+      ],
+      "requires": [],
+      "tags": [
+        "has-read-ops",
+        "has-write-ops"
+      ],
+      "agent": {
+        "name": "credentials-agent",
+        "description": "Manages AES-256-GCM encrypted secrets — add, retrieve, list, delete, and rotate named credentials stored at ~/.aibtc/credentials.json."
+      }
+    },
+    {
+      "name": "defi",
+      "description": "DeFi operations on Stacks — ALEX DEX token swaps and liquidity pool queries, plus Zest Protocol lending (supply, withdraw, borrow, repay, claim rewards). All operations are mainnet-only. Write operations require an unlocked wallet.",
+      "category": "defi",
+      "user-invocable": false,
+      "entry-point": "defi.ts",
+      "arguments": [
+        "alex-get-swap-quote",
+        "alex-swap",
+        "alex-get-pool-info",
+        "alex-list-pools",
+        "zest-list-assets",
+        "zest-get-position",
+        "zest-supply",
+        "zest-withdraw",
+        "zest-borrow",
+        "zest-repay",
+        "zest-claim-rewards"
+      ],
+      "requires": [
+        "wallet"
+      ],
+      "tags": [
+        "requires-wallet",
+        "mainnet-only",
+        "has-read-ops",
+        "has-write-ops",
+        "requires-funds"
+      ],
+      "agent": {
+        "name": "defi-agent",
+        "description": "DeFi operations on Stacks mainnet — ALEX DEX token swaps and pool queries, plus Zest Protocol lending (supply, withdraw, borrow, repay, claim rewards)."
+      }
+    },
+    {
+      "name": "identity",
+      "description": "ERC-8004 on-chain agent identity and reputation management — register agent identities, query identity info, submit and retrieve reputation feedback, and manage third-party validation requests.",
+      "category": "identity",
+      "user-invocable": false,
+      "entry-point": "identity.ts",
+      "arguments": [
+        "register",
+        "get",
+        "give-feedback",
+        "get-reputation",
+        "request-validation",
+        "get-validation-status",
+        "get-validation-summary"
+      ],
+      "requires": [
+        "wallet"
+      ],
+      "tags": [
+        "requires-wallet",
+        "has-read-ops",
+        "has-write-ops"
+      ],
+      "agent": {
+        "name": "identity-agent",
+        "description": "ERC-8004 on-chain agent identity and reputation management — register agent identities, query identity info, submit reputation feedback, and manage third-party validation requests."
+      }
+    },
+    {
+      "name": "nft",
+      "description": "SIP-009 NFT operations on Stacks L2 — list NFT holdings, get token metadata, transfer NFTs, get token owner, get collection information, and get transfer history. Transfer operations require an unlocked wallet.",
+      "category": "assets",
+      "user-invocable": false,
+      "entry-point": "nft.ts",
+      "arguments": [
+        "get-holdings",
+        "get-metadata",
+        "transfer",
+        "get-owner",
+        "get-collection-info",
+        "get-history"
+      ],
+      "requires": [
+        "wallet"
+      ],
+      "tags": [
+        "requires-wallet",
+        "has-read-ops",
+        "has-write-ops"
+      ],
+      "agent": {
+        "name": "nft-agent",
+        "description": "SIP-009 NFT operations on Stacks L2 — list holdings, get metadata, transfer NFTs, query ownership, get collection info, and retrieve transfer history."
+      }
+    },
+    {
+      "name": "ordinals",
+      "description": "Bitcoin ordinals operations — get the Taproot receive address, estimate inscription fees, create inscriptions via the two-step commit/reveal pattern, and fetch existing inscription content from reveal transactions.",
+      "category": "bitcoin-l1",
+      "user-invocable": false,
+      "entry-point": "ordinals.ts",
+      "arguments": [
+        "get-taproot-address",
+        "estimate-fee",
+        "inscribe",
+        "inscribe-reveal",
+        "get-inscription"
+      ],
+      "requires": [
+        "wallet"
+      ],
+      "tags": [
+        "requires-wallet",
+        "has-read-ops",
+        "has-write-ops",
+        "requires-funds"
+      ],
+      "agent": {
+        "name": "ordinals-agent",
+        "description": "Bitcoin ordinals operations — get the Taproot receive address, estimate inscription fees, create inscriptions via two-step commit/reveal, and fetch existing inscription content."
+      }
+    },
+    {
+      "name": "pillar",
+      "description": "Pillar smart wallet operations in two modes — browser-handoff (pillar.ts) opens the Pillar frontend for user signing, and agent-signed direct (pillar-direct.ts) signs locally with a secp256k1 keypair and submits directly to the Pillar API (no browser required, gas sponsored). Supports sBTC send/supply/boost/unwind, DCA programs, stacking, key management, wallet creation, and position queries.",
+      "category": "smart-wallets",
+      "user-invocable": false,
+      "entry-point": "pillar.ts",
+      "arguments": [
+        "connect",
+        "disconnect",
+        "status",
+        "send",
+        "fund",
+        "add-admin",
+        "supply",
+        "auto-compound",
+        "unwind",
+        "boost",
+        "position",
+        "create-wallet",
+        "invite",
+        "dca-invite",
+        "dca-partners",
+        "dca-leaderboard",
+        "dca-status",
+        "key-generate",
+        "key-unlock",
+        "key-lock",
+        "key-info",
+        "direct-boost",
+        "direct-unwind",
+        "direct-supply",
+        "direct-send",
+        "direct-auto-compound",
+        "direct-position",
+        "direct-withdraw-collateral",
+        "direct-add-admin",
+        "direct-create-wallet",
+        "direct-dca-invite",
+        "direct-dca-partners",
+        "direct-dca-leaderboard",
+        "direct-dca-status",
+        "direct-quote",
+        "direct-resolve-recipient",
+        "direct-stack-stx",
+        "direct-revoke-fast-pool",
+        "direct-stacking-status"
+      ],
+      "requires": [
+        "wallet"
+      ],
+      "tags": [
+        "requires-wallet",
+        "mainnet-only",
+        "has-read-ops",
+        "has-write-ops",
+        "requires-funds"
+      ],
+      "agent": {
+        "name": "pillar-agent",
+        "description": "Pillar smart wallet operations in two modes — browser-handoff (pillar.ts) for user-signed operations via the Pillar frontend, and agent-signed direct (pillar-direct.ts) for fully autonomous gas-sponsored operations with a local secp256k1 keypair."
+      }
+    },
+    {
+      "name": "query",
+      "description": "Stacks network and blockchain query operations — get STX fees, account info, transaction history, block info, mempool transactions, contract info and events, network status, and call read-only contract functions. All queries use the Hiro API.",
+      "category": "stacks-l2",
+      "user-invocable": false,
+      "entry-point": "query.ts",
+      "arguments": [
+        "get-stx-fees",
+        "get-account-info",
+        "get-account-transactions",
+        "get-block-info",
+        "get-mempool-info",
+        "get-contract-info",
+        "get-contract-events",
+        "get-network-status",
+        "call-read-only"
+      ],
+      "requires": [],
+      "tags": [
+        "read-only",
+        "has-read-ops"
+      ],
+      "agent": {
+        "name": "query-agent",
+        "description": "Read-only Stacks blockchain queries — account info, transaction history, block data, mempool, contract info and events, network status, and read-only contract function calls."
+      }
+    },
+    {
+      "name": "sbtc",
+      "description": "sBTC token operations on Stacks L2 — check balances, transfer sBTC, get deposit info, check peg statistics, deposit BTC to receive sBTC, and track deposit status. Transfer and deposit operations require an unlocked wallet.",
+      "category": "assets",
+      "user-invocable": false,
+      "entry-point": "sbtc.ts",
+      "arguments": [
+        "get-balance",
+        "transfer",
+        "get-deposit-info",
+        "get-peg-info",
+        "deposit",
+        "deposit-status"
+      ],
+      "requires": [
+        "wallet"
+      ],
+      "tags": [
+        "requires-wallet",
+        "has-read-ops",
+        "has-write-ops",
+        "requires-funds"
+      ],
+      "agent": {
+        "name": "sbtc-agent",
+        "description": "sBTC operations on Stacks L2 — check balances, transfer sBTC, deposit BTC to receive sBTC, track deposit status, and query peg statistics."
+      }
+    },
+    {
+      "name": "settings",
+      "description": "Manage AIBTC skill settings stored at ~/.aibtc/config.json. Configure the Hiro API key for authenticated rate limits, set a custom Stacks API node URL, and check the current package version.",
+      "category": "stacks-l2",
+      "user-invocable": false,
+      "entry-point": "settings.ts",
+      "arguments": [
+        "set-hiro-api-key",
+        "get-hiro-api-key",
+        "delete-hiro-api-key",
+        "set-stacks-api-url",
+        "get-stacks-api-url",
+        "delete-stacks-api-url",
+        "get-server-version"
+      ],
+      "requires": [],
+      "tags": [
+        "has-read-ops",
+        "has-write-ops"
+      ],
+      "agent": {
+        "name": "settings-agent",
+        "description": "Configures AIBTC skill suite settings — Hiro API key for authenticated rate limits, custom Stacks API node URL, and package version queries."
+      }
+    },
+    {
+      "name": "signing",
+      "description": "Message signing and verification — SIP-018 structured Clarity data signing (on-chain verifiable), Stacks plain-text message signing (SIWS-compatible), Bitcoin BIP-137 message signing, and BIP-340 Schnorr signing for Taproot multisig. All signing requires an unlocked wallet; hash and verify operations do not.",
+      "category": "bitcoin-l1",
+      "user-invocable": false,
+      "entry-point": "signing.ts",
+      "arguments": [
+        "sip018-sign",
+        "sip018-verify",
+        "sip018-hash",
+        "stacks-sign",
+        "stacks-verify",
+        "btc-sign",
+        "btc-verify",
+        "schnorr-sign-digest",
+        "schnorr-verify-digest"
+      ],
+      "requires": [
+        "wallet"
+      ],
+      "tags": [
+        "requires-wallet",
+        "has-read-ops",
+        "has-write-ops"
+      ],
+      "agent": {
+        "name": "signing-agent",
+        "description": "Cryptographic message signing and verification across four standards — SIP-018 structured Clarity data, Stacks plain-text (SIWS), Bitcoin BIP-137, and BIP-340 Schnorr for Taproot multisig."
+      }
+    },
+    {
+      "name": "stacking",
+      "description": "STX stacking operations on Stacks — query PoX cycle info, check stacking status, lock STX to earn BTC rewards (stack-stx), and extend an existing stacking lock period. Write operations require an unlocked wallet.",
+      "category": "defi",
+      "user-invocable": false,
+      "entry-point": "stacking.ts",
+      "arguments": [
+        "get-pox-info",
+        "get-stacking-status",
+        "stack-stx",
+        "extend-stacking"
+      ],
+      "requires": [
+        "wallet"
+      ],
+      "tags": [
+        "requires-wallet",
+        "has-read-ops",
+        "has-write-ops",
+        "requires-funds"
+      ],
+      "agent": {
+        "name": "stacking-agent",
+        "description": "STX stacking operations on Stacks — query PoX cycle info, check stacking status, lock STX to earn BTC rewards, and extend an existing stacking lock period."
+      }
+    },
+    {
+      "name": "stx",
+      "description": "Stacks L2 STX token operations — check balances, transfer STX, broadcast pre-signed transactions, call Clarity contracts, deploy contracts, and check transaction status. Transfer and contract operations require an unlocked wallet.",
+      "category": "stacks-l2",
+      "user-invocable": false,
+      "entry-point": "stx.ts",
+      "arguments": [
+        "get-balance",
+        "transfer",
+        "broadcast-transaction",
+        "call-contract",
+        "deploy-contract",
+        "get-transaction-status"
+      ],
+      "requires": [
+        "wallet"
+      ],
+      "tags": [
+        "requires-wallet",
+        "has-read-ops",
+        "has-write-ops",
+        "requires-funds"
+      ],
+      "agent": {
+        "name": "stx-agent",
+        "description": "Stacks L2 STX token and smart contract operations — check balances, transfer STX, broadcast transactions, call and deploy Clarity contracts, and check transaction status."
+      }
+    },
+    {
+      "name": "tokens",
+      "description": "SIP-010 fungible token operations on Stacks L2 — check balances, transfer tokens, get token metadata, list all tokens owned by an address, and get top token holders. Supports well-known tokens by symbol (sBTC, USDCx, ALEX, DIKO) or full contract ID.",
+      "category": "assets",
+      "user-invocable": false,
+      "entry-point": "tokens.ts",
+      "arguments": [
+        "get-balance",
+        "transfer",
+        "get-info",
+        "list-user-tokens",
+        "get-holders"
+      ],
+      "requires": [
+        "wallet"
+      ],
+      "tags": [
+        "requires-wallet",
+        "has-read-ops",
+        "has-write-ops",
+        "requires-funds"
+      ],
+      "agent": {
+        "name": "tokens-agent",
+        "description": "SIP-010 fungible token operations on Stacks L2 — check balances, transfer tokens, get metadata, list all tokens for an address, and query top holders. Supports well-known symbols and full contract IDs."
+      }
+    },
+    {
+      "name": "wallet",
+      "description": "Manage encrypted BIP39 wallets stored at ~/.aibtc/. Create, import, unlock, lock, list, switch, delete, export, rotate passwords, set auto-lock timeouts, and check status or info for Stacks and Bitcoin addresses.",
+      "category": "wallet-keys",
+      "user-invocable": false,
+      "entry-point": "wallet.ts",
+      "arguments": [
+        "create",
+        "import",
+        "unlock",
+        "lock",
+        "list",
+        "switch",
+        "delete",
+        "export",
+        "rotate-password",
+        "set-timeout",
+        "status",
+        "info",
+        "stx-balance"
+      ],
+      "requires": [],
+      "tags": [
+        "has-write-ops",
+        "has-read-ops"
+      ],
+      "agent": {
+        "name": "wallet-agent",
+        "description": "Manages encrypted BIP39 wallet lifecycle — create, import, unlock, lock, switch, and export wallets stored at ~/.aibtc/."
+      }
+    },
+    {
+      "name": "x402",
+      "description": "x402 paid API endpoints, inbox messaging, project scaffolding, and OpenRouter AI integration. Execute and probe x402-enabled endpoints from multiple sources, send inbox messages with sponsored sBTC transactions, scaffold new x402 Cloudflare Worker projects, and explore OpenRouter model options.",
+      "category": "payments",
+      "user-invocable": false,
+      "entry-point": "x402.ts",
+      "arguments": [
+        "list-endpoints",
+        "execute-endpoint",
+        "probe-endpoint",
+        "send-inbox-message",
+        "scaffold-endpoint",
+        "scaffold-ai-endpoint",
+        "openrouter-guide",
+        "openrouter-models"
+      ],
+      "requires": [
+        "wallet"
+      ],
+      "tags": [
+        "requires-wallet",
+        "has-read-ops",
+        "has-write-ops",
+        "requires-funds"
+      ],
+      "agent": {
+        "name": "x402-agent",
+        "description": "x402 paid API endpoint interactions, inbox messaging with sBTC micropayments, x402 Cloudflare Worker project scaffolding, and OpenRouter AI model discovery."
+      }
+    },
+    {
+      "name": "yield-hunter",
+      "description": "Autonomous sBTC yield hunting daemon — monitors wallet sBTC balance and automatically deposits to Zest Protocol when balance exceeds a configurable threshold. Only works on mainnet. Requires an unlocked wallet with sBTC balance and STX for transaction fees.",
+      "category": "defi",
+      "user-invocable": false,
+      "entry-point": "yield-hunter.ts",
+      "arguments": [
+        "start",
+        "stop",
+        "status",
+        "configure"
+      ],
+      "requires": [
+        "wallet",
+        "sbtc"
+      ],
+      "tags": [
+        "requires-wallet",
+        "mainnet-only",
+        "requires-funds",
+        "has-write-ops"
+      ],
+      "agent": {
+        "name": "yield-hunter-agent",
+        "description": "Autonomous sBTC yield hunting daemon — monitors wallet sBTC balance and automatically deposits to Zest Protocol when balance exceeds a configurable threshold. Mainnet-only."
+      }
+    }
+  ]
+}

--- a/stacking/SKILL.md
+++ b/stacking/SKILL.md
@@ -3,6 +3,10 @@ name: stacking
 description: STX stacking operations on Stacks — query PoX cycle info, check stacking status, lock STX to earn BTC rewards (stack-stx), and extend an existing stacking lock period. Write operations require an unlocked wallet.
 user-invocable: false
 arguments: get-pox-info | get-stacking-status | stack-stx | extend-stacking
+category: defi
+requires: [wallet]
+tags: [requires-wallet, has-read-ops, has-write-ops, requires-funds]
+entry-point: stacking.ts
 ---
 
 # Stacking Skill

--- a/stx/SKILL.md
+++ b/stx/SKILL.md
@@ -3,6 +3,10 @@ name: stx
 description: Stacks L2 STX token operations — check balances, transfer STX, broadcast pre-signed transactions, call Clarity contracts, deploy contracts, and check transaction status. Transfer and contract operations require an unlocked wallet.
 user-invocable: false
 arguments: get-balance | transfer | broadcast-transaction | call-contract | deploy-contract | get-transaction-status
+category: stacks-l2
+requires: [wallet]
+tags: [requires-wallet, has-read-ops, has-write-ops, requires-funds]
+entry-point: stx.ts
 ---
 
 # STX Skill

--- a/tokens/SKILL.md
+++ b/tokens/SKILL.md
@@ -3,6 +3,10 @@ name: tokens
 description: SIP-010 fungible token operations on Stacks L2 — check balances, transfer tokens, get token metadata, list all tokens owned by an address, and get top token holders. Supports well-known tokens by symbol (sBTC, USDCx, ALEX, DIKO) or full contract ID.
 user-invocable: false
 arguments: get-balance | transfer | get-info | list-user-tokens | get-holders
+category: assets
+requires: [wallet]
+tags: [requires-wallet, has-read-ops, has-write-ops, requires-funds]
+entry-point: tokens.ts
 ---
 
 # Tokens Skill

--- a/wallet/SKILL.md
+++ b/wallet/SKILL.md
@@ -3,6 +3,10 @@ name: wallet
 description: Manage encrypted BIP39 wallets stored at ~/.aibtc/. Create, import, unlock, lock, list, switch, delete, export, rotate passwords, set auto-lock timeouts, and check status or info for Stacks and Bitcoin addresses.
 user-invocable: false
 arguments: create | import | unlock | lock | list | switch | delete | export | rotate-password | set-timeout | status | info | stx-balance
+category: wallet-keys
+requires: []
+tags: [has-write-ops, has-read-ops]
+entry-point: wallet.ts
 ---
 
 # Wallet Skill

--- a/x402/SKILL.md
+++ b/x402/SKILL.md
@@ -3,6 +3,10 @@ name: x402
 description: x402 paid API endpoints, inbox messaging, project scaffolding, and OpenRouter AI integration. Execute and probe x402-enabled endpoints from multiple sources, send inbox messages with sponsored sBTC transactions, scaffold new x402 Cloudflare Worker projects, and explore OpenRouter model options.
 user-invocable: false
 arguments: list-endpoints | execute-endpoint | probe-endpoint | send-inbox-message | scaffold-endpoint | scaffold-ai-endpoint | openrouter-guide | openrouter-models
+category: payments
+requires: [wallet]
+tags: [requires-wallet, has-read-ops, has-write-ops, requires-funds]
+entry-point: x402.ts
 ---
 
 # x402 Skill

--- a/yield-hunter/SKILL.md
+++ b/yield-hunter/SKILL.md
@@ -3,6 +3,10 @@ name: yield-hunter
 description: Autonomous sBTC yield hunting daemon — monitors wallet sBTC balance and automatically deposits to Zest Protocol when balance exceeds a configurable threshold. Only works on mainnet. Requires an unlocked wallet with sBTC balance and STX for transaction fees.
 user-invocable: false
 arguments: start | stop | status | configure
+category: defi
+requires: [wallet, sbtc]
+tags: [requires-wallet, mainnet-only, requires-funds, has-write-ops]
+entry-point: yield-hunter.ts
 ---
 
 # Yield Hunter Skill


### PR DESCRIPTION
## Summary

Addresses #8 — machine-readable skill metadata and manifest for better AX.

- **Enriched SKILL.md frontmatter** across all 19 skills with `category`, `requires`, `tags`, and `entry-point` fields
- **Built `scripts/generate-skills-json.ts`** — scans skill directories, parses YAML frontmatter, validates against Zod schema, and emits `skills.json`
- **Added `scripts/schema.ts`** — Zod schemas for SKILL.md frontmatter, AGENT.md frontmatter, and the manifest format
- **Generated `skills.json`** — single machine-readable index of all 19 skills with O(1) lookup by category, tags, dependencies

### New frontmatter fields

```yaml
category: bitcoin-l1          # 8 categories for grouping
requires: [wallet]             # dependency graph
tags: [requires-wallet, mainnet-only, has-read-ops]  # capability filtering
entry-point: btc.ts            # standardized CLI entry point
```

### Categories (8)

| Category | Skills |
|----------|--------|
| wallet-keys | wallet, credentials |
| bitcoin-l1 | btc, ordinals, signing |
| stacks-l2 | stx, query, settings |
| assets | sbtc, tokens, nft, bns |
| defi | defi, bitflow, stacking, yield-hunter |
| identity | identity |
| payments | x402 |
| smart-wallets | pillar |

### Tags (6)

`read-only`, `mainnet-only`, `requires-funds`, `requires-wallet`, `has-write-ops`, `has-read-ops`

### Usage

```bash
# Generate manifest
bun run scripts/generate-skills-json.ts

# CI check (exit 1 if stale)
bun run scripts/generate-skills-json.ts --check
```

### What's left from #8

- [ ] Extract shared CLI boilerplate (`printJson`/`handleError` → `src/lib/utils/cli.ts`)
- [ ] Remove numbered prefixes from workflow guides (use `order` in frontmatter)
- [ ] CI workflow for `--check` validation on PRs

## Test plan

- [x] Generator runs and produces valid `skills.json` with 19 skills
- [x] `--check` mode passes when manifest is up to date
- [x] All SKILL.md frontmatters validate against Zod schema
- [x] AGENT.md frontmatters parsed and included in manifest
- [ ] Verify on Bun runtime (tested with `npx tsx` on Node.js 22)

🤖 Generated with [Claude Code](https://claude.com/claude-code)