### PR TITLE
fix(signing): remove varint prepend from bip322TaggedHash

### DIFF
--- a/signing/signing.ts
+++ b/signing/signing.ts
@@ -229,11 +229,16 @@ function taggedHash(tag: string, data: Uint8Array): Uint8Array {
 }
 
 /**
- * BIP-322 message hash: taggedHash("BIP0322-signed-message", varint(msg.len) || msg)
+ * BIP-322 message hash: taggedHash("BIP0322-signed-message", msg)
+ *
+ * Per BIP-322 spec, the tagged hash takes the raw message bytes directly.
+ * Prepending a varint length prefix was incorrect — that belongs to BIP-137
+ * serialization, not BIP-322's tagged hash construction.
+ * See: https://github.com/aibtcdev/x402-sponsor-relay/issues/135
  */
 function bip322TaggedHash(message: string): Uint8Array {
   const msgBytes = new TextEncoder().encode(message);
-  return taggedHash("BIP0322-signed-message", concatBytes(encodeVarInt(msgBytes.length), msgBytes));
+  return taggedHash("BIP0322-signed-message", msgBytes);
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes a bug in `bip322TaggedHash` where a varint length prefix was incorrectly prepended to the message before computing the BIP-322 tagged hash.

**Root cause:** BIP-322's tagged hash construction takes raw message bytes directly:
```
SHA256(SHA256(tag) || SHA256(tag) || message_bytes)
```
The previous implementation followed BIP-137 message serialization conventions instead, prepending `varint(message.length)` before the message bytes. This caused signature verification failures against any spec-compliant BIP-322 verifier.

**Fix:** Remove the `encodeVarInt` call and pass `msgBytes` directly to `taggedHash`.

```ts
// Before (incorrect)
return taggedHash("BIP0322-signed-message", concatBytes(encodeVarInt(msgBytes.length), msgBytes));

// After (correct per BIP-322 spec)
return taggedHash("BIP0322-signed-message", msgBytes);
```

Note: `encodeVarInt` is still used in BIP-137 message signing (line 129) and script serialization — no dead code introduced.

## Related

- Fixes: https://github.com/aibtcdev/x402-sponsor-relay/issues/135
- This same bug exists in `x402-sponsor-relay`, `aibtc-mcp-server`, and `landing-page` — tracked in the issue above.

## Test plan

- [ ] Verify BIP-322 signatures from `skills/signing` can be verified by a spec-compliant verifier (e.g., Bitcoin Core `verifymessage` or reference implementation)
- [ ] Confirm cross-repo signing/verification round-trips work once all four repos are patched

🤖 Generated with [Claude Code](https://claude.com/claude-code)