### PR TITLE
fix(lib): add node: prefix to bare stdlib imports

### DIFF
--- a/src/lib/services/scaffold.service.ts
+++ b/src/lib/services/scaffold.service.ts
@@ -1,5 +1,5 @@
-import fs from "fs/promises";
-import path from "path";
+import fs from "node:fs/promises";
+import path from "node:path";
 
 export type PricingTier = "free" | "simple" | "standard" | "ai" | "heavy_ai" | "storage_read" | "storage_write";
 

--- a/src/lib/services/signing-key.service.ts
+++ b/src/lib/services/signing-key.service.ts
@@ -1,7 +1,7 @@
-import fs from "fs/promises";
-import path from "path";
-import os from "os";
-import crypto from "crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import crypto from "node:crypto";
 import {
   signMessageHashRsv,
   privateKeyToPublic,

--- a/src/lib/services/x402.service.ts
+++ b/src/lib/services/x402.service.ts
@@ -20,7 +20,7 @@ import { getWalletManager } from "./wallet-manager.js";
 import { formatStx, formatSbtc } from "../utils/formatting.js";
 import { getSbtcService } from "./sbtc.service.js";
 import { getHiroApi } from "./hiro-api.js";
-import { createHash } from "crypto";
+import { createHash } from "node:crypto";
 import { InsufficientBalanceError } from "../utils/errors.js";
 import { getContracts, parseContractId } from "../config/contracts.js";
 

--- a/src/lib/utils/encryption.ts
+++ b/src/lib/utils/encryption.ts
@@ -1,4 +1,4 @@
-import crypto from "crypto";
+import crypto from "node:crypto";
 
 /**
  * Encrypted data structure with all parameters needed for decryption

--- a/src/lib/utils/storage.ts
+++ b/src/lib/utils/storage.ts
@@ -1,6 +1,6 @@
-import fs from "fs/promises";
-import path from "path";
-import os from "os";
+import fs from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
 import type { EncryptedData } from "./encryption.js";
 import type { Network } from "../config/networks.js";
 


### PR DESCRIPTION
## Summary

This is a mechanical, no-behavior-change fix applying the convention decided in issue #94 (arc0btc's audit).

**Decision applied: Option 2 — `node:` prefix everywhere in `src/lib/`**

Files changed:
- `src/lib/utils/storage.ts`: `"fs/promises"` → `"node:fs/promises"`, `"path"` → `"node:path"`, `"os"` → `"node:os"`
- `src/lib/utils/encryption.ts`: `"crypto"` → `"node:crypto"`
- `src/lib/services/signing-key.service.ts`: same four imports
- `src/lib/services/scaffold.service.ts`: `"fs/promises"` → `"node:fs/promises"`, `"path"` → `"node:path"`
- `src/lib/services/x402.service.ts`: `{ createHash } from "crypto"` → `"node:crypto"`

The `scripts/` directory was intentionally left untouched — those files already use Bun-native APIs as noted in the audit.

## Verification

- Searched all `src/lib/` TypeScript files for bare `"fs"`, `"path"`, `"os"`, `"crypto"`, `"fs/promises"` imports — none remain.
- `tsc --noEmit` passes cleanly after the changes.

## Related

Closes #94

Arc0btc's audit identified the inconsistency and proposed the options. This PR implements Option 2 as discussed.