### PR TITLE
fix(bitflow): correct amount-in docs — human-readable decimal, not smallest units

### DIFF
--- a/bitflow/SKILL.md
+++ b/bitflow/SKILL.md
@@ -116,13 +116,13 @@ Output:
 Get a swap quote from Bitflow DEX. Returns expected output amount, best route, and price impact analysis.
 
 ```
-bun run bitflow/bitflow.ts get-quote --token-x <tokenId> --token-y <tokenId> --amount-in <units>
+bun run bitflow/bitflow.ts get-quote --token-x <tokenId> --token-y <tokenId> --amount-in <decimal>
 ```
 
 Options:
 - `--token-x` (required) — Input token ID (e.g. `token-stx`, `token-sbtc`)
 - `--token-y` (required) — Output token ID (e.g. `token-sbtc`, `token-aeusdc`)
-- `--amount-in` (required) — Amount of input token (in smallest units)
+- `--amount-in` (required) — Amount of input token in human-readable decimal (e.g. `0.00015` for 15,000 sats sBTC, `21.0` for 21 STX). The SDK auto-scales by `10^decimals` internally.
 
 Output:
 ```json
@@ -131,8 +131,8 @@ Output:
   "quote": {
     "tokenIn": "token-stx",
     "tokenOut": "token-sbtc",
-    "amountIn": "1000000",
-    "expectedAmountOut": "12",
+    "amountIn": "1.0",
+    "expectedAmountOut": "0.0000036",
     "route": ["token-stx", "token-sbtc"]
   },
   "priceImpact": {
@@ -179,14 +179,14 @@ Execute a token swap on Bitflow DEX. Automatically finds the best route across a
 
 ```
 bun run bitflow/bitflow.ts swap \
-  --token-x <tokenId> --token-y <tokenId> --amount-in <units> \
+  --token-x <tokenId> --token-y <tokenId> --amount-in <decimal> \
   [--slippage-tolerance <decimal>] [--fee <value>] [--confirm-high-impact]
 ```
 
 Options:
 - `--token-x` (required) — Input token ID (contract address)
 - `--token-y` (required) — Output token ID (contract address)
-- `--amount-in` (required) — Amount of input token (in smallest units)
+- `--amount-in` (required) — Amount of input token in human-readable decimal (e.g. `0.00015` for 15,000 sats sBTC, `21.0` for 21 STX). The SDK auto-scales by `10^decimals` internally.
 - `--slippage-tolerance` (optional) — Slippage tolerance as decimal (default 0.01 = 1%)
 - `--fee` (optional) — Fee: `low` | `medium` | `high` preset or micro-STX amount. If omitted, auto-estimated.
 - `--confirm-high-impact` (optional) — Required to execute swaps with price impact above 5%
@@ -199,7 +199,7 @@ Output:
   "swap": {
     "tokenIn": "token-stx",
     "tokenOut": "token-sbtc",
-    "amountIn": "1000000",
+    "amountIn": "1.0",
     "slippageTolerance": 0.01,
     "priceImpact": { "combinedImpactPct": "0.23%", "severity": "low" }
   },

--- a/bitflow/bitflow.ts
+++ b/bitflow/bitflow.ts
@@ -173,8 +173,8 @@ program
     "Output token ID (e.g. 'token-sbtc', 'token-aeusdc')"
   )
   .requiredOption(
-    "--amount-in <units>",
-    "Amount of input token (in smallest units)"
+    "--amount-in <decimal>",
+    "Amount in human-readable decimal (e.g. 0.00015 for 15k sats sBTC, 21.0 for 21 STX)"
   )
   .action(
     async (opts: { tokenX: string; tokenY: string; amountIn: string }) => {
@@ -274,8 +274,8 @@ program
     "Output token ID (contract address)"
   )
   .requiredOption(
-    "--amount-in <units>",
-    "Amount of input token (in smallest units)"
+    "--amount-in <decimal>",
+    "Amount in human-readable decimal (e.g. 0.00015 for 15k sats sBTC, 21.0 for 21 STX)"
   )
   .option(
     "--slippage-tolerance <decimal>",


### PR DESCRIPTION
The Bitflow SDK (`@bitflowlabs/core-sdk`) auto-scales input amounts by `10^decimals` internally via `callReadOnlyFunctionHelper`. The `--amount-in` parameter should be human-readable decimal, not smallest units.

**Bug**: Passing `15000` for sBTC means 15,000 BTC (1.5 trillion sats), not 15,000 sats. The XYK pool caps output at total reserves, so all amounts return ~2.86M µSTX regardless of input.

**Fix**: `0.00015` for 15k sats sBTC, `21.0` for 21 STX.

**Verified**:
- `--amount-in 0.00015` (token-sbtc → token-stx) = 41.4 STX ✅
- `--amount-in 15000` (same) = 2.86M µSTX for any input ❌

Changes:
- `bitflow.ts`: Updated CLI help text for `--amount-in` on get-quote and swap commands
- `SKILL.md`: Updated docs and example values

---
Signed-by: cocoa007.btc (BTC: bc1qv8dt3v9kx3l7r9mnz2gj9r9n9k63frn6w6zmrt)
Signature: 2809c05d833f3ebfa75482c6f86d09249b3748e5204a31eb4c83e9a09c6bedeaba703eb2df431b7b93649d97bdbb393d672c95eb8e05c47176fd3151bbe0831341