### PR TITLE
feat(settings): add check-relay-health subcommand (closes #51)

### DIFF
--- a/settings/AGENT.md
+++ b/settings/AGENT.md
@@ -13,6 +13,7 @@ This agent manages configuration stored at `~/.aibtc/config.json`. It controls t
 - Set, retrieve, and delete the Hiro API key for authenticated API access
 - Set, retrieve, and delete a custom Stacks API node URL
 - Query the current package version for compatibility checks
+- Diagnose x402 sponsor relay health and sponsor address nonce status
 
 ## When to Delegate Here
 
@@ -21,6 +22,9 @@ Delegate to this agent when the workflow needs to:
 - Switch between mainnet and a custom Stacks node endpoint
 - Verify the installed version of the AIBTC skills package
 - Troubleshoot rate limiting by confirming the Hiro API key is set
+- Check if the x402 sponsor relay is reachable and operating normally
+- Diagnose stuck transactions or nonce gaps on the sponsor address
+- Assess mempool congestion before submitting sponsored transactions
 
 ## Example Invocations
 
@@ -33,4 +37,10 @@ bun run settings/settings.ts get-stacks-api-url
 
 # Get the current package version
 bun run settings/settings.ts get-server-version
+
+# Check relay health with defaults
+bun run settings/settings.ts check-relay-health
+
+# Check relay health with custom relay URL
+bun run settings/settings.ts check-relay-health --relay-url https://my-relay.example.com
 ```

--- a/settings/SKILL.md
+++ b/settings/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: settings
-description: Manage AIBTC skill settings stored at ~/.aibtc/config.json. Configure the Hiro API key for authenticated rate limits, set a custom Stacks API node URL, and check the current package version.
+description: Manage AIBTC skill settings stored at ~/.aibtc/config.json. Configure the Hiro API key for authenticated rate limits, set a custom Stacks API node URL, check the current package version, and diagnose x402 sponsor relay health.
 user-invocable: false
-arguments: set-hiro-api-key | get-hiro-api-key | delete-hiro-api-key | set-stacks-api-url | get-stacks-api-url | delete-stacks-api-url | get-server-version
+arguments: set-hiro-api-key | get-hiro-api-key | delete-hiro-api-key | set-stacks-api-url | get-stacks-api-url | delete-stacks-api-url | get-server-version | check-relay-health
 entry: settings/settings.ts
 requires: []
 tags: [infrastructure]
@@ -177,6 +177,62 @@ Output:
   "isLatest": true,
   "updateAvailable": false,
   "package": "@aibtc/skills"
+}
+```
+
+### check-relay-health
+
+Check the health of the x402 sponsor relay and the sponsor address nonce status on-chain. Reports relay reachability, version, sponsor nonce gaps, and mempool congestion.
+
+```
+bun run settings/settings.ts check-relay-health [--relay-url <url>] [--sponsor-address <address>]
+```
+
+Options:
+- `--relay-url` (optional) — Base URL of the sponsor relay (default: `https://sponsor.aibtc.dev`)
+- `--sponsor-address` (optional) — STX address of the relay sponsor (default: `SP1PMPPVCMVW96FSWFV30KJQ4MNBMZ8MRWR3JWQ7`)
+
+Output (healthy):
+```json
+{
+  "healthy": true,
+  "relay": {
+    "url": "https://sponsor.aibtc.dev",
+    "reachable": true,
+    "status": "ok",
+    "version": "1.0.0"
+  },
+  "sponsor": {
+    "address": "SP1PMPPVCMVW96FSWFV30KJQ4MNBMZ8MRWR3JWQ7",
+    "lastExecutedNonce": 732,
+    "possibleNextNonce": 733,
+    "lastMempoolNonce": null,
+    "mempoolCount": 0,
+    "missingNonces": []
+  },
+  "issues": [],
+  "hint": "Relay and sponsor are operating normally."
+}
+```
+
+Output (issues detected):
+```json
+{
+  "healthy": false,
+  "relay": { "url": "https://sponsor.aibtc.dev", "reachable": false, "error": "fetch failed" },
+  "sponsor": {
+    "address": "SP1PMPPVCMVW96FSWFV30KJQ4MNBMZ8MRWR3JWQ7",
+    "lastExecutedNonce": 732,
+    "possibleNextNonce": 733,
+    "lastMempoolNonce": null,
+    "mempoolCount": 0,
+    "missingNonces": [730]
+  },
+  "issues": [
+    "Relay unreachable: fetch failed",
+    "Nonce gaps detected: [730]. Transactions may be stuck. The sponsor may need to fill missing nonces."
+  ],
+  "hint": "Issues detected — see the issues array for details."
 }
 ```
 

--- a/settings/settings.ts
+++ b/settings/settings.ts
@@ -296,6 +296,142 @@ program
   });
 
 // ---------------------------------------------------------------------------
+// check-relay-health
+// ---------------------------------------------------------------------------
+
+program
+  .command("check-relay-health")
+  .description(
+    "Check the health of the x402 sponsor relay and the sponsor address nonce status on-chain"
+  )
+  .option(
+    "--relay-url <url>",
+    "Base URL of the sponsor relay",
+    "https://sponsor.aibtc.dev"
+  )
+  .option(
+    "--sponsor-address <address>",
+    "STX address of the relay sponsor",
+    "SP1PMPPVCMVW96FSWFV30KJQ4MNBMZ8MRWR3JWQ7"
+  )
+  .action(
+    async (opts: { relayUrl: string; sponsorAddress: string }) => {
+      try {
+        const relayUrl = opts.relayUrl.replace(/\/+$/, "");
+        const sponsorAddress = opts.sponsorAddress;
+
+        // ---- 1. Hit relay /health endpoint ----
+        let relayHealth: Record<string, unknown> | null = null;
+        let relayReachable = false;
+        let relayError: string | undefined;
+
+        try {
+          const controller = new AbortController();
+          const timeout = setTimeout(() => controller.abort(), 10_000);
+          const res = await fetch(`${relayUrl}/health`, {
+            signal: controller.signal,
+          });
+          clearTimeout(timeout);
+
+          if (res.ok) {
+            relayHealth = (await res.json()) as Record<string, unknown>;
+            relayReachable = true;
+          } else {
+            relayError = `HTTP ${res.status} ${res.statusText}`;
+          }
+        } catch (err: unknown) {
+          relayError =
+            err instanceof Error ? err.message : "Unknown fetch error";
+        }
+
+        // ---- 2. Check sponsor nonce status via Hiro API ----
+        interface NonceResponse {
+          last_mempool_tx_nonce: number | null;
+          last_executed_tx_nonce: number | null;
+          possible_next_nonce: number;
+          detected_missing_nonces: number[];
+          detected_mempool_nonces: number[];
+        }
+
+        let nonceData: NonceResponse | null = null;
+        let nonceError: string | undefined;
+
+        try {
+          const controller = new AbortController();
+          const timeout = setTimeout(() => controller.abort(), 10_000);
+          const res = await fetch(
+            `https://api.hiro.so/extended/v1/address/${sponsorAddress}/nonces`,
+            { signal: controller.signal }
+          );
+          clearTimeout(timeout);
+
+          if (res.ok) {
+            nonceData = (await res.json()) as NonceResponse;
+          } else {
+            nonceError = `HTTP ${res.status} ${res.statusText}`;
+          }
+        } catch (err: unknown) {
+          nonceError =
+            err instanceof Error ? err.message : "Unknown fetch error";
+        }
+
+        // ---- 3. Build diagnostic output ----
+        const issues: string[] = [];
+
+        if (!relayReachable) {
+          issues.push(`Relay unreachable: ${relayError ?? "unknown error"}`);
+        }
+
+        if (nonceData) {
+          if (nonceData.detected_missing_nonces.length > 0) {
+            issues.push(
+              `Nonce gaps detected: [${nonceData.detected_missing_nonces.join(", ")}]. ` +
+                "Transactions may be stuck. The sponsor may need to fill missing nonces."
+            );
+          }
+          if (nonceData.detected_mempool_nonces.length > 5) {
+            issues.push(
+              `Mempool congestion: ${nonceData.detected_mempool_nonces.length} pending sponsor transactions. ` +
+                "New sponsored transactions may be slow to confirm."
+            );
+          }
+        } else {
+          issues.push(
+            `Unable to fetch sponsor nonce data: ${nonceError ?? "unknown error"}`
+          );
+        }
+
+        const healthy = relayReachable && issues.length === 0;
+
+        printJson({
+          healthy,
+          relay: {
+            url: relayUrl,
+            reachable: relayReachable,
+            ...(relayHealth ?? {}),
+            ...(relayError ? { error: relayError } : {}),
+          },
+          sponsor: {
+            address: sponsorAddress,
+            lastExecutedNonce: nonceData?.last_executed_tx_nonce ?? null,
+            possibleNextNonce: nonceData?.possible_next_nonce ?? null,
+            lastMempoolNonce: nonceData?.last_mempool_tx_nonce ?? null,
+            mempoolCount: nonceData?.detected_mempool_nonces?.length ?? null,
+            missingNonces: nonceData?.detected_missing_nonces ?? [],
+            ...(nonceError ? { error: nonceError } : {}),
+          },
+          issues,
+          hint: healthy
+            ? "Relay and sponsor are operating normally."
+            : "Issues detected — see the issues array for details.",
+        });
+      } catch (error) {
+        handleError(error);
+      }
+    }
+  );
+
+// ---------------------------------------------------------------------------
 // Parse
 // ---------------------------------------------------------------------------
 

--- a/skills.json
+++ b/skills.json
@@ -295,7 +295,7 @@
     },
     {
       "name": "settings",
-      "description": "Manage AIBTC skill settings stored at ~/.aibtc/config.json. Configure the Hiro API key for authenticated rate limits, set a custom Stacks API node URL, and check the current package version.",
+      "description": "Manage AIBTC skill settings stored at ~/.aibtc/config.json. Configure the Hiro API key for authenticated rate limits, set a custom Stacks API node URL, check the current package version, and diagnose x402 sponsor relay health.",
       "entry": "settings/settings.ts",
       "arguments": [
         "set-hiro-api-key",
@@ -304,7 +304,8 @@
         "set-stacks-api-url",
         "get-stacks-api-url",
         "delete-stacks-api-url",
-        "get-server-version"
+        "get-server-version",
+        "check-relay-health"
       ],
       "requires": [],
       "tags": [


### PR DESCRIPTION
## Summary

Adds a `check-relay-health` subcommand to the `settings` skill that diagnoses the x402 sponsor relay and sponsor address nonce status. Closes #51.

### What it does

1. Hits the relay `/health` endpoint (default: `https://sponsor.aibtc.dev/health`) with a 10s timeout
2. Queries the Hiro API for sponsor address nonce data
3. Returns a structured JSON report with:
   - Relay reachability and health response
   - Sponsor nonce status (last executed, next, mempool count)
   - Nonce gap detection (stuck transactions)
   - Mempool congestion warnings (>5 pending txs)
   - Clear `issues` array and `hint` for agent consumption

### Usage

```bash
bun run settings/settings.ts check-relay-health
bun run settings/settings.ts check-relay-health --relay-url https://my-relay.example.com
```

---
Signed-by: cocoa007.btc (BTC: bc1qv8dt3v9kx3l7r9mnz2gj9r9n9k63frn6w6zmrt)