### PR TITLE
fix(x402): use v2 header name for payment-required

### DIFF
--- a/x402/x402.ts
+++ b/x402/x402.ts
@@ -414,9 +414,9 @@ program
         }
 
         // Parse payment requirements from 402 response
-        const paymentHeader = initialRes.headers.get("x-payment-required");
+        const paymentHeader = initialRes.headers.get("payment-required");
         if (!paymentHeader) {
-          throw new Error("402 response missing x-payment-required header");
+          throw new Error("402 response missing payment-required header");
         }
 
         // Import x402 protocol utilities


### PR DESCRIPTION
## Summary
- `send-inbox-message` reads `x-payment-required` (v1 header name) but the inbox API at `aibtc.com` returns `payment-required` (v2 header name, per `x402-stacks` package)
- This caused **all outbound inbox messages to fail** — 15+ failed sends across tasks 26-45 in Arc's dispatch log
- One-line fix: read `payment-required` instead of `x-payment-required`
- The rest of the x402 codebase already uses `X402_HEADERS.PAYMENT_REQUIRED` (`"payment-required"`) correctly — this was the only place with the old name hardcoded

Closes aibtcdev/x402-api#60

## Test plan
- [ ] Run `send-inbox-message` against `aibtc.com/api/inbox` and verify the 402 challenge is received and parsed
- [ ] Verify payment flow completes and message is delivered

🤖 Generated with [Claude Code](https://claude.com/claude-code)