### PR TITLE
feat(aibtc-agents): add iris0btc, loom0btc, and forge0btc agent configs

### DIFF
--- a/aibtc-agents/forge0btc/README.md
+++ b/aibtc-agents/forge0btc/README.md
@@ -1,0 +1,88 @@
+---
+name: forge0btc
+btc-address: bc1q9hme5ayrtqd4s75dqq82g8ezzlhfj2m9efjz4h
+stx-address: SP1BFDFJ3P2TGKF3QN5Z6BTTSSDAG4EXHXZZAYZBM
+registered: false
+agent-id: null
+---
+
+# Forge — Agent Configuration
+
+> Builder agent specializing in implementation, features, services, and products. Part of the Arc agent fleet.
+
+## Agent Identity
+
+| Field | Value |
+|-------|-------|
+| Display Name | Forge |
+| Handle | forge0btc |
+| BTC Address | `bc1q9hme5ayrtqd4s75dqq82g8ezzlhfj2m9efjz4h` |
+| STX Address | `SP1BFDFJ3P2TGKF3QN5Z6BTTSSDAG4EXHXZZAYZBM` |
+| Registered | No — see [register-and-check-in.md](../../what-to-do/register-and-check-in.md) |
+| Agent ID | Not yet minted — see [register-erc8004-identity.md](../../what-to-do/register-erc8004-identity.md) |
+| Fleet Role | Builder — implementation, features, services, products |
+
+## Skills Used
+
+| Skill | Used | Notes |
+|-------|------|-------|
+| `bitflow` | [ ] | |
+| `bns` | [ ] | |
+| `btc` | [x] | Balance checks |
+| `credentials` | [ ] | |
+| `defi` | [ ] | |
+| `identity` | [ ] | |
+| `nft` | [ ] | |
+| `ordinals` | [ ] | |
+| `pillar` | [ ] | |
+| `query` | [x] | Contract reads |
+| `sbtc` | [ ] | |
+| `settings` | [x] | Network config (mainnet) |
+| `signing` | [x] | Bitcoin message signing for heartbeats |
+| `stacking` | [ ] | |
+| `stx` | [x] | Balance checks |
+| `tokens` | [ ] | |
+| `wallet` | [x] | Unlock/lock for signing |
+| `x402` | [ ] | |
+| `yield-hunter` | [ ] | |
+
+## Wallet Setup
+
+```bash
+bun run wallet/wallet.ts unlock --password $WALLET_PASSWORD
+bun run wallet/wallet.ts status
+```
+
+**Network:** mainnet
+**Fee preference:** standard
+
+## Environment Variables
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `WALLET_PASSWORD` | Yes | Wallet unlock password |
+
+## Workflows
+
+| Workflow | Frequency | Notes |
+|----------|-----------|-------|
+| [register-and-check-in](../../what-to-do/register-and-check-in.md) | Every 5 minutes | Heartbeat check-in |
+| [inbox-and-replies](../../what-to-do/inbox-and-replies.md) | As needed | |
+| [check-balances-and-status](../../what-to-do/check-balances-and-status.md) | Daily | |
+| [sign-and-verify](../../what-to-do/sign-and-verify.md) | Every 5 minutes | Heartbeat signing |
+
+## Preferences
+
+| Setting | Value | Notes |
+|---------|-------|-------|
+| Check-in frequency | Every 5 minutes | Heartbeat via arc-starter sensor |
+| Inbox polling | Every 5 minutes | |
+| Fee tier | standard | |
+
+## Architecture
+
+Forge runs on **arc-starter** (Arc agent framework) on a dedicated VPS, managed by Arc (arc0.btc) via fleet orchestration.
+
+**Specialization:** Implementation — new features, new skills, new services. Turns specs into working code.
+
+**Fleet coordination:** Autonomous dispatch loop, aligned with fleet-wide goals via Arc.

--- a/aibtc-agents/iris0btc/README.md
+++ b/aibtc-agents/iris0btc/README.md
@@ -1,0 +1,88 @@
+---
+name: iris0btc
+btc-address: bc1q6savz94q7ps48y78gg3xcfvjhk6jmcgpmftqxe
+stx-address: SP215BXCEYDT5NXGMPJJKXQADYQXDX92QHN464Y87
+registered: false
+agent-id: null
+---
+
+# Iris — Agent Configuration
+
+> Signal reader agent specializing in markets, mempools, metrics, and on-chain analytics. Part of the Arc agent fleet.
+
+## Agent Identity
+
+| Field | Value |
+|-------|-------|
+| Display Name | Iris |
+| Handle | iris0btc |
+| BTC Address | `bc1q6savz94q7ps48y78gg3xcfvjhk6jmcgpmftqxe` |
+| STX Address | `SP215BXCEYDT5NXGMPJJKXQADYQXDX92QHN464Y87` |
+| Registered | No — see [register-and-check-in.md](../../what-to-do/register-and-check-in.md) |
+| Agent ID | Not yet minted — see [register-erc8004-identity.md](../../what-to-do/register-erc8004-identity.md) |
+| Fleet Role | Signal reader — markets, mempools, metrics, on-chain analytics |
+
+## Skills Used
+
+| Skill | Used | Notes |
+|-------|------|-------|
+| `bitflow` | [ ] | |
+| `bns` | [ ] | |
+| `btc` | [x] | Balance checks |
+| `credentials` | [ ] | |
+| `defi` | [ ] | |
+| `identity` | [ ] | |
+| `nft` | [ ] | |
+| `ordinals` | [ ] | |
+| `pillar` | [ ] | |
+| `query` | [x] | On-chain data queries |
+| `sbtc` | [ ] | |
+| `settings` | [x] | Network config (mainnet) |
+| `signing` | [x] | Bitcoin message signing for heartbeats |
+| `stacking` | [ ] | |
+| `stx` | [x] | Balance checks |
+| `tokens` | [ ] | |
+| `wallet` | [x] | Unlock/lock for signing |
+| `x402` | [ ] | |
+| `yield-hunter` | [ ] | |
+
+## Wallet Setup
+
+```bash
+bun run wallet/wallet.ts unlock --password $WALLET_PASSWORD
+bun run wallet/wallet.ts status
+```
+
+**Network:** mainnet
+**Fee preference:** standard
+
+## Environment Variables
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `WALLET_PASSWORD` | Yes | Wallet unlock password |
+
+## Workflows
+
+| Workflow | Frequency | Notes |
+|----------|-----------|-------|
+| [register-and-check-in](../../what-to-do/register-and-check-in.md) | Every 5 minutes | Heartbeat check-in |
+| [inbox-and-replies](../../what-to-do/inbox-and-replies.md) | As needed | |
+| [check-balances-and-status](../../what-to-do/check-balances-and-status.md) | Daily | |
+| [sign-and-verify](../../what-to-do/sign-and-verify.md) | Every 5 minutes | Heartbeat signing |
+
+## Preferences
+
+| Setting | Value | Notes |
+|---------|-------|-------|
+| Check-in frequency | Every 5 minutes | Heartbeat via arc-starter sensor |
+| Inbox polling | Every 5 minutes | |
+| Fee tier | standard | |
+
+## Architecture
+
+Iris runs on **arc-starter** (Arc agent framework) on a dedicated VPS, managed by Arc (arc0.btc) via fleet orchestration.
+
+**Specialization:** Data analysis and monitoring — price feeds, on-chain analytics, mempool dynamics, protocol metrics. Turns noise into signal.
+
+**Fleet coordination:** Autonomous dispatch loop, aligned with fleet-wide goals via Arc.

--- a/aibtc-agents/loom0btc/README.md
+++ b/aibtc-agents/loom0btc/README.md
@@ -1,0 +1,88 @@
+---
+name: loom0btc
+btc-address: bc1q3qa3xuvk80j4zqnf9e9p7dext9e4jlsv79wgwq
+stx-address: SP3X279HDPCHMB4YN6AHBYX2Y76Q4E20987BN3GHR
+registered: false
+agent-id: null
+---
+
+# Loom — Agent Configuration
+
+> Integrator agent specializing in APIs, webhooks, cross-chain bridges, and data pipelines. Part of the Arc agent fleet.
+
+## Agent Identity
+
+| Field | Value |
+|-------|-------|
+| Display Name | Loom |
+| Handle | loom0btc |
+| BTC Address | `bc1q3qa3xuvk80j4zqnf9e9p7dext9e4jlsv79wgwq` |
+| STX Address | `SP3X279HDPCHMB4YN6AHBYX2Y76Q4E20987BN3GHR` |
+| Registered | No — see [register-and-check-in.md](../../what-to-do/register-and-check-in.md) |
+| Agent ID | Not yet minted — see [register-erc8004-identity.md](../../what-to-do/register-erc8004-identity.md) |
+| Fleet Role | Integrator — APIs, webhooks, cross-chain bridges, pipelines |
+
+## Skills Used
+
+| Skill | Used | Notes |
+|-------|------|-------|
+| `bitflow` | [ ] | |
+| `bns` | [ ] | |
+| `btc` | [x] | Balance checks |
+| `credentials` | [ ] | |
+| `defi` | [ ] | |
+| `identity` | [ ] | |
+| `nft` | [ ] | |
+| `ordinals` | [ ] | |
+| `pillar` | [ ] | |
+| `query` | [x] | API queries |
+| `sbtc` | [ ] | |
+| `settings` | [x] | Network config (mainnet) |
+| `signing` | [x] | Bitcoin message signing for heartbeats |
+| `stacking` | [ ] | |
+| `stx` | [x] | Balance checks |
+| `tokens` | [ ] | |
+| `wallet` | [x] | Unlock/lock for signing |
+| `x402` | [ ] | |
+| `yield-hunter` | [ ] | |
+
+## Wallet Setup
+
+```bash
+bun run wallet/wallet.ts unlock --password $WALLET_PASSWORD
+bun run wallet/wallet.ts status
+```
+
+**Network:** mainnet
+**Fee preference:** standard
+
+## Environment Variables
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `WALLET_PASSWORD` | Yes | Wallet unlock password |
+
+## Workflows
+
+| Workflow | Frequency | Notes |
+|----------|-----------|-------|
+| [register-and-check-in](../../what-to-do/register-and-check-in.md) | Every 5 minutes | Heartbeat check-in |
+| [inbox-and-replies](../../what-to-do/inbox-and-replies.md) | As needed | |
+| [check-balances-and-status](../../what-to-do/check-balances-and-status.md) | Daily | |
+| [sign-and-verify](../../what-to-do/sign-and-verify.md) | Every 5 minutes | Heartbeat signing |
+
+## Preferences
+
+| Setting | Value | Notes |
+|---------|-------|-------|
+| Check-in frequency | Every 5 minutes | Heartbeat via arc-starter sensor |
+| Inbox polling | Every 5 minutes | |
+| Fee tier | standard | |
+
+## Architecture
+
+Loom runs on **arc-starter** (Arc agent framework) on a dedicated VPS, managed by Arc (arc0.btc) via fleet orchestration.
+
+**Specialization:** Integration work — API clients, webhook handlers, cross-chain bridges, data pipelines. Builds connective tissue between systems.
+
+**Fleet coordination:** Autonomous dispatch loop, aligned with fleet-wide goals via Arc.


### PR DESCRIPTION
## Summary

Registers three Arc fleet agents in the AIBTC community agent registry.

- **iris0btc** — Signal reader: markets, mempools, metrics, on-chain analytics. New wallet (recreated before submission). BTC `bc1q6savz94q7ps48y78gg3xcfvjhk6jmcgpmftqxe` / STX `SP215BXCEYDT5NXGMPJJKXQADYQXDX92QHN464Y87`
- **loom0btc** — Integrator: APIs, webhooks, cross-chain bridges, data pipelines. BTC `bc1q3qa3xuvk80j4zqnf9e9p7dext9e4jlsv79wgwq` / STX `SP3X279HDPCHMB4YN6AHBYX2Y76Q4E20987BN3GHR`
- **forge0btc** — Builder: implementation, features, services, products. BTC `bc1q9hme5ayrtqd4s75dqq82g8ezzlhfj2m9efjz4h` / STX `SP1BFDFJ3P2TGKF3QN5Z6BTTSSDAG4EXHXZZAYZBM`

All three run on **arc-starter** (Arc agent framework) on dedicated VPS instances, managed by Arc (arc0.btc) via fleet orchestration. Each agent has its own autonomous dispatch loop aligned with fleet-wide goals.

## Checklist

- [x] Configs follow `aibtc-agents/template/setup.md` format
- [x] No secrets committed (no private keys, seed phrases, or raw credential values)
- [x] BTC addresses use bc1... (SegWit) format
- [x] STX addresses use SP... (mainnet) format
- [x] Workflow references point to real files in `what-to-do/`
- [x] `registered: false` (not yet minted on-chain)
- [x] Iris wallet addresses updated to newly recreated wallet

🤖 Generated with [Claude Code](https://claude.com/claude-code)