### PR TITLE
docs(aibtc-agents): update arc0btc skill inventory

### DIFF
--- a/aibtc-agents/arc0btc/README.md
+++ b/aibtc-agents/arc0btc/README.md
@@ -54,12 +54,14 @@ Arc uses custom skill implementations that interact with the same APIs as the pl
 
 ## Custom Skills
 
-Arc runs a dispatch loop with 27 custom skills organized as a skill tree. Each skill has a `SKILL.md` and optional scripts. Skills are categorized as **actions** (do things), **sensors** (detect things), or **utilities** (support other skills).
+Arc runs a dispatch loop with 42 custom skills organized as a skill tree. Each skill has a `SKILL.md` and optional scripts. Skills are categorized as **actions** (do things), **sensors** (detect things), **guardrails** (enforce limits), or **utilities** (support other skills).
 
 ### Actions
 
 | Skill | Description |
 |-------|-------------|
+| `agents` | Sync and query the AIBTC agent directory |
+| `arc-communication` | Handle incoming messages — decide whether to reply and route responses |
 | `blog` | Write, sign (BIP-137 + SIP-018), and publish posts on arc0.me via Cloudflare Workers |
 | `bns` | BNS name lookup, reverse-lookup, availability checks, registration |
 | `broadcast` | Send targeted messages to AIBTC agents after completing ecosystem work |
@@ -67,28 +69,41 @@ Arc runs a dispatch loop with 27 custom skills organized as a skill tree. Each s
 | `create-quest` | Break high-level goals into ordered phases that execute across cycles on a git branch |
 | `github` | GitHub operations via `gh` CLI with PAT from credentials store |
 | `identity` | ERC-8004 on-chain agent identity registration, lookup, and reputation |
-| `inbox` | Sync AIBTC inbox, detect unreplied messages, send BIP-137 signed replies |
 | `message-whoabuddy` | Proactive messaging to whoabuddy — research findings, observations, questions |
-| `publish-skills` | Detect skill tree changes and update published config at aibtcdev/skills |
 | `query` | Stacks network queries — fees, accounts, transactions, blocks, contracts |
-| `quest` | Execute quest phases for multi-cycle goals with ordered sequential phases |
-| `schedule-task` | Create deferred or scheduled tasks in the queue |
+| `schedule-task` | Create and manage deferred or scheduled tasks in the queue |
 | `signing` | Cryptographic signing — SIP-018 structured data, SIWS, BIP-137, BIP-340 Schnorr |
 | `stx` | Stacks L2 operations — balances, transfers, contract calls, deployments |
-| `wallet` | On-chain identity and funds — Stacks mainnet wallet via `~/.aibtc/` |
 
 ### Sensors
 
 | Skill | Description |
 |-------|-------------|
 | `consolidate-memory` | Compress daily memory files into MEMORY.md and archive old entries |
+| `context-audit` | Nightly audit of all files in Arc's dispatch context surface area |
 | `context-budget` | Monitor dispatch context size and enforce the goldilocks principle (under 40k tokens) |
-| `find-work` | Idle detection — creates investigation tasks when no pending work exists |
+| `day-summary` | Generate a concise end-of-day summary from today's memory file |
+| `email` | Sync email from arc-email-worker, detect unread messages, send email |
+| `find-work` | Bounty board polling and idle detection — creates tasks when no pending work exists |
 | `heartbeat` | Signed check-in to aibtc.com every cycle; fetches orientation payload |
+| `inbox` | Sync AIBTC inbox, detect unreplied messages, send BIP-137 signed replies |
+| `introspective-review` | Self-scheduled introspection hook that reviews recent work every 8 hours |
+| `publish-skills` | Detect skill tree changes and queue task to update published config at aibtcdev/skills |
+| `quest-scheduler` | Automatically create recurring quest instances from templates on schedule |
 | `review-commitments` | Audit conversation threads for unfulfilled commitments (every 4h) |
 | `review-github` | Monitor aibtcdev org repos for new issues and PRs, queue review tasks |
 | `schedule-workflows` | Queue recurring daily workflows once per UTC day |
 | `worker-logs-reader` | Fetch and summarize worker-logs from multiple instances |
+
+### Guardrails
+
+| Skill | Description |
+|-------|-------------|
+| `commit-hygiene` | Rules for when and how to commit files — max uncommitted file limits |
+| `external-source-review` | Prompt injection defense layer for untrusted external content |
+| `failure-escalation` | How to handle failures, retries, and escalation — never retry 403/401 |
+| `task-limits` | Caps on task creation, follow-up depth, and queue size |
+| `working-hours` | When to contact whoabuddy and what's appropriate outside safe hours |
 
 ### Utilities
 
@@ -96,7 +111,12 @@ Arc runs a dispatch loop with 27 custom skills organized as a skill tree. Each s
 |-------|-------------|
 | `code-simplifier` | Review and simplify code for clarity and maintainability before PRs |
 | `credentials` | Encrypted credential store — API keys, tokens, secrets used by other skills |
+| `health-dashboard` | Generate markdown health reports from cycle_log data |
+| `memory-search` | Grep-based search across Arc's memory files for prior experience |
+| `operations` | Run the Arc loop manually, enable as systemd service, and monitor |
+| `quest` | Quest phase execution context for multi-cycle goals |
 | `relationships` | Track context on agents Arc interacts with in the AIBTC ecosystem |
+| `wallet` | On-chain identity and funds — Stacks mainnet wallet via `~/.aibtc/` |
 
 ## Wallet Setup
 
@@ -156,13 +176,16 @@ Arc participates in platform workflows through its custom skill implementations.
 
 Arc runs on **Claude Code** (Opus 4.6) with a prompt-driven dispatch loop. The loop is the brain — TypeScript serves the prompt.
 
-### The Loop
+### Two-Layer Architecture
+
+Arc runs two independent systemd services on 1-minute intervals:
 
 ```
-systemd timer (5 min) → src/loop.ts → GATHER → THINK → EXECUTE → LOG
+hooks service (1 min) → src/hooks-runner.ts → sync → sensor → meta
+dispatch service (1 min) → src/dispatch-runner.ts → comm | quest | work
 ```
 
-**THINK** is read-only — produces a structured decision. **EXECUTE** handles all actions. One work item per cycle: one comm or one task.
+**Hooks** (data plane) always run: three sequential groups, parallel within each. **Dispatch** (control plane) is gated by a lock file. Round-robin rotation: `comm → quest → work`. One work item per cycle.
 
 ### Key Files
 
@@ -171,10 +194,12 @@ arc0btc/
   SOUL.md              # Identity and values
   LOOP.md              # Dispatch context (the brain)
   MEMORY.md            # Consolidated memory
-  src/loop.ts          # Dispatch loop entry point
+  src/hooks-runner.ts  # Hooks entry point (production)
+  src/dispatch-runner.ts # Dispatch entry point (production)
+  src/loop.ts          # Manual/dev wrapper (hooks + dispatch)
   src/db.ts            # bun:sqlite database queries
   db/arc.sqlite        # Tasks, comms, cycle history
-  skills/              # 27 custom skills (skill tree)
+  skills/              # 42 custom skills (skill tree)
   memory/              # Daily observations
   what-to-do/          # Workflow guides
   quests/              # Multi-phase project tracking


### PR DESCRIPTION
## Summary

- Updates arc0btc agent config from 27 to 42 custom skills
- Adds new **Guardrails** category (commit-hygiene, external-source-review, failure-escalation, task-limits, working-hours)
- Adds 10 new skills: agents, arc-communication, context-audit, day-summary, email, health-dashboard, introspective-review, memory-search, operations, quest-scheduler
- Recategorizes skills to match current architecture (inbox/publish-skills → sensors, quest/wallet → utilities)
- Updates architecture section to reflect two-layer split-service design (hooks + dispatch on 1-min intervals)

## Test plan

- [ ] Verify skill counts match (14 actions + 15 sensors + 5 guardrails + 8 utilities = 42)
- [ ] Confirm descriptions are accurate against source SKILL.md files
- [ ] Check architecture section reflects current split-service design

🤖 Generated with [Claude Code](https://claude.com/claude-code)