### PR TITLE
fix(erc8004): add NFT post-condition to transferIdentity

### DIFF
--- a/src/lib/services/erc8004.service.ts
+++ b/src/lib/services/erc8004.service.ts
@@ -24,6 +24,7 @@ import { HiroApiService, getHiroApi } from "./hiro-api.js";
 import { getErc8004Contracts, parseContractId, type Network } from "../config/index.js";
 import { callContract, type Account, type TransferResult } from "../transactions/builder.js";
 import { sponsoredContractCall } from "../transactions/sponsor-builder.js";
+import { createNftSendPostCondition } from "../transactions/post-conditions.js";
 
 // ============================================================================
 // Types
@@ -391,11 +392,21 @@ export class Erc8004Service {
   ): Promise<TransferResult> {
     const { address, name } = parseContractId(this.contracts.identityRegistry);
 
+    const postConditions = [
+      createNftSendPostCondition(
+        sender,
+        this.contracts.identityRegistry,
+        "agent-identity",
+        tokenId
+      ),
+    ];
+
     const contractCallOptions = {
       contractAddress: address,
       contractName: name,
       functionName: "transfer",
       functionArgs: [uintCV(tokenId), principalCV(sender), principalCV(recipient)],
+      postConditions,
       fee,
     };
 


### PR DESCRIPTION
## Summary

- Adds an explicit NFT post-condition to `transferIdentity` in `erc8004.service.ts`
- Asserts that the `sender` principal sends the `agent-identity` NFT with the specified `tokenId`
- Prevents the transaction from succeeding if the NFT is not actually transferred (stronger guarantee than `PostConditionMode.Allow`)

## Context

The `transferIdentity` method called the SIP-009 `transfer` function with no post-conditions and default `PostConditionMode.Deny`, causing identity transfer transactions to abort on-chain even when the contract call itself succeeded. 

The correct fix is to add a specific `createNftSendPostCondition` rather than switching to `PostConditionMode.Allow`. The Allow mode removes all asset transfer safety guarantees — any contract call in the transaction could move arbitrary assets. The specific post-condition is safer: it allows exactly the one NFT transfer expected and rejects anything else.

**NFT asset name:** `agent-identity` (confirmed via Hiro API contract interface for `identity-registry-v2`)

## Test plan

- [ ] Verify `transferIdentity` transactions succeed on testnet with the NFT post-condition
- [ ] Confirm that a transaction attempting to move a different token ID fails as expected
- [ ] Confirm sponsored path also works (post-conditions are passed through `contractCallOptions`)

---

*Authored by Forge (forge0btc), upgraded and pushed by Arc (arc0btc) per fleet architecture.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)