### PR TITLE
fix(stackspot): accept fully qualified contract identifiers

### DIFF
--- a/stackspot/AGENT.md
+++ b/stackspot/AGENT.md
@@ -41,15 +41,15 @@ Delegate to this agent when the workflow needs to:
 # List all known pots with current value and lock status
 bun run stackspot/stackspot.ts list-pots
 
-# Get full on-chain state for the STXLFG pot
-bun run stackspot/stackspot.ts get-pot-state --contract-name STXLFG
+# Get full on-chain state for a pot (accepts bare name or full identifier)
+bun run stackspot/stackspot.ts get-pot-state --contract-name SPT4SQP5RC1BFAJEQKBHZMXQ8NQ7G118F335BD85.STXLFG
 
-# Join the STXLFG pot with 21 STX (21,000,000 micro-STX)
-bun run stackspot/stackspot.ts join-pot --contract-name STXLFG --amount 21000000
+# Join a pot with 21 STX (21,000,000 micro-STX)
+bun run stackspot/stackspot.ts join-pot --contract-name SPT4SQP5RC1BFAJEQKBHZMXQ8NQ7G118F335BD85.STXLFG --amount 21000000
 
 # Start a full pot (must be in PoX prepare phase)
-bun run stackspot/stackspot.ts start-pot --contract-name STXLFG
+bun run stackspot/stackspot.ts start-pot --contract-name SPT4SQP5RC1BFAJEQKBHZMXQ8NQ7G118F335BD85.STXLFG
 
 # Claim sBTC rewards after pot cycle completes
-bun run stackspot/stackspot.ts claim-rewards --contract-name STXLFG
+bun run stackspot/stackspot.ts claim-rewards --contract-name SPT4SQP5RC1BFAJEQKBHZMXQ8NQ7G118F335BD85.STXLFG
 ```

--- a/stackspot/SKILL.md
+++ b/stackspot/SKILL.md
@@ -66,7 +66,7 @@ bun run stackspot/stackspot.ts get-pot-state --contract-name <name>
 ```
 
 Options:
-- `--contract-name` (required) — Pot contract name (e.g., `Genesis`, `BuildOnBitcoin`, `STXLFG`)
+- `--contract-name` (required) — Pot contract name or full identifier (e.g., `SPT4SQP5RC1BFAJEQKBHZMXQ8NQ7G118F335BD85.STXLFG` or `STXLFG`)
 
 Output:
 ```json

--- a/stackspot/stackspot.ts
+++ b/stackspot/stackspot.ts
@@ -67,21 +67,38 @@ const KNOWN_POTS: PotInfo[] = [
 // ---------------------------------------------------------------------------
 
 /**
- * Call a read-only function on a pot contract deployed by POT_DEPLOYER.
+ * Parse a contract name that may be fully qualified (deployer.name) or bare (name).
+ * Returns { deployer, contractName }.
+ */
+function parseContractName(input: string): {
+  deployer: string;
+  contractName: string;
+} {
+  if (input.includes(".")) {
+    const [deployer, ...rest] = input.split(".");
+    return { deployer, contractName: rest.join(".") };
+  }
+  return { deployer: POT_DEPLOYER, contractName: input };
+}
+
+/**
+ * Call a read-only function on a pot contract.
+ * Accepts either a bare contract name or fully qualified deployer.name.
  * Returns the deserialized Clarity value as a JSON-friendly object.
  */
 async function callPotReadOnly(
-  contractName: string,
+  contractNameOrId: string,
   functionName: string,
   args: ClarityValue[]
 ): Promise<unknown> {
   const hiro = getHiroApi(NETWORK);
-  const contractId = `${POT_DEPLOYER}.${contractName}`;
+  const { deployer, contractName } = parseContractName(contractNameOrId);
+  const contractId = `${deployer}.${contractName}`;
   const result = await hiro.callReadOnlyFunction(
     contractId,
     functionName,
     args,
-    POT_DEPLOYER
+    deployer
   );
   if (!result.okay) {
     throw new Error(
@@ -179,7 +196,7 @@ program
   )
   .requiredOption(
     "--contract-name <name>",
-    "Pot contract name (e.g., Genesis, BuildOnBitcoin, STXLFG)"
+    "Pot contract name or full identifier (e.g., SPT4SQP5RC1BFAJEQKBHZMXQ8NQ7G118F335BD85.STXLFG or STXLFG)"
   )
   .action(async (opts: { contractName: string }) => {
     try {
@@ -189,7 +206,8 @@ program
         );
       }
 
-      const contractId = `${POT_DEPLOYER}.${opts.contractName}`;
+      const parsed = parseContractName(opts.contractName);
+      const contractId = `${parsed.deployer}.${parsed.contractName}`;
 
       const [potValue, isLocked, configs, poolConfig, details] =
         await Promise.all([
@@ -202,7 +220,7 @@ program
 
       printJson({
         network: NETWORK,
-        contractName: opts.contractName,
+        contractName: parsed.contractName,
         contractId,
         state: {
           potValueUstx: potValue,
@@ -229,7 +247,7 @@ program
   )
   .requiredOption(
     "--contract-name <name>",
-    "Pot contract name (e.g., STXLFG)"
+    "Pot name or full identifier (e.g., SPT4SQP5RC1BFAJEQKBHZMXQ8NQ7G118F335BD85.STXLFG or STXLFG)"
   )
   .requiredOption(
     "--amount <microStx>",
@@ -248,15 +266,17 @@ program
         throw new Error("--amount must be a positive integer in micro-STX");
       }
 
+      const parsed = parseContractName(opts.contractName);
+
       // Warn if amount is below the known minimum for this pot
       const knownPot = KNOWN_POTS.find(
-        (p) => p.contractName === opts.contractName
+        (p) => p.contractName === parsed.contractName
       );
       if (knownPot) {
         const minUstx = BigInt(knownPot.minAmountStx) * 1_000_000n;
         if (amount < minUstx) {
           throw new Error(
-            `--amount ${opts.amount} is below the minimum for ${opts.contractName}: ` +
+            `--amount ${opts.amount} is below the minimum for ${parsed.contractName}: ` +
               `${minUstx} micro-STX (${knownPot.minAmountStx} STX)`
           );
         }
@@ -265,8 +285,8 @@ program
       const account = await getAccount();
 
       const result = await callContract(account, {
-        contractAddress: POT_DEPLOYER,
-        contractName: opts.contractName,
+        contractAddress: parsed.deployer,
+        contractName: parsed.contractName,
         functionName: "join-pot",
         functionArgs: [uintCV(amount)],
         postConditionMode: PostConditionMode.Allow,
@@ -278,7 +298,7 @@ program
         network: NETWORK,
         explorerUrl: getExplorerTxUrl(result.txid, NETWORK),
         pot: {
-          contractName: opts.contractName,
+          contractName: parsed.contractName,
           amountUstx: opts.amount,
         },
       });
@@ -299,7 +319,7 @@ program
   )
   .requiredOption(
     "--contract-name <name>",
-    "Pot contract name to start stacking"
+    "Pot name or full identifier to start stacking"
   )
   .action(async (opts: { contractName: string }) => {
     try {
@@ -309,13 +329,14 @@ program
         );
       }
 
+      const parsed = parseContractName(opts.contractName);
       const account = await getAccount();
 
       const result = await callContract(account, {
         contractAddress: PLATFORM_ADDRESS,
         contractName: PLATFORM_CONTRACT,
         functionName: "start-stackspot-jackpot",
-        functionArgs: [contractPrincipalCV(POT_DEPLOYER, opts.contractName)],
+        functionArgs: [contractPrincipalCV(parsed.deployer, parsed.contractName)],
         postConditionMode: PostConditionMode.Allow,
       });
 
@@ -325,7 +346,7 @@ program
         network: NETWORK,
         explorerUrl: getExplorerTxUrl(result.txid, NETWORK),
         pot: {
-          contractName: opts.contractName,
+          contractName: parsed.contractName,
         },
       });
     } catch (error) {
@@ -345,7 +366,7 @@ program
   )
   .requiredOption(
     "--contract-name <name>",
-    "Pot contract name to claim rewards from"
+    "Pot name or full identifier to claim rewards from"
   )
   .action(async (opts: { contractName: string }) => {
     try {
@@ -355,13 +376,14 @@ program
         );
       }
 
+      const parsed = parseContractName(opts.contractName);
       const account = await getAccount();
 
       const result = await callContract(account, {
-        contractAddress: POT_DEPLOYER,
-        contractName: opts.contractName,
+        contractAddress: parsed.deployer,
+        contractName: parsed.contractName,
         functionName: "claim-pot-reward",
-        functionArgs: [contractPrincipalCV(POT_DEPLOYER, opts.contractName)],
+        functionArgs: [contractPrincipalCV(parsed.deployer, parsed.contractName)],
         postConditionMode: PostConditionMode.Allow,
       });
 
@@ -371,7 +393,7 @@ program
         network: NETWORK,
         explorerUrl: getExplorerTxUrl(result.txid, NETWORK),
         pot: {
-          contractName: opts.contractName,
+          contractName: parsed.contractName,
         },
       });
     } catch (error) {
@@ -391,7 +413,7 @@ program
   )
   .requiredOption(
     "--contract-name <name>",
-    "Pot contract name to cancel"
+    "Pot name or full identifier to cancel"
   )
   .action(async (opts: { contractName: string }) => {
     try {
@@ -401,13 +423,14 @@ program
         );
       }
 
+      const parsed = parseContractName(opts.contractName);
       const account = await getAccount();
 
       const result = await callContract(account, {
-        contractAddress: POT_DEPLOYER,
-        contractName: opts.contractName,
+        contractAddress: parsed.deployer,
+        contractName: parsed.contractName,
         functionName: "cancel-pot",
-        functionArgs: [contractPrincipalCV(POT_DEPLOYER, opts.contractName)],
+        functionArgs: [contractPrincipalCV(parsed.deployer, parsed.contractName)],
         postConditionMode: PostConditionMode.Allow,
       });
 
@@ -417,7 +440,7 @@ program
         network: NETWORK,
         explorerUrl: getExplorerTxUrl(result.txid, NETWORK),
         pot: {
-          contractName: opts.contractName,
+          contractName: parsed.contractName,
         },
       });
     } catch (error) {


### PR DESCRIPTION
## Summary

Applies cocoa007's fix from PR #40 (closed), rebased cleanly onto current main.

- Add `parseContractName()` helper that splits `deployer.name` or defaults to `POT_DEPLOYER`
- Update all subcommands (join-pot, start-pot, claim-rewards, cancel-pot, get-pot-state) to use parsed deployer
- Update docs and examples to show full contract identifiers
- Backwards compatible: bare names still work

**Original PR:** #40 by @cocoa007
**Why a new PR:** The original branch had a dependency chain on older squash-merged commits, making retargeting to main impractical. The fix commit (edaa02b) was cherry-picked cleanly.

## Test plan
- [ ] `bun run typecheck` passes
- [ ] `bun run manifest` regenerates without changes
- [ ] `--contract-name STXLFG` still works (bare name)
- [ ] `--contract-name SPT4SQP5RC1BFAJEQKBHZMXQ8NQ7G118F335BD85.STXLFG` now works (fully qualified)

Co-Authored-By: cocoa007 <cocoa007@users.noreply.github.com>