### PR TITLE
feat: add unit tests (77 tests across 7 modules)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "@aibtc/skills",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "bun build src/lib/index.ts --outdir dist",
     "typecheck": "tsc --noEmit",
     "manifest": "bun run scripts/generate-manifest.ts",
-    "validate": "bun run scripts/validate-frontmatter.ts"
+    "validate": "bun run scripts/validate-frontmatter.ts",
+    "test": "bun test"
   },
   "keywords": [
     "claude",

--- a/src/lib/config/bitcoin-constants.test.ts
+++ b/src/lib/config/bitcoin-constants.test.ts
@@ -1,0 +1,41 @@
+import { describe, test, expect } from "bun:test";
+import {
+  P2WPKH_INPUT_VBYTES,
+  P2WPKH_OUTPUT_VBYTES,
+  P2TR_OUTPUT_VBYTES,
+  TX_OVERHEAD_VBYTES,
+  DUST_THRESHOLD,
+  P2TR_INPUT_BASE_VBYTES,
+} from "./bitcoin-constants.js";
+
+describe("bitcoin constants", () => {
+  test("P2WPKH input size is 68 vB", () => {
+    expect(P2WPKH_INPUT_VBYTES).toBe(68);
+  });
+
+  test("P2WPKH output size is 31 vB", () => {
+    expect(P2WPKH_OUTPUT_VBYTES).toBe(31);
+  });
+
+  test("P2TR output size is 43 vB", () => {
+    expect(P2TR_OUTPUT_VBYTES).toBe(43);
+  });
+
+  test("TX overhead is 10.5 vB", () => {
+    expect(TX_OVERHEAD_VBYTES).toBe(10.5);
+  });
+
+  test("dust threshold is 546 sats", () => {
+    expect(DUST_THRESHOLD).toBe(546);
+  });
+
+  test("P2TR input base size is 57.5 vB", () => {
+    expect(P2TR_INPUT_BASE_VBYTES).toBe(57.5);
+  });
+
+  test("simple fee estimation: 1-in-1-out P2WPKH tx", () => {
+    const estimatedVbytes = TX_OVERHEAD_VBYTES + P2WPKH_INPUT_VBYTES + P2WPKH_OUTPUT_VBYTES;
+    // 10.5 + 68 + 31 = 109.5 vB — reasonable for a simple tx
+    expect(estimatedVbytes).toBe(109.5);
+  });
+});

--- a/src/lib/config/caip.test.ts
+++ b/src/lib/config/caip.test.ts
@@ -1,0 +1,69 @@
+import { describe, test, expect } from "bun:test";
+import {
+  STACKS_CHAIN_IDS,
+  BITCOIN_CHAIN_IDS,
+  getStacksChainId,
+  getBitcoinChainId,
+  parseChainId,
+  isStacksChainId,
+  isBitcoinChainId,
+  getNetworkFromStacksChainId,
+  getNetworkFromBitcoinChainId,
+} from "./caip.js";
+
+describe("CAIP-2 chain identifiers", () => {
+  test("STACKS_CHAIN_IDS has correct values", () => {
+    expect(STACKS_CHAIN_IDS.mainnet).toBe("stacks:1");
+    expect(STACKS_CHAIN_IDS.testnet).toBe("stacks:2147483648");
+  });
+
+  test("BITCOIN_CHAIN_IDS has correct values", () => {
+    expect(BITCOIN_CHAIN_IDS.mainnet).toBe("bip122:000000000019d6689c085ae165831e93");
+    expect(BITCOIN_CHAIN_IDS.testnet).toBe("bip122:000000000933ea01ad0ee984209779ba");
+  });
+
+  test("getStacksChainId returns correct chain ID", () => {
+    expect(getStacksChainId("mainnet")).toBe("stacks:1");
+    expect(getStacksChainId("testnet")).toBe("stacks:2147483648");
+  });
+
+  test("getBitcoinChainId returns correct chain ID", () => {
+    expect(getBitcoinChainId("mainnet")).toBe("bip122:000000000019d6689c085ae165831e93");
+    expect(getBitcoinChainId("testnet")).toBe("bip122:000000000933ea01ad0ee984209779ba");
+  });
+
+  test("parseChainId splits namespace and reference", () => {
+    expect(parseChainId("stacks:1")).toEqual({ namespace: "stacks", reference: "1" });
+    expect(parseChainId("bip122:000000000019d6689c085ae165831e93")).toEqual({
+      namespace: "bip122",
+      reference: "000000000019d6689c085ae165831e93",
+    });
+  });
+
+  test("parseChainId throws on invalid input", () => {
+    expect(() => parseChainId("invalid")).toThrow("Invalid CAIP-2 chain ID");
+    expect(() => parseChainId("")).toThrow("Invalid CAIP-2 chain ID");
+  });
+
+  test("isStacksChainId correctly identifies Stacks chains", () => {
+    expect(isStacksChainId("stacks:1")).toBe(true);
+    expect(isStacksChainId("bip122:000000000019d6689c085ae165831e93")).toBe(false);
+  });
+
+  test("isBitcoinChainId correctly identifies Bitcoin chains", () => {
+    expect(isBitcoinChainId("bip122:000000000019d6689c085ae165831e93")).toBe(true);
+    expect(isBitcoinChainId("stacks:1")).toBe(false);
+  });
+
+  test("getNetworkFromStacksChainId returns correct network", () => {
+    expect(getNetworkFromStacksChainId("stacks:1")).toBe("mainnet");
+    expect(getNetworkFromStacksChainId("stacks:2147483648")).toBe("testnet");
+    expect(getNetworkFromStacksChainId("stacks:999")).toBeNull();
+  });
+
+  test("getNetworkFromBitcoinChainId returns correct network", () => {
+    expect(getNetworkFromBitcoinChainId("bip122:000000000019d6689c085ae165831e93")).toBe("mainnet");
+    expect(getNetworkFromBitcoinChainId("bip122:000000000933ea01ad0ee984209779ba")).toBe("testnet");
+    expect(getNetworkFromBitcoinChainId("bip122:unknown")).toBeNull();
+  });
+});

--- a/src/lib/config/contracts.test.ts
+++ b/src/lib/config/contracts.test.ts
@@ -1,0 +1,93 @@
+import { describe, test, expect } from "bun:test";
+import {
+  MAINNET_CONTRACTS,
+  TESTNET_CONTRACTS,
+  getContracts,
+  parseContractId,
+  WELL_KNOWN_TOKENS,
+  getAlexContracts,
+  getZestContracts,
+  getWellKnownTokens,
+  getBitflowContracts,
+  getErc8004Contracts,
+  ZEST_ASSETS,
+  ZEST_ASSETS_LIST,
+  BITFLOW_CONTRACTS,
+} from "./contracts.js";
+
+describe("contracts config", () => {
+  test("getContracts returns mainnet contracts for mainnet", () => {
+    const contracts = getContracts("mainnet");
+    expect(contracts).toBe(MAINNET_CONTRACTS);
+    expect(contracts.SBTC_TOKEN).toContain("SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4");
+  });
+
+  test("getContracts returns testnet contracts for testnet", () => {
+    const contracts = getContracts("testnet");
+    expect(contracts).toBe(TESTNET_CONTRACTS);
+    expect(contracts.SBTC_TOKEN).toContain("ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM");
+  });
+
+  test("parseContractId splits address and name", () => {
+    expect(parseContractId("SP000000000000000000002Q6VF78.bns")).toEqual({
+      address: "SP000000000000000000002Q6VF78",
+      name: "bns",
+    });
+  });
+
+  test("parseContractId throws on invalid input", () => {
+    expect(() => parseContractId("invalid")).toThrow("Invalid contract ID");
+    expect(() => parseContractId("")).toThrow("Invalid contract ID");
+  });
+
+  test("WELL_KNOWN_TOKENS has STX as native on both networks", () => {
+    expect(WELL_KNOWN_TOKENS.mainnet.STX).toBe("native");
+    expect(WELL_KNOWN_TOKENS.testnet.STX).toBe("native");
+  });
+
+  test("getAlexContracts returns contracts for mainnet, null for testnet", () => {
+    expect(getAlexContracts("mainnet")).toHaveProperty("ammPool");
+    expect(getAlexContracts("testnet")).toBeNull();
+  });
+
+  test("getZestContracts returns contracts for mainnet, null for testnet", () => {
+    const zest = getZestContracts("mainnet");
+    expect(zest).not.toBeNull();
+    expect(zest!.poolBorrow).toBeDefined();
+    expect(getZestContracts("testnet")).toBeNull();
+  });
+
+  test("ZEST_ASSETS has expected assets with correct structure", () => {
+    const sbtc = ZEST_ASSETS.sBTC;
+    expect(sbtc.decimals).toBe(8);
+    expect(sbtc.symbol).toBe("sBTC");
+    expect(sbtc.token).toContain("sbtc-token");
+  });
+
+  test("ZEST_ASSETS_LIST has 10 entries", () => {
+    expect(ZEST_ASSETS_LIST).toHaveLength(10);
+  });
+
+  test("getWellKnownTokens returns correct tokens per network", () => {
+    const mainnetTokens = getWellKnownTokens("mainnet");
+    expect(mainnetTokens.sBTC).toBe(MAINNET_CONTRACTS.SBTC_TOKEN);
+  });
+
+  test("getBitflowContracts returns correct addresses", () => {
+    expect(getBitflowContracts("mainnet").PRIMARY).toBe(BITFLOW_CONTRACTS.mainnet.PRIMARY);
+    expect(getBitflowContracts("testnet").PRIMARY).toBe(BITFLOW_CONTRACTS.testnet.PRIMARY);
+  });
+
+  test("getErc8004Contracts returns registry addresses", () => {
+    const erc = getErc8004Contracts("mainnet");
+    expect(erc.identityRegistry).toBe(MAINNET_CONTRACTS.IDENTITY_REGISTRY);
+    expect(erc.reputationRegistry).toBe(MAINNET_CONTRACTS.REPUTATION_REGISTRY);
+    expect(erc.validationRegistry).toBe(MAINNET_CONTRACTS.VALIDATION_REGISTRY);
+  });
+
+  test("all contract IDs follow address.name format", () => {
+    for (const [key, value] of Object.entries(MAINNET_CONTRACTS)) {
+      expect(value).toMatch(/^S[A-Z0-9]+\.[a-zA-Z0-9-]+$/);
+    }
+  });
+});

--- a/src/lib/config/networks.test.ts
+++ b/src/lib/config/networks.test.ts
@@ -1,0 +1,40 @@
+import { describe, test, expect } from "bun:test";
+import {
+  getStacksNetwork,
+  getApiBaseUrl,
+  EXPLORER_URL,
+  getExplorerTxUrl,
+  getExplorerAddressUrl,
+  getExplorerContractUrl,
+} from "./networks.js";
+
+describe("networks config", () => {
+  test("getStacksNetwork maps correctly", () => {
+    expect(getStacksNetwork("mainnet")).toBe("mainnet");
+    expect(getStacksNetwork("testnet")).toBe("testnet");
+  });
+
+  test("getApiBaseUrl returns correct Hiro API URLs", () => {
+    expect(getApiBaseUrl("mainnet")).toBe("https://api.mainnet.hiro.so");
+    expect(getApiBaseUrl("testnet")).toBe("https://api.testnet.hiro.so");
+  });
+
+  test("EXPLORER_URL is hiro explorer", () => {
+    expect(EXPLORER_URL).toBe("https://explorer.hiro.so");
+  });
+
+  test("getExplorerTxUrl formats correctly", () => {
+    const url = getExplorerTxUrl("0xabc123", "mainnet");
+    expect(url).toBe("https://explorer.hiro.so/txid/0xabc123?chain=mainnet");
+  });
+
+  test("getExplorerAddressUrl formats correctly", () => {
+    const url = getExplorerAddressUrl("SP123", "testnet");
+    expect(url).toBe("https://explorer.hiro.so/address/SP123?chain=testnet");
+  });
+
+  test("getExplorerContractUrl formats correctly", () => {
+    const url = getExplorerContractUrl("SP123.contract", "mainnet");
+    expect(url).toBe("https://explorer.hiro.so/txid/SP123.contract?chain=mainnet");
+  });
+});

--- a/src/lib/services/inscription-parser.test.ts
+++ b/src/lib/services/inscription-parser.test.ts
@@ -1,0 +1,43 @@
+import { describe, test, expect } from "bun:test";
+import { InscriptionParser, createInscriptionParser } from "./inscription-parser.js";
+
+describe("InscriptionParser", () => {
+  test("createInscriptionParser returns an InscriptionParser instance", () => {
+    const parser = createInscriptionParser("mainnet");
+    expect(parser).toBeInstanceOf(InscriptionParser);
+  });
+
+  test("parser can be created for both networks", () => {
+    const mainnet = createInscriptionParser("mainnet");
+    const testnet = createInscriptionParser("testnet");
+    expect(mainnet).toBeInstanceOf(InscriptionParser);
+    expect(testnet).toBeInstanceOf(InscriptionParser);
+  });
+
+  test("parseWitness throws for non-3-element witness (micro-ordinals requirement)", () => {
+    const parser = createInscriptionParser("mainnet");
+    // micro-ordinals requires exactly 3 witness elements
+    expect(() => parser.parseWitness([])).toThrow("Wrong witness");
+    expect(() => parser.parseWitness(["deadbeef"])).toThrow("Wrong witness");
+    expect(() => parser.parseWitness(["aa", "bb"])).toThrow("Wrong witness");
+  });
+
+  test("parseWitness with invalid script data throws or returns undefined", () => {
+    const parser = createInscriptionParser("mainnet");
+    // micro-ordinals is strict about script parsing — invalid data throws
+    // This validates the wrapper doesn't silently swallow random data
+    const witness = [
+      "3044022047ac8e878352d3ebbde1c94ce3a10d057c24175747116f8288e5d794d12d482f0220217f36a485cae903c713331d877c1f64677e3622ad4010726870540656fe9dcb01",
+      "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
+      "51".repeat(33), // valid-length control block with OP_1 opcodes
+    ];
+    // Should either throw or return undefined — both are acceptable
+    try {
+      const result = parser.parseWitness(witness);
+      // If it doesn't throw, result should be undefined (no inscriptions)
+      expect(result).toBeUndefined();
+    } catch (e) {
+      expect(e).toBeDefined();
+    }
+  });
+});

--- a/src/lib/transactions/clarity-values.test.ts
+++ b/src/lib/transactions/clarity-values.test.ts
@@ -1,0 +1,170 @@
+import { describe, test, expect } from "bun:test";
+import { cvToString } from "@stacks/transactions";
+import {
+  parseArgToClarityValue,
+  clarityToString,
+  createUint,
+  createInt,
+  createPrincipal,
+  createStringAscii,
+  createStringUtf8,
+  createBool,
+  createBuffer,
+  createList,
+  createTuple,
+  createNone,
+  createSome,
+  serializeClarityValue,
+  deserializeClarityValue,
+} from "./clarity-values.js";
+
+describe("parseArgToClarityValue", () => {
+  test("null/undefined → none", () => {
+    expect(clarityToString(parseArgToClarityValue(null))).toBe("none");
+    expect(clarityToString(parseArgToClarityValue(undefined))).toBe("none");
+  });
+
+  test("boolean → bool", () => {
+    expect(clarityToString(parseArgToClarityValue(true))).toBe("true");
+    expect(clarityToString(parseArgToClarityValue(false))).toBe("false");
+  });
+
+  test("positive integer → uint", () => {
+    expect(clarityToString(parseArgToClarityValue(42))).toBe("u42");
+  });
+
+  test("negative integer → int", () => {
+    expect(clarityToString(parseArgToClarityValue(-5))).toBe("-5");
+  });
+
+  test("zero → uint", () => {
+    expect(clarityToString(parseArgToClarityValue(0))).toBe("u0");
+  });
+
+  test("float throws", () => {
+    expect(() => parseArgToClarityValue(1.5)).toThrow("Floating point");
+  });
+
+  test("principal string → principal", () => {
+    const addr = "SP000000000000000000002Q6VF78";
+    const cv = parseArgToClarityValue(addr);
+    expect(clarityToString(cv)).toContain(addr);
+  });
+
+  test("contract principal string → principal", () => {
+    const addr = "SP000000000000000000002Q6VF78.bns";
+    const cv = parseArgToClarityValue(addr);
+    expect(clarityToString(cv)).toContain("SP000000000000000000002Q6VF78.bns");
+  });
+
+  test("regular string → string-utf8", () => {
+    const cv = parseArgToClarityValue("hello");
+    expect(clarityToString(cv)).toBe(`u"hello"`);
+  });
+
+  test("array → list", () => {
+    const cv = parseArgToClarityValue([1, 2, 3]);
+    const str = clarityToString(cv);
+    expect(str).toContain("u1");
+    expect(str).toContain("u2");
+    expect(str).toContain("u3");
+  });
+
+  test("object → tuple", () => {
+    const cv = parseArgToClarityValue({ a: 1, b: true });
+    const str = clarityToString(cv);
+    expect(str).toContain("a");
+    expect(str).toContain("u1");
+  });
+
+  test("typed value with type field", () => {
+    expect(clarityToString(parseArgToClarityValue({ type: "uint", value: 100 }))).toBe("u100");
+    expect(clarityToString(parseArgToClarityValue({ type: "int", value: -10 }))).toBe("-10");
+    expect(clarityToString(parseArgToClarityValue({ type: "string-ascii", value: "hi" }))).toBe(`"hi"`);
+    expect(clarityToString(parseArgToClarityValue({ type: "bool", value: false }))).toBe("false");
+    expect(clarityToString(parseArgToClarityValue({ type: "none", value: null }))).toBe("none");
+    expect(clarityToString(parseArgToClarityValue({ type: "some", value: 5 }))).toBe("(some u5)");
+  });
+
+  test("typed list value", () => {
+    const cv = parseArgToClarityValue({ type: "list", value: [1, 2] });
+    const str = clarityToString(cv);
+    expect(str).toContain("u1");
+  });
+
+  test("typed tuple value", () => {
+    const cv = parseArgToClarityValue({ type: "tuple", value: { x: 1 } });
+    const str = clarityToString(cv);
+    expect(str).toContain("x");
+  });
+
+  test("unknown type throws", () => {
+    expect(() => parseArgToClarityValue({ type: "unknown", value: 1 })).toThrow("Unknown type");
+  });
+});
+
+describe("clarity helper creators", () => {
+  test("createUint", () => {
+    expect(clarityToString(createUint(100))).toBe("u100");
+    expect(clarityToString(createUint("999"))).toBe("u999");
+    expect(clarityToString(createUint(BigInt(42)))).toBe("u42");
+  });
+
+  test("createInt", () => {
+    expect(clarityToString(createInt(-7))).toBe("-7");
+  });
+
+  test("createPrincipal", () => {
+    const cv = createPrincipal("SP000000000000000000002Q6VF78");
+    expect(clarityToString(cv)).toContain("SP000000000000000000002Q6VF78");
+  });
+
+  test("createStringAscii", () => {
+    expect(clarityToString(createStringAscii("hello"))).toBe(`"hello"`);
+  });
+
+  test("createStringUtf8", () => {
+    expect(clarityToString(createStringUtf8("hello"))).toBe(`u"hello"`);
+  });
+
+  test("createBool", () => {
+    expect(clarityToString(createBool(true))).toBe("true");
+    expect(clarityToString(createBool(false))).toBe("false");
+  });
+
+  test("createBuffer from hex", () => {
+    const cv = createBuffer("deadbeef");
+    expect(clarityToString(cv)).toBe("0xdeadbeef");
+  });
+
+  test("createNone and createSome", () => {
+    expect(clarityToString(createNone())).toBe("none");
+    expect(clarityToString(createSome(createUint(1)))).toBe("(some u1)");
+  });
+
+  test("createList", () => {
+    const cv = createList([createUint(1), createUint(2)]);
+    expect(clarityToString(cv)).toContain("u1");
+  });
+
+  test("createTuple", () => {
+    const cv = createTuple({ amount: createUint(50) });
+    expect(clarityToString(cv)).toContain("amount");
+    expect(clarityToString(cv)).toContain("u50");
+  });
+});
+
+describe("serializeClarityValue", () => {
+  test("returns a hex string", () => {
+    const hex = serializeClarityValue(createUint(1));
+    expect(typeof hex).toBe("string");
+    expect(hex).toMatch(/^[0-9a-f]+$/);
+    expect(hex.length).toBeGreaterThan(0);
+  });
+
+  test("different values produce different hex", () => {
+    const hex1 = serializeClarityValue(createUint(1));
+    const hex2 = serializeClarityValue(createUint(2));
+    expect(hex1).not.toBe(hex2);
+  });
+});

--- a/src/lib/transactions/post-conditions.test.ts
+++ b/src/lib/transactions/post-conditions.test.ts
@@ -1,0 +1,85 @@
+import { describe, test, expect } from "bun:test";
+import {
+  createStxPostCondition,
+  createContractStxPostCondition,
+  createFungiblePostCondition,
+  createContractFungiblePostCondition,
+  createNftSendPostCondition,
+  createNftNotSendPostCondition,
+  PostConditionMode,
+} from "./post-conditions.js";
+
+const TEST_ADDR = "SP000000000000000000002Q6VF78";
+const TEST_CONTRACT = "SP000000000000000000002Q6VF78.pox-4";
+const TOKEN_CONTRACT = "SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-token";
+
+describe("STX post conditions", () => {
+  test("createStxPostCondition returns a post condition for each code", () => {
+    for (const code of ["eq", "gt", "gte", "lt", "lte"] as const) {
+      const pc = createStxPostCondition(TEST_ADDR, code, 1000n);
+      expect(pc).toBeDefined();
+      expect(pc.type).toContain("stx");
+    }
+  });
+
+  test("default condition code is eq", () => {
+    const pc = createStxPostCondition(TEST_ADDR, "eq" as any, 500n);
+    expect(pc).toBeDefined();
+  });
+
+  test("createContractStxPostCondition works for all codes", () => {
+    for (const code of ["eq", "gt", "gte", "lt", "lte"] as const) {
+      const pc = createContractStxPostCondition(TEST_CONTRACT, code, 2000n);
+      expect(pc).toBeDefined();
+      expect(pc.type).toContain("stx");
+    }
+  });
+});
+
+describe("fungible token post conditions", () => {
+  test("createFungiblePostCondition for all codes", () => {
+    for (const code of ["eq", "gt", "gte", "lt", "lte"] as const) {
+      const pc = createFungiblePostCondition(TEST_ADDR, TOKEN_CONTRACT, "sbtc-token", code, 100n);
+      expect(pc).toBeDefined();
+      expect(pc.type).toContain("ft");
+    }
+  });
+
+  test("createContractFungiblePostCondition for all codes", () => {
+    for (const code of ["eq", "gt", "gte", "lt", "lte"] as const) {
+      const pc = createContractFungiblePostCondition(TEST_CONTRACT, TOKEN_CONTRACT, "sbtc-token", code, 100n);
+      expect(pc).toBeDefined();
+      expect(pc.type).toContain("ft");
+    }
+  });
+
+  test("invalid contract ID throws", () => {
+    expect(() => createFungiblePostCondition(TEST_ADDR, "invalid", "token", "eq", 100n)).toThrow("Invalid contract ID");
+  });
+});
+
+describe("NFT post conditions", () => {
+  test("createNftSendPostCondition with bigint tokenId", () => {
+    const pc = createNftSendPostCondition(TEST_ADDR, TOKEN_CONTRACT, "nft-name", 1n);
+    expect(pc).toBeDefined();
+    expect(pc.type).toContain("nft");
+  });
+
+  test("createNftSendPostCondition with number tokenId", () => {
+    const pc = createNftSendPostCondition(TEST_ADDR, TOKEN_CONTRACT, "nft-name", 42);
+    expect(pc).toBeDefined();
+  });
+
+  test("createNftNotSendPostCondition", () => {
+    const pc = createNftNotSendPostCondition(TEST_ADDR, TOKEN_CONTRACT, "nft-name", 1n);
+    expect(pc).toBeDefined();
+    expect(pc.type).toContain("nft");
+  });
+});
+
+describe("PostConditionMode export", () => {
+  test("PostConditionMode has Allow and Deny", () => {
+    expect(PostConditionMode.Allow).toBeDefined();
+    expect(PostConditionMode.Deny).toBeDefined();
+  });
+});


### PR DESCRIPTION
Closes #15

Adds a comprehensive bun:test test suite covering pure/unit-testable modules:

## Test Coverage (77 tests, all passing)

| Module | Tests | What's tested |
|--------|-------|---------------|
| `config/caip.ts` | 10 | CAIP-2 chain ID parsing, network lookups, type checks |
| `config/contracts.ts` | 13 | Contract configs, parseContractId, network-specific getters, format validation |
| `config/networks.ts` | 6 | Network mapping, API URLs, explorer URL generation |
| `config/bitcoin-constants.ts` | 7 | All constants + fee estimation sanity check |
| `transactions/clarity-values.ts` | 27 | parseArgToClarityValue (all types), creator helpers, serialization |
| `transactions/post-conditions.ts` | 10 | STX/FT/NFT post-conditions, all condition codes, error handling |
| `services/inscription-parser.ts` | 4 | Parser instantiation, witness validation |

## Changes
- Added `"test": "bun test"` script to package.json
- Test files colocated next to source (`foo.test.ts` beside `foo.ts`)
- No mocks, no network calls — pure function tests only
- Uses `bun:test` built-in (describe/test/expect)