### PR TITLE
signing: align SIP-018 domain parsing with MCP shape + parity tests

### DIFF
--- a/signing/SKILL.md
+++ b/signing/SKILL.md
@@ -51,8 +51,8 @@ Options:
   - `{"type":"list","value":[...]}` → `list`
   - `{"type":"tuple","value":{...}}` → `tuple`
   - Implicit: `string → string-utf8`, `number → int`, `boolean → bool`, `null → none`
-- `--domain-name` (required) — Application name for domain binding
-- `--domain-version` (required) — Application version for domain binding
+- `--domain-name` + `--domain-version` (required together) — Flat CLI domain fields
+- `--domain` (alternative) — MCP-style JSON object: `{"name":"My App","version":"1.0.0"}` (optional `chainId`)
 
 Output:
 ```json
@@ -120,9 +120,9 @@ bun run signing/signing.ts sip018-hash \
 
 Options:
 - `--message` (required) — Structured data as a JSON string (same format as sip018-sign)
-- `--domain-name` (required) — Application name
-- `--domain-version` (required) — Application version
-- `--chain-id` (optional) — Chain ID (default: 1 for mainnet, 2147483648 for testnet)
+- `--domain-name` + `--domain-version` (required together) — Flat CLI domain fields
+- `--domain` (alternative) — MCP-style JSON object: `{"name":"My App","version":"1.0.0"}` (optional `chainId`)
+- `--chain-id` (optional) — Chain ID override (takes precedence over `domain.chainId`)
 
 Output:
 ```json

--- a/signing/signing.test.ts
+++ b/signing/signing.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from "bun:test";
+
+function runSip018Hash(args: string[]) {
+  const proc = Bun.spawnSync([
+    "bun",
+    "run",
+    "signing/signing.ts",
+    "sip018-hash",
+    "--message",
+    '{"amount":{"type":"uint","value":100},"memo":"hello"}',
+    ...args,
+  ]);
+
+  const stdout = Buffer.from(proc.stdout).toString("utf8").trim();
+  const stderr = Buffer.from(proc.stderr).toString("utf8").trim();
+
+  if (proc.exitCode !== 0) {
+    throw new Error(`sip018-hash failed (${proc.exitCode})\nstdout: ${stdout}\nstderr: ${stderr}`);
+  }
+
+  return JSON.parse(stdout);
+}
+
+describe("signing/sip018 domain parameter alignment", () => {
+  test("CLI flat domain flags and MCP-style --domain object produce identical hashes", () => {
+    const viaCli = runSip018Hash([
+      "--domain-name",
+      "My App",
+      "--domain-version",
+      "1.0.0",
+    ]);
+
+    const viaMcpShape = runSip018Hash([
+      "--domain",
+      '{"name":"My App","version":"1.0.0"}',
+    ]);
+
+    expect(viaCli.success).toBe(true);
+    expect(viaMcpShape.success).toBe(true);
+
+    expect(viaCli.hashes).toEqual(viaMcpShape.hashes);
+    expect(viaCli.domain).toEqual(viaMcpShape.domain);
+  });
+
+  test("MCP-style domain.chainId matches --chain-id behavior", () => {
+    const viaCliChainOverride = runSip018Hash([
+      "--domain-name",
+      "My App",
+      "--domain-version",
+      "1.0.0",
+      "--chain-id",
+      "1",
+    ]);
+
+    const viaMcpDomainChainId = runSip018Hash([
+      "--domain",
+      '{"name":"My App","version":"1.0.0","chainId":1}',
+    ]);
+
+    expect(viaCliChainOverride.success).toBe(true);
+    expect(viaMcpDomainChainId.success).toBe(true);
+
+    expect(viaCliChainOverride.hashes).toEqual(viaMcpDomainChainId.hashes);
+    expect(viaCliChainOverride.domain).toEqual(viaMcpDomainChainId.domain);
+  });
+});

--- a/signing/signing.ts
+++ b/signing/signing.ts
@@ -813,7 +813,7 @@ function resolveDomainParams(opts: {
   domain?: string;
   domainName?: string;
   domainVersion?: string;
-}): { name: string; version: string } {
+}): { name: string; version: string; chainId?: number } {
   if (opts.domain) {
     const parsed = parseJsonObject(opts.domain, "--domain");
     if (typeof parsed.name !== "string" || typeof parsed.version !== "string") {
@@ -821,7 +821,20 @@ function resolveDomainParams(opts: {
         '--domain must be a JSON object with "name" and "version" string fields'
       );
     }
-    return { name: parsed.name, version: parsed.version };
+
+    let chainId: number | undefined;
+    if (parsed.chainId !== undefined) {
+      const parsedChainId =
+        typeof parsed.chainId === "string"
+          ? parseInt(parsed.chainId, 10)
+          : parsed.chainId;
+      if (!Number.isInteger(parsedChainId)) {
+        throw new Error('--domain.chainId must be an integer when provided');
+      }
+      chainId = parsedChainId;
+    }
+
+    return { name: parsed.name, version: parsed.version, chainId };
   }
   if (opts.domainName && opts.domainVersion) {
     return { name: opts.domainName, version: opts.domainVersion };
@@ -838,7 +851,7 @@ function addDomainOptions(cmd: Command): Command {
   return cmd
     .option(
       "--domain <json>",
-      "Domain as JSON object matching MCP format (e.g., '{\"name\":\"My App\",\"version\":\"1.0.0\"}')"
+      "Domain as JSON object matching MCP format (e.g., '{\"name\":\"My App\",\"version\":\"1.0.0\",\"chainId\":2147483648}')"
     )
     .option(
       "--domain-name <name>",
@@ -898,9 +911,13 @@ addDomainOptions(sip018SignCmd)
       try {
         const account = requireUnlockedWallet();
         const messageJson = parseJsonObject(opts.message, "--message");
-        const { name: domainName, version: domainVersion } = resolveDomainParams(opts);
+        const {
+          name: domainName,
+          version: domainVersion,
+          chainId: domainChainId,
+        } = resolveDomainParams(opts);
 
-        const chainId = CHAIN_IDS[NETWORK];
+        const chainId = domainChainId ?? CHAIN_IDS[NETWORK];
         const domainCV = buildDomainCV(domainName, domainVersion, chainId);
         const messageCV = jsonToClarityValue(messageJson);
 
@@ -1033,11 +1050,15 @@ addDomainOptions(sip018HashCmd)
     }) => {
       try {
         const messageJson = parseJsonObject(opts.message, "--message");
-        const { name: domainName, version: domainVersion } = resolveDomainParams(opts);
+        const {
+          name: domainName,
+          version: domainVersion,
+          chainId: domainChainId,
+        } = resolveDomainParams(opts);
 
         const chainId = opts.chainId
           ? parseInt(opts.chainId, 10)
-          : CHAIN_IDS[NETWORK];
+          : domainChainId ?? CHAIN_IDS[NETWORK];
 
         if (isNaN(chainId)) {
           throw new Error("--chain-id must be an integer");


### PR DESCRIPTION
## Summary
- Align `sip018-sign` / `sip018-hash` domain parsing with MCP shape by supporting optional `domain.chainId` in `--domain` JSON.
- Keep backward compatibility with existing flat CLI flags (`--domain-name`, `--domain-version`, `--chain-id`).
- Add parity tests to prove CLI-flat and MCP-style domain inputs produce identical SIP-018 hash outputs for the same input.

## Changes
- `signing/signing.ts`
  - `resolveDomainParams` now accepts optional `chainId` in `--domain` JSON and validates it as an integer.
  - `sip018-sign` uses `domain.chainId` when provided (otherwise network default).
  - `sip018-hash` accepts `domain.chainId` and still lets `--chain-id` override it.
- `signing/signing.test.ts`
  - Test 1: CLI flat domain args == MCP-style `--domain` JSON hashes
  - Test 2: `--chain-id` == `domain.chainId` hashes
- `signing/SKILL.md`
  - Document `--domain` JSON as MCP-style alternative and chain-id precedence.

## Validation
- `npx bun test signing/signing.test.ts` (2 passing)

Closes #50
