### PR TITLE
fix(styx): move OP_RETURN to output index 0

### DIFF
--- a/styx/styx.ts
+++ b/styx/styx.ts
@@ -281,14 +281,7 @@ program
           });
         }
 
-        // Add deposit output (to Styx deposit address)
-        tx.addOutputAddress(
-          prepared.depositAddress,
-          BigInt(prepared.amountInSatoshis),
-          btcNetwork
-        );
-
-        // Add OP_RETURN output if present
+        // Add OP_RETURN output first (must be output index 0 for Styx protocol)
         // opReturnData from Styx SDK is a full script hex (starts with 6a = OP_RETURN)
         if (prepared.opReturnData) {
           const opReturnScript = hex.decode(prepared.opReturnData);
@@ -297,6 +290,13 @@ program
             amount: BigInt(0),
           });
         }
+
+        // Add deposit output (to Styx deposit address)
+        tx.addOutputAddress(
+          prepared.depositAddress,
+          BigInt(prepared.amountInSatoshis),
+          btcNetwork
+        );
 
         // Add change output if there's change
         if (prepared.changeAmount > 0) {


### PR DESCRIPTION
## Summary

- Styx protocol requires the OP_RETURN output at transaction output index 0
- Previously, the deposit output was added first (index 0) and OP_RETURN second (index 1)
- This caused deposit tracking failures since Styx looks for OP_RETURN data at index 0
- Fix: swap output ordering so OP_RETURN is added before the deposit output

## Test plan

- [ ] Verify Styx deposit flow completes successfully with OP_RETURN at index 0
- [ ] Confirm deposit status updates correctly after broadcast

🤖 Generated with [Claude Code](https://claude.com/claude-code)