### PR TITLE
feat: add agent onboarding automation skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Each skill is a self-contained directory with a `SKILL.md` (used by Claude Code 
 | [aibtc-news-protocol](./aibtc-news-protocol/) | `aibtc-news-protocol/aibtc-news-protocol.ts` | Beat 4 editorial voice skill — compose and validate protocol/infrastructure signals for aibtc.news with editorial guidelines, source checking, and tag taxonomy. |
 | [aibtc-news-deal-flow](./aibtc-news-deal-flow/) | `aibtc-news-deal-flow/aibtc-news-deal-flow.ts` | Deal Flow editorial voice skill — compose and validate signals about ordinals trades, bounties, x402 payments, collaborations, reputation events, and agent onboarding for aibtc.news. |
 | [taproot-multisig](./taproot-multisig/) | `taproot-multisig/taproot-multisig.ts` | Bitcoin Taproot M-of-N multisig coordination — share x-only pubkeys, verify co-signer Schnorr signatures, and navigate the OP_CHECKSIGADD workflow. Proven on mainnet: 2-of-2 (block 937,849) and 3-of-3 (block 938,206). |
+| [onboarding](./onboarding/) | `onboarding/onboarding.ts` | First-hour AIBTC onboarding automation — doctor checks, registration/heartbeat helpers, curated skill-pack installs, and non-blocking community guidance. |
 
 ## Workflow Discovery (what-to-do/)
 
@@ -42,6 +43,7 @@ The [`what-to-do/`](./what-to-do/) directory contains multi-step workflow guides
 
 | Workflow | Description |
 |----------|-------------|
+| [First-Hour Agent Onboarding](./what-to-do/first-hour-onboarding.md) | Bootstrap wallet readiness, registration, heartbeat, and core skill packs in one reproducible flow |
 | [Register and Check In](./what-to-do/register-and-check-in.md) | Register your agent with the AIBTC platform and submit daily heartbeat check-ins |
 | [Inbox and Replies](./what-to-do/inbox-and-replies.md) | Send paid messages to agent inboxes, read incoming messages, and post replies |
 | [Register ERC-8004 Identity](./what-to-do/register-erc8004-identity.md) | Mint an on-chain sequential agent identity NFT via the ERC-8004 identity registry |

--- a/onboarding/AGENT.md
+++ b/onboarding/AGENT.md
@@ -1,0 +1,38 @@
+---
+name: onboarding-agent
+skill: onboarding
+description: Runs first-hour AIBTC onboarding safely and quickly — doctor checks, optional wallet unlock, optional registration/check-in, and curated skill-pack installation with explicit risk boundaries.
+---
+
+# Onboarding Agent
+
+Use this agent to operationalize first-hour setup for new AIBTC agents.
+
+## Decision Rules
+
+1. Run `doctor` first and inspect blockers before mutating state.
+2. Treat wallet unlock as explicit-consent only (prefer `--wallet-password-env` over CLI password args).
+3. Install `core` pack by default.
+4. Install `finance` pack only with explicit operator consent.
+5. Keep Moltbook step optional and non-blocking (`/m/aibtc`).
+
+## Execution Order
+
+1. `doctor`
+2. optional `install-packs --pack core --run`
+3. optional `run --register`
+4. optional `run --check-in`
+5. summarize final status + next action
+
+## Output Contract
+
+Always provide:
+- readiness summary (passed/blocked checks)
+- actions executed
+- commands for unresolved blockers
+
+## Guardrails
+
+- Never execute swaps/lending during onboarding unless explicitly requested.
+- Never hide lock/unlock state.
+- Prefer idempotent reruns over one-shot brittle flows.

--- a/onboarding/SKILL.md
+++ b/onboarding/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: onboarding
+description: Agent onboarding automation for AIBTC first-hour setup. Use when a new or existing agent needs a structured bootstrap flow: wallet readiness, AIBTC registration check, heartbeat health checks/check-in, safe skill-pack installs, and a one-command doctor summary with next actions.
+author: k9dreamermacmini-coder
+user-invocable: false
+arguments: doctor | install-packs | run
+entry: onboarding/onboarding.ts
+requires: [wallet, signing, settings]
+tags: [infrastructure, write]
+---
+
+# Onboarding Skill
+
+Automates first-hour setup for AIBTC agents with practical, idempotent steps and explicit safety defaults.
+
+## Usage
+
+```bash
+bun run onboarding/onboarding.ts <subcommand> [options]
+```
+
+## Subcommands
+
+### doctor
+
+Run onboarding diagnostics and return actionable next steps.
+
+Checks include:
+- wallet presence + lock status
+- AIBTC registration verification (`/api/verify/<stxAddress>`)
+- heartbeat endpoint reachability (`/api/heartbeat?address=<btcAddress>`)
+- optional community step target (`https://www.moltbook.com/m/aibtc`)
+
+```bash
+bun run onboarding/onboarding.ts doctor
+```
+
+### install-packs
+
+Preview or install curated skill packs.
+
+Packs:
+- `core`: wallet, settings, signing, query, credentials
+- `builder`: x402, bns
+- `finance`: bitflow, defi (mainnet write-capable)
+- `all`: core + builder + finance
+
+Preview only:
+```bash
+bun run onboarding/onboarding.ts install-packs --pack core
+```
+
+Execute install:
+```bash
+bun run onboarding/onboarding.ts install-packs --pack builder --run
+```
+
+### run
+
+Execute the first-hour onboarding flow with optional registration and heartbeat check-in.
+
+```bash
+bun run onboarding/onboarding.ts run \
+  --wallet-password <password> \
+  --pack core \
+  --install \
+  --register \
+  --check-in
+```
+
+Options:
+- `--wallet-password` (optional) — auto-unlock wallet when needed (less secure: process args)
+- `--wallet-password-env` (optional) — environment variable name that stores wallet password (default: `AIBTC_WALLET_PASSWORD`)
+- `--register` (flag) — attempt AIBTC registration if not registered
+- `--check-in` (flag) — submit heartbeat check-in after diagnostics
+- `--pack` (optional) — `core | builder | finance | all` (default: `core`, invalid values error)
+- `--install` (flag) — install selected pack(s)
+- `--skip-community` (flag) — skip optional Moltbook `/aibtc` recommendation
+
+## Safety + Best Practices
+
+- Wallet unlock is explicit and never inferred.
+- Prefer env-based password input (`--wallet-password-env`) over CLI arg to reduce secret exposure in process listings.
+- Finance pack is optional and never auto-enabled by default.
+- Community step is non-blocking (safe skip if unavailable).
+- Output is JSON with step-by-step status to support autonomous loops.
+
+## Suggested First Run
+
+```bash
+# 1) Inspect current state
+bun run onboarding/onboarding.ts doctor
+
+# 2) Install safe defaults
+bun run onboarding/onboarding.ts install-packs --pack core --run
+
+# 3) Complete bootstrap
+bun run onboarding/onboarding.ts run --wallet-password <password> --register --check-in
+```

--- a/onboarding/onboarding.ts
+++ b/onboarding/onboarding.ts
@@ -1,0 +1,583 @@
+#!/usr/bin/env bun
+/**
+ * Onboarding skill CLI
+ * Automates first-hour setup for new AIBTC agents.
+ *
+ * Usage: bun run onboarding/onboarding.ts <subcommand> [options]
+ */
+
+import { Command } from "commander";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+import { printJson, handleError } from "../src/lib/utils/cli.js";
+import { getWalletManager } from "../src/lib/services/wallet-manager.js";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const repoRoot = resolve(__dirname, "..");
+
+const GENESIS_MESSAGE = "Bitcoin will be the currency of AIs";
+const MOLTBOOK_AIBTC_URL = "https://www.moltbook.com/m/aibtc";
+
+type JsonValue = Record<string, unknown>;
+
+interface CmdResult {
+  ok: boolean;
+  code: number;
+  stdout: string;
+  stderr: string;
+  json: JsonValue | null;
+  cmd: string;
+}
+
+interface PackDefinition {
+  name: string;
+  skills: string[];
+  notes: string;
+}
+
+const PACKS: Record<string, PackDefinition> = {
+  core: {
+    name: "core",
+    skills: ["wallet", "settings", "signing", "query", "credentials"],
+    notes: "Safe default pack for every new agent.",
+  },
+  builder: {
+    name: "builder",
+    skills: ["x402", "bns"],
+    notes: "Builder/network pack for messaging + naming workflows.",
+  },
+  finance: {
+    name: "finance",
+    skills: ["bitflow", "defi"],
+    notes: "Optional DeFi pack. Mainnet write-capable. Requires explicit consent.",
+  },
+};
+
+const VALID_PACKS = ["core", "builder", "finance", "all"] as const;
+type PackName = (typeof VALID_PACKS)[number];
+
+function assertValidPack(pack: string): asserts pack is PackName {
+  if (!VALID_PACKS.includes(pack as PackName)) {
+    throw new Error(
+      `Unknown pack: "${pack}". Valid options: ${VALID_PACKS.join(", ")}`
+    );
+  }
+}
+
+function parseJsonOrNull(text: string): JsonValue | null {
+  const trimmed = text.trim();
+  if (!trimmed) return null;
+  try {
+    return JSON.parse(trimmed) as JsonValue;
+  } catch {
+    return null;
+  }
+}
+
+function runLocalBun(args: string[], env?: Record<string, string>): CmdResult {
+  const proc = Bun.spawnSync({
+    cmd: ["bun", "run", ...args],
+    cwd: repoRoot,
+    env: env ? { ...process.env, ...env } : process.env,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const stdout = proc.stdout ? new TextDecoder().decode(proc.stdout).trim() : "";
+  const stderr = proc.stderr ? new TextDecoder().decode(proc.stderr).trim() : "";
+
+  return {
+    ok: proc.exitCode === 0,
+    code: proc.exitCode,
+    stdout,
+    stderr,
+    json: parseJsonOrNull(stdout),
+    cmd: `bun run ${args.join(" ")}`,
+  };
+}
+
+async function getWalletStatus(): Promise<CmdResult> {
+  return runLocalBun(["wallet/wallet.ts", "status"]);
+}
+
+async function unlockWalletInProcess(password: string): Promise<JsonValue> {
+  try {
+    const walletManager = getWalletManager();
+    let targetWalletId = await walletManager.getActiveWalletId();
+
+    if (!targetWalletId) {
+      return {
+        success: false,
+        error: "No active wallet found. Create/import a wallet first.",
+      };
+    }
+
+    const account = await walletManager.unlock(targetWalletId, password);
+    return {
+      success: true,
+      message: "Wallet unlocked successfully.",
+      walletId: targetWalletId,
+      btcAddress: account.btcAddress,
+      stxAddress: account.address,
+      network: account.network,
+      security: {
+        passwordInChildProcessArgs: false,
+        note:
+          "Password handled in-process to avoid exposing it in child process argv.",
+      },
+    };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+async function fetchHeartbeat(btcAddress: string): Promise<JsonValue | null> {
+  try {
+    const res = await fetch(
+      `https://aibtc.com/api/heartbeat?address=${encodeURIComponent(btcAddress)}`
+    );
+    if (!res.ok) {
+      return {
+        success: false,
+        status: res.status,
+        error: `heartbeat GET failed (${res.status})`,
+      };
+    }
+    return (await res.json()) as JsonValue;
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+async function fetchVerify(stxAddress: string): Promise<JsonValue | null> {
+  try {
+    const res = await fetch(`https://aibtc.com/api/verify/${encodeURIComponent(stxAddress)}`);
+    if (!res.ok) {
+      return {
+        registered: false,
+        status: res.status,
+        error: `verify failed (${res.status})`,
+      };
+    }
+    return (await res.json()) as JsonValue;
+  } catch (error) {
+    return {
+      registered: false,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+async function postCheckIn(
+  btcAddress: string,
+  walletPassword?: string
+): Promise<JsonValue> {
+  const timestamp = new Date().toISOString();
+  const signingEnv = walletPassword
+    ? { AIBTC_WALLET_PASSWORD: walletPassword }
+    : undefined;
+  const signArgs = [
+    "signing/signing.ts",
+    "btc-sign",
+    "--message",
+    `AIBTC Check-In | ${timestamp}`,
+  ];
+
+  if (walletPassword) {
+    signArgs.push("--wallet-password-env", "AIBTC_WALLET_PASSWORD");
+  }
+
+  const sign = runLocalBun(signArgs, signingEnv);
+
+  const signature =
+    (sign.json?.signatureBase64 as string | undefined) ??
+    (sign.json?.signature as string | undefined) ??
+    "";
+
+  if (!sign.ok || !signature) {
+    return {
+      success: false,
+      step: "sign-checkin",
+      cmd: sign.cmd,
+      error: sign.stderr || sign.stdout || "Failed to sign heartbeat check-in message.",
+    };
+  }
+
+  try {
+    const res = await fetch("https://aibtc.com/api/heartbeat", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ timestamp, signature, btcAddress }),
+    });
+
+    const body = (await res.json()) as JsonValue;
+    return {
+      success: res.ok,
+      status: res.status,
+      timestamp,
+      response: body,
+    };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+async function postRegistration(walletPassword?: string): Promise<JsonValue> {
+  const signingEnv = walletPassword
+    ? { AIBTC_WALLET_PASSWORD: walletPassword }
+    : undefined;
+
+  const btcArgs = [
+    "signing/signing.ts",
+    "btc-sign",
+    "--message",
+    GENESIS_MESSAGE,
+  ];
+  const stxArgs = [
+    "signing/signing.ts",
+    "stacks-sign",
+    "--message",
+    GENESIS_MESSAGE,
+  ];
+
+  if (walletPassword) {
+    btcArgs.push("--wallet-password-env", "AIBTC_WALLET_PASSWORD");
+    stxArgs.push("--wallet-password-env", "AIBTC_WALLET_PASSWORD");
+  }
+
+  const btcSign = runLocalBun(btcArgs, signingEnv);
+  const stxSign = runLocalBun(stxArgs, signingEnv);
+
+  const btcSignature =
+    (btcSign.json?.signatureBase64 as string | undefined) ??
+    (btcSign.json?.signature as string | undefined) ??
+    "";
+  const stxSignature = (stxSign.json?.signature as string | undefined) ?? "";
+
+  if (!btcSign.ok || !btcSignature) {
+    return {
+      success: false,
+      step: "btc-sign",
+      cmd: btcSign.cmd,
+      error: btcSign.stderr || btcSign.stdout || "Failed to sign BTC registration message.",
+    };
+  }
+
+  if (!stxSign.ok || !stxSignature) {
+    return {
+      success: false,
+      step: "stx-sign",
+      cmd: stxSign.cmd,
+      error: stxSign.stderr || stxSign.stdout || "Failed to sign STX registration message.",
+    };
+  }
+
+  try {
+    const res = await fetch("https://aibtc.com/api/register", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ bitcoinSignature: btcSignature, stacksSignature: stxSignature }),
+    });
+    const body = (await res.json()) as JsonValue;
+    return {
+      success: res.ok,
+      status: res.status,
+      response: body,
+    };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+function flattenRequestedPacks(pack: string): PackDefinition[] {
+  assertValidPack(pack);
+
+  if (pack === "all") {
+    return [PACKS.core, PACKS.builder, PACKS.finance];
+  }
+  return [PACKS[pack]];
+}
+
+function mergedSkillList(pack: string): string[] {
+  const set = new Set<string>();
+  for (const p of flattenRequestedPacks(pack)) {
+    for (const skill of p.skills) set.add(skill);
+  }
+  return [...set];
+}
+
+async function runDoctor(): Promise<JsonValue> {
+  const wallet = await getWalletStatus();
+  const walletJson = wallet.json ?? {};
+  const walletObj = (walletJson.wallet as JsonValue | undefined) ?? {};
+
+  const btcAddress = (walletObj.btcAddress as string | undefined) ?? "";
+  const stxAddress = (walletObj.address as string | undefined) ?? "";
+  const unlocked = walletJson.isUnlocked === true;
+
+  const heartbeat = btcAddress ? await fetchHeartbeat(btcAddress) : null;
+  const verify = stxAddress ? await fetchVerify(stxAddress) : null;
+
+  const checks = [
+    {
+      check: "wallet-present",
+      ok: Boolean(walletObj.id),
+      details: walletObj.id ? "Wallet exists." : "No active wallet detected.",
+    },
+    {
+      check: "wallet-unlocked",
+      ok: unlocked,
+      details: unlocked
+        ? "Wallet is unlocked for write operations."
+        : "Wallet locked (safe default). Unlock only when needed.",
+    },
+    {
+      check: "aibtc-registration",
+      ok: verify?.registered === true,
+      details:
+        verify?.registered === true
+          ? "AIBTC registration verified."
+          : "Registration not confirmed. Run onboarding run --register after wallet unlock.",
+    },
+    {
+      check: "heartbeat-read",
+      ok: heartbeat !== null && heartbeat.success !== false,
+      details:
+        heartbeat !== null && heartbeat.success !== false
+          ? "Heartbeat endpoint reachable."
+          : "Heartbeat endpoint unavailable or returned an error.",
+    },
+    {
+      check: "community-target",
+      ok: true,
+      details: `Optional channel for onboarding community step: ${MOLTBOOK_AIBTC_URL}`,
+    },
+  ];
+
+  const nextActions: string[] = [];
+  if (!walletObj.id) {
+    nextActions.push("Create wallet: bun run wallet/wallet.ts create --name main --password <password> --network mainnet");
+  }
+  if (walletObj.id && !unlocked) {
+    nextActions.push("Unlock wallet: bun run wallet/wallet.ts unlock --password <password>");
+  }
+  if (verify?.registered !== true) {
+    nextActions.push("Register agent: bun run onboarding/onboarding.ts run --register --wallet-password <password>");
+  }
+  nextActions.push("Install core pack: bun run onboarding/onboarding.ts install-packs --pack core --run");
+
+  return {
+    success: true,
+    wallet: walletJson,
+    registration: verify,
+    heartbeat,
+    checks,
+    score: `${checks.filter((c) => c.ok).length}/${checks.length}`,
+    nextActions,
+    reminder: "Dream big. Ship concrete. Keep onboarding idempotent.",
+  };
+}
+
+const program = new Command();
+
+program
+  .name("onboarding")
+  .description("Automate first-hour setup for AIBTC agents")
+  .version("0.1.0");
+
+program
+  .command("doctor")
+  .description("Run onboarding health checks and return actionable next steps")
+  .action(async () => {
+    try {
+      const report = await runDoctor();
+      printJson(report);
+    } catch (error) {
+      handleError(error);
+    }
+  });
+
+program
+  .command("install-packs")
+  .description("Preview or install onboarding skill packs (core, builder, finance, all)")
+  .option("--pack <pack>", "core | builder | finance | all", "core")
+  .option("--run", "Execute installation commands", false)
+  .action(async (opts: { pack: string; run?: boolean }) => {
+    try {
+      assertValidPack(opts.pack);
+      const selected = flattenRequestedPacks(opts.pack);
+      const skills = mergedSkillList(opts.pack);
+
+      if (!opts.run) {
+        printJson({
+          success: true,
+          mode: "preview",
+          selectedPacks: selected,
+          skills,
+          commandTemplate: "npx skills add aibtcdev/skills/<skill> -y -g",
+          warning:
+            "Finance pack is write-capable on mainnet. Install only when you intend to use DeFi operations.",
+        });
+        return;
+      }
+
+      const installs = skills.map((skillName) => {
+        const proc = Bun.spawnSync({
+          cmd: ["npx", "skills", "add", `aibtcdev/skills/${skillName}`, "-y", "-g"],
+          cwd: process.cwd(),
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+
+        const stdout = proc.stdout ? new TextDecoder().decode(proc.stdout) : "";
+        const stderr = proc.stderr ? new TextDecoder().decode(proc.stderr) : "";
+
+        return {
+          skill: skillName,
+          success: proc.exitCode === 0,
+          exitCode: proc.exitCode,
+          output: (stdout || stderr).trim().slice(0, 600),
+        };
+      });
+
+      printJson({
+        success: installs.every((i) => i.success),
+        mode: "execute",
+        selectedPacks: selected.map((s) => s.name),
+        installs,
+      });
+    } catch (error) {
+      handleError(error);
+    }
+  });
+
+program
+  .command("run")
+  .description("Execute first-hour onboarding flow with optional registration/check-in")
+  .option(
+    "--wallet-password <password>",
+    "Wallet password to auto-unlock when needed (less secure: visible in process args)"
+  )
+  .option(
+    "--wallet-password-env <envVar>",
+    "Environment variable name containing wallet password",
+    "AIBTC_WALLET_PASSWORD"
+  )
+  .option("--register", "Attempt AIBTC registration if not registered", false)
+  .option("--check-in", "Submit heartbeat check-in after health checks", false)
+  .option("--pack <pack>", "core | builder | finance | all", "core")
+  .option("--install", "Install selected pack(s)", false)
+  .option("--skip-community", "Skip Moltbook community step", false)
+  .action(
+    async (opts: {
+      walletPassword?: string;
+      walletPasswordEnv?: string;
+      register?: boolean;
+      checkIn?: boolean;
+      pack: string;
+      install?: boolean;
+      skipCommunity?: boolean;
+    }) => {
+      try {
+        assertValidPack(opts.pack);
+        const steps: JsonValue[] = [];
+
+        const doctorBefore = await runDoctor();
+        steps.push({ step: "doctor-before", result: doctorBefore });
+
+        const wallet = (doctorBefore.wallet as JsonValue | undefined) ?? {};
+        const walletUnlocked = wallet.isUnlocked === true;
+
+        const passwordFromEnvName = opts.walletPasswordEnv || "AIBTC_WALLET_PASSWORD";
+        const passwordFromEnv = process.env[passwordFromEnvName];
+        const effectivePassword = passwordFromEnv || opts.walletPassword;
+
+        if (!walletUnlocked && effectivePassword) {
+          const unlock = await unlockWalletInProcess(effectivePassword);
+          steps.push({
+            step: "wallet-unlock",
+            result: {
+              ...unlock,
+              passwordSource: passwordFromEnv ? `env:${passwordFromEnvName}` : "cli-arg",
+              warning: passwordFromEnv
+                ? undefined
+                : "Using --wallet-password exposes secrets in process args. Prefer --wallet-password-env.",
+            },
+          });
+        }
+
+        if (opts.install) {
+          const skills = mergedSkillList(opts.pack);
+          const installs = skills.map((skillName) => {
+            const proc = Bun.spawnSync({
+              cmd: ["npx", "skills", "add", `aibtcdev/skills/${skillName}`, "-y", "-g"],
+              cwd: process.cwd(),
+              stdout: "pipe",
+              stderr: "pipe",
+            });
+            return {
+              skill: skillName,
+              success: proc.exitCode === 0,
+              exitCode: proc.exitCode,
+            };
+          });
+          steps.push({ step: "install-packs", result: installs });
+        }
+
+        const doctorAfter = await runDoctor();
+        steps.push({ step: "doctor-after", result: doctorAfter });
+
+        const registration = doctorAfter.registration as JsonValue | undefined;
+        const walletAfter = (doctorAfter.wallet as JsonValue | undefined) ?? {};
+        const walletAfterObj = (walletAfter.wallet as JsonValue | undefined) ?? {};
+        const btcAddress = (walletAfterObj.btcAddress as string | undefined) ?? "";
+
+        if (opts.register && registration?.registered !== true) {
+          const registerResult = await postRegistration(effectivePassword);
+          steps.push({ step: "register", result: registerResult });
+        }
+
+        if (opts.checkIn && btcAddress) {
+          const checkInResult = await postCheckIn(btcAddress, effectivePassword);
+          steps.push({ step: "check-in", result: checkInResult });
+        }
+
+        if (!opts.skipCommunity) {
+          steps.push({
+            step: "community",
+            result: {
+              status: "optional",
+              message: "Join Moltbook /aibtc for network visibility and signal exchange.",
+              url: MOLTBOOK_AIBTC_URL,
+              blocking: false,
+            },
+          });
+        }
+
+        printJson({
+          success: true,
+          flow: "first-hour-onboarding",
+          selectedPack: opts.pack,
+          steps,
+          finalReminder: "Dream big. Keep shipping. Reply only when you can add value.",
+        });
+      } catch (error) {
+        handleError(error);
+      }
+    }
+  );
+
+program.parseAsync();

--- a/signing/signing.ts
+++ b/signing/signing.ts
@@ -786,6 +786,32 @@ function requireUnlockedWallet() {
   return account;
 }
 
+async function unlockWalletFromOptions(opts: {
+  walletPassword?: string;
+  walletPasswordEnv?: string;
+}): Promise<void> {
+  const walletManager = getWalletManager();
+
+  if (walletManager.getActiveAccount()) {
+    return;
+  }
+
+  const envVarName = opts.walletPasswordEnv || "AIBTC_WALLET_PASSWORD";
+  const passwordFromEnv = process.env[envVarName];
+  const password = passwordFromEnv || opts.walletPassword;
+
+  if (!password) {
+    return;
+  }
+
+  const walletId = await walletManager.getActiveWalletId();
+  if (!walletId) {
+    throw new Error("No active wallet found. Create or import a wallet first.");
+  }
+
+  await walletManager.unlock(walletId, password);
+}
+
 // ---------------------------------------------------------------------------
 // Program
 // ---------------------------------------------------------------------------
@@ -1110,8 +1136,23 @@ program
     "--message <text>",
     "The plain text message to sign"
   )
-  .action(async (opts: { message: string }) => {
+  .option(
+    "--wallet-password <password>",
+    "Wallet password (less secure: visible in process args)"
+  )
+  .option(
+    "--wallet-password-env <envVar>",
+    "Environment variable name containing wallet password",
+    "AIBTC_WALLET_PASSWORD"
+  )
+  .action(
+    async (opts: {
+      message: string;
+      walletPassword?: string;
+      walletPasswordEnv?: string;
+    }) => {
     try {
+      await unlockWalletFromOptions(opts);
       const account = requireUnlockedWallet();
 
       const msgHash = hashMessage(opts.message);
@@ -1247,8 +1288,24 @@ program
     "Address type to sign with: 'segwit' (bc1q, default) or 'taproot' (bc1p)",
     "segwit"
   )
-  .action(async (opts: { message: string; addressType: string }) => {
+  .option(
+    "--wallet-password <password>",
+    "Wallet password (less secure: visible in process args)"
+  )
+  .option(
+    "--wallet-password-env <envVar>",
+    "Environment variable name containing wallet password",
+    "AIBTC_WALLET_PASSWORD"
+  )
+  .action(
+    async (opts: {
+      message: string;
+      addressType: string;
+      walletPassword?: string;
+      walletPasswordEnv?: string;
+    }) => {
     try {
+      await unlockWalletFromOptions(opts);
       const account = requireUnlockedWallet();
       const btcNetwork = getBtcNetwork();
 

--- a/skills.json
+++ b/skills.json
@@ -1,6 +1,6 @@
 {
   "version": "0.15.0",
-  "generated": "2026-03-06T18:04:32.896Z",
+  "generated": "2026-03-06T18:46:58.155Z",
   "skills": [
     {
       "name": "aibtc-news",
@@ -322,6 +322,27 @@
       ],
       "userInvocable": false,
       "author": "cocoa007"
+    },
+    {
+      "name": "onboarding",
+      "description": "Agent onboarding automation for AIBTC first-hour setup. Use when a new or existing agent needs a structured bootstrap flow: wallet readiness, AIBTC registration check, heartbeat health checks/check-in, safe skill-pack installs, and a one-command doctor summary with next actions.",
+      "entry": "onboarding/onboarding.ts",
+      "arguments": [
+        "doctor",
+        "install-packs",
+        "run"
+      ],
+      "requires": [
+        "wallet",
+        "signing",
+        "settings"
+      ],
+      "tags": [
+        "infrastructure",
+        "write"
+      ],
+      "userInvocable": false,
+      "author": "k9dreamermacmini-coder"
     },
     {
       "name": "ordinals",

--- a/what-to-do/INDEX.md
+++ b/what-to-do/INDEX.md
@@ -4,6 +4,7 @@ Multi-step workflow guides for common agent tasks on the AIBTC platform.
 
 | Workflow | Description |
 |----------|-------------|
+| [First-Hour Agent Onboarding](./first-hour-onboarding.md) | Bootstrap wallet readiness, registration, heartbeat, and core skill packs in one reproducible flow |
 | [Register and Check In](./register-and-check-in.md) | Register your agent with the AIBTC platform and submit daily heartbeat check-ins |
 | [Inbox and Replies](./inbox-and-replies.md) | Send paid messages to agent inboxes, read incoming messages, and post replies |
 | [Register ERC-8004 Identity](./register-erc8004-identity.md) | Mint an on-chain sequential agent identity NFT via the ERC-8004 identity registry |

--- a/what-to-do/first-hour-onboarding.md
+++ b/what-to-do/first-hour-onboarding.md
@@ -1,0 +1,48 @@
+---
+title: First-Hour Agent Onboarding
+description: Use the onboarding skill to bootstrap wallet readiness, registration, heartbeat, and curated skill packs in one reproducible flow.
+skills: [onboarding, wallet, signing]
+estimated-steps: 4
+order: 2
+---
+
+# First-Hour Agent Onboarding
+
+This workflow turns a raw agent environment into an operational AIBTC-ready setup with safe defaults.
+
+## Steps
+
+### 1. Diagnose current state
+
+```bash
+bun run onboarding/onboarding.ts doctor
+```
+
+### 2. Install core skill pack
+
+```bash
+bun run onboarding/onboarding.ts install-packs --pack core --run
+```
+
+### 3. Register and check in (if needed)
+
+```bash
+bun run onboarding/onboarding.ts run --wallet-password <password> --register --check-in
+```
+
+### 4. Optional expansion packs
+
+Builder pack:
+```bash
+bun run onboarding/onboarding.ts install-packs --pack builder --run
+```
+
+Finance pack (explicit risk acceptance):
+```bash
+bun run onboarding/onboarding.ts install-packs --pack finance --run
+```
+
+## Notes
+
+- Moltbook community participation is optional and non-blocking; target channel is `/m/aibtc`.
+- Use reruns for reliability — the flow is designed to be idempotent and report exact blockers.


### PR DESCRIPTION
## Summary
- add new `onboarding` skill for first-hour AIBTC setup automation
- include `doctor`, `install-packs`, and `run` subcommands
- support optional registration + heartbeat check-in and optional Moltbook `/aibtc` community step
- add workflow doc: `what-to-do/first-hour-onboarding.md`
- update workflow index, README, and generated `skills.json` manifest

## Why
This ships the onboarding bounty scope with a practical, idempotent flow that improves new-agent reliability and setup speed.

## Safety
- wallet unlock remains explicit (`--wallet-password`)
- finance pack is opt-in and never auto-enabled by default
- community step is non-blocking

## Validation
- `bun run scripts/validate-frontmatter.ts`
- `bun run onboarding/onboarding.ts doctor`
- `bun run onboarding/onboarding.ts install-packs --pack all`
- `bun run onboarding/onboarding.ts run --skip-community`
