### PR TITLE
feat(nostr): add amplify-signal and amplify-text subcommands

### DIFF
--- a/nostr/AGENT.md
+++ b/nostr/AGENT.md
@@ -1,7 +1,7 @@
 ---
 name: nostr-agent
 skill: nostr
-description: Nostr protocol operations for AI agents — post kind:1 notes, read feeds, search by hashtag tags, get/set profiles, derive keys (BTC-shared path) from BIP84 wallet, and manage relay connections.
+description: Nostr protocol operations for AI agents — post kind:1 notes, read feeds, search by hashtag tags, get/set profiles, derive keys (BTC-shared path) from BIP84 wallet, amplify aibtc.news signals to Nostr, and manage relay connections.
 ---
 
 # Nostr Agent
@@ -17,6 +17,7 @@ This agent handles Nostr protocol operations. It can post notes, read feeds, sea
 - Set your own kind:0 profile metadata
 - Derive and display your Nostr public key (npub + hex) from BIP84 wallet
 - List configured relay URLs
+- **Amplify aibtc.news signals** to Nostr — fetch by signal ID or broadcast content directly
 
 ## When to Delegate Here
 
@@ -26,6 +27,7 @@ Delegate to this agent when:
 - Looking up a user's profile information
 - Setting up or updating the agent's own Nostr profile
 - Deriving the agent's Nostr identity from its wallet
+- Broadcasting an aibtc.news signal to Nostr relays (use `amplify-signal` or `amplify-text`)
 
 ## Prerequisites
 

--- a/nostr/SKILL.md
+++ b/nostr/SKILL.md
@@ -1,9 +1,10 @@
 ---
 name: nostr
-description: Nostr protocol operations for AI agents — post kind:1 notes, read feeds, search by hashtag tags (#t filter), get/set profiles, derive keys (BTC-shared path) from BIP84 wallet path, and manage relay connections. Uses nostr-tools + ws packages. Write operations require an unlocked wallet.
+description: Nostr protocol operations for AI agents — post kind:1 notes, read feeds, search by hashtag tags (#t filter), get/set profiles, derive keys (BTC-shared path) from BIP84 wallet path, amplify aibtc.news signals to the Nostr network, and manage relay connections. Uses nostr-tools + ws packages. Write operations require an unlocked wallet.
 author: cocoa007
+author_agent: Fluid Briar
 user-invocable: false
-arguments: post | read-feed | search-tags | get-profile | set-profile | get-pubkey | relay-list
+arguments: post | read-feed | search-tags | get-profile | set-profile | get-pubkey | relay-list | amplify-signal | amplify-text
 entry: nostr/nostr.ts
 requires: [wallet, signing]
 tags: [l1, write]
@@ -111,6 +112,46 @@ bun run nostr/nostr.ts relay-list
 ```
 
 Default relays: `wss://relay.damus.io`, `wss://nos.lol`
+
+### amplify-signal
+
+Fetch an aibtc.news signal by ID and broadcast it as a formatted Nostr note. Requires unlocked wallet.
+
+```bash
+bun run nostr/nostr.ts amplify-signal --signal-id <id> [--beat "BTC Macro"] [--relays wss://relay1,wss://relay2]
+```
+
+Options:
+- `--signal-id` (required) — Signal ID from aibtc.news
+- `--beat` (optional) — Beat name for context label (e.g. `BTC Macro`)
+- `--relays` (optional) — Comma-separated relay URLs (overrides defaults)
+
+Output:
+```json
+{
+  "success": true,
+  "signalId": "abc123",
+  "eventId": "def456...",
+  "pubkey": "2b4603d2...",
+  "relays": { "wss://relay.damus.io": "ok" }
+}
+```
+
+### amplify-text
+
+Publish formatted aibtc.news signal content directly as a Nostr note — no API fetch needed. Requires unlocked wallet.
+
+```bash
+bun run nostr/nostr.ts amplify-text --content "BTC holding above 200-week MA..." [--beat "BTC Macro"] [--signal-id <id>]
+```
+
+Options:
+- `--content` (required) — Signal thesis or content to broadcast
+- `--beat` (optional) — Beat name, defaults to `BTC Macro`
+- `--signal-id` (optional) — Signal ID for reference link in the note
+- `--relays` (optional) — Comma-separated relay URLs (overrides defaults)
+
+Output: `{success, eventId, pubkey, relays}`
 
 ## Technical Details
 

--- a/nostr/nostr.ts
+++ b/nostr/nostr.ts
@@ -135,6 +135,43 @@ async function queryRelays(
 }
 
 // ---------------------------------------------------------------------------
+// aibtc.news amplification helpers
+// ---------------------------------------------------------------------------
+
+interface AibtcSignal {
+  thesis?: string;
+  target_claim?: string;
+  beat_topic?: string;
+}
+
+/**
+ * Format an aibtc.news signal as a Nostr note with standard tags.
+ */
+function formatSignalNote(signal: {
+  beat?: string;
+  content: string;
+  signalId?: string;
+}): { content: string; tags: string[][] } {
+  const parts: string[] = [];
+
+  if (signal.beat) parts.push(`📡 aibtc.news — ${signal.beat}`);
+  parts.push(signal.content);
+  if (signal.signalId) parts.push(`\nSignal: ${signal.signalId}`);
+  parts.push("\n#bitcoin #aibtcnews #nostr");
+
+  const tags: string[][] = [
+    ["t", "bitcoin"],
+    ["t", "aibtcnews"],
+    ["t", "nostr"],
+  ];
+  if (signal.signalId) {
+    tags.push(["r", `https://aibtc.news/signals/${signal.signalId}`]);
+  }
+
+  return { content: parts.join("\n"), tags };
+}
+
+// ---------------------------------------------------------------------------
 // CLI
 // ---------------------------------------------------------------------------
 
@@ -414,6 +451,114 @@ program
       relays: DEFAULT_RELAYS,
       note: "relay.nostr.band is often unreachable from sandboxed environments. Prefer damus + nos.lol.",
     });
+  });
+
+// ---------------------------------------------------------------------------
+// amplify-signal
+// ---------------------------------------------------------------------------
+
+program
+  .command("amplify-signal")
+  .description(
+    "Fetch an aibtc.news signal by ID and broadcast it as a formatted Nostr note. Requires unlocked wallet."
+  )
+  .requiredOption("--signal-id <id>", "Signal ID from aibtc.news")
+  .option("--beat <name>", "Beat name for context (e.g. 'BTC Macro')")
+  .option("--relays <urls>", "Comma-separated relay URLs (overrides defaults)")
+  .action(async (opts) => {
+    try {
+      const { sk, pubkey } = deriveNostrKeys();
+      const relays = opts.relays
+        ? (opts.relays as string).split(",").map((r: string) => r.trim())
+        : DEFAULT_RELAYS;
+
+      // Fetch signal from aibtc.news API
+      const res = await fetch(
+        `https://1btc-news-api.p-d07.workers.dev/takes/${opts.signalId}`
+      );
+      if (!res.ok) throw new Error(`Failed to fetch signal: ${res.status} ${res.statusText}`);
+      const signal = (await res.json()) as AibtcSignal;
+
+      const content = signal.thesis || signal.target_claim || "";
+      if (!content) throw new Error("Signal has no content to amplify");
+
+      const { content: noteContent, tags } = formatSignalNote({
+        beat: opts.beat || signal.beat_topic || "aibtc.news",
+        content,
+        signalId: opts.signalId,
+      });
+
+      const template: EventTemplate = {
+        kind: 1,
+        created_at: Math.floor(Date.now() / 1000),
+        tags,
+        content: noteContent,
+      };
+
+      const event = finalizeEvent(template, sk);
+      const pool = createPool();
+      const results = await publishToRelays(pool, event, relays);
+      pool.close(relays);
+
+      printJson({
+        success: true,
+        signalId: opts.signalId,
+        eventId: event.id,
+        pubkey,
+        relays: results,
+      });
+    } catch (err) {
+      handleError(err);
+    }
+  });
+
+// ---------------------------------------------------------------------------
+// amplify-text
+// ---------------------------------------------------------------------------
+
+program
+  .command("amplify-text")
+  .description(
+    "Publish formatted aibtc.news signal content directly as a Nostr note (no API fetch needed). Requires unlocked wallet."
+  )
+  .requiredOption("--content <text>", "Signal content/thesis to broadcast")
+  .option("--beat <name>", "Beat name", "BTC Macro")
+  .option("--signal-id <id>", "Signal ID for reference link")
+  .option("--relays <urls>", "Comma-separated relay URLs (overrides defaults)")
+  .action(async (opts) => {
+    try {
+      const { sk, pubkey } = deriveNostrKeys();
+      const relays = opts.relays
+        ? (opts.relays as string).split(",").map((r: string) => r.trim())
+        : DEFAULT_RELAYS;
+
+      const { content: noteContent, tags } = formatSignalNote({
+        beat: opts.beat,
+        content: opts.content,
+        signalId: opts.signalId,
+      });
+
+      const template: EventTemplate = {
+        kind: 1,
+        created_at: Math.floor(Date.now() / 1000),
+        tags,
+        content: noteContent,
+      };
+
+      const event = finalizeEvent(template, sk);
+      const pool = createPool();
+      const results = await publishToRelays(pool, event, relays);
+      pool.close(relays);
+
+      printJson({
+        success: true,
+        eventId: event.id,
+        pubkey,
+        relays: results,
+      });
+    } catch (err) {
+      handleError(err);
+    }
   });
 
 // ---------------------------------------------------------------------------

--- a/skills.json
+++ b/skills.json
@@ -1,6 +1,6 @@
 {
   "version": "0.15.0",
-  "generated": "2026-03-06T18:46:58.155Z",
+  "generated": "2026-03-06T19:20:45.688Z",
   "skills": [
     {
       "name": "aibtc-news",
@@ -301,7 +301,7 @@
     },
     {
       "name": "nostr",
-      "description": "Nostr protocol operations for AI agents — post kind:1 notes, read feeds, search by hashtag tags (#t filter), get/set profiles, derive keys (BTC-shared path) from BIP84 wallet path, and manage relay connections. Uses nostr-tools + ws packages. Write operations require an unlocked wallet.",
+      "description": "Nostr protocol operations for AI agents — post kind:1 notes, read feeds, search by hashtag tags (#t filter), get/set profiles, derive keys (BTC-shared path) from BIP84 wallet path, amplify aibtc.news signals to the Nostr network, and manage relay connections. Uses nostr-tools + ws packages. Write operations require an unlocked wallet.",
       "entry": "nostr/nostr.ts",
       "arguments": [
         "post",
@@ -310,7 +310,9 @@
         "get-profile",
         "set-profile",
         "get-pubkey",
-        "relay-list"
+        "relay-list",
+        "amplify-signal",
+        "amplify-text"
       ],
       "requires": [
         "wallet",
@@ -321,7 +323,8 @@
         "write"
       ],
       "userInvocable": false,
-      "author": "cocoa007"
+      "author": "cocoa007",
+      "authorAgent": "Fluid Briar"
     },
     {
       "name": "onboarding",


### PR DESCRIPTION
## Summary

Extends the existing `nostr` skill with two new subcommands for broadcasting aibtc.news signals to the Nostr network.

## New Subcommands

### `amplify-signal`
Fetch a signal by ID from aibtc.news and broadcast it as a formatted kind:1 note. Auto-tags with `#bitcoin`, `#aibtcnews`, `#nostr`. Adds a reference link to the original signal.

```bash
bun run nostr/nostr.ts amplify-signal --signal-id <id> [--beat "BTC Macro"]
```

### `amplify-text`
Broadcast signal content directly — no API fetch needed. Useful when you already have the content at hand.

```bash
bun run nostr/nostr.ts amplify-text --content "BTC holding above 200-week MA..." [--beat "BTC Macro"] [--signal-id <id>]
```

## Implementation Notes

- Both commands use the existing BTC-shared key derivation (`deriveNostrKeys()`) — same identity as `post`
- Uses `finalizeEvent` + `publishToRelays` consistent with the rest of the skill
- No new dependencies
- Publishes to the default relay set; `--relays` override supported

## Files Changed

- `nostr/nostr.ts` — added `formatSignalNote` helper, `amplify-signal`, and `amplify-text` commands
- `nostr/SKILL.md` — updated description + arguments frontmatter, added subcommand docs
- `nostr/AGENT.md` — updated description and capabilities
- `skills.json` — updated description and arguments list for the `nostr` skill

---

_Closes #83 (previous PR had merge conflicts from dual-stacking + conflicting nostr/ dir; this is a clean rebase off current main)_