### PR TITLE
fix(defi): read Zest supply from LP token balance, not reserve data

### DIFF
--- a/src/lib/services/defi.service.ts
+++ b/src/lib/services/defi.service.ts
@@ -453,38 +453,53 @@ export class ZestProtocolService {
   }
 
   /**
-   * Get user's reserve/position data for an asset
+   * Get user's position for an asset.
+   *
+   * Supply is read from the LP token contract's get-balance (e.g. zsbtc-v2-0),
+   * not from get-user-reserve-data which only holds borrow-side fields.
+   * This matches the fix confirmed in aibtcdev/aibtc-mcp-server v1.33.3.
    */
   async getUserPosition(
     asset: string,
     userAddress: string
   ): Promise<ZestUserPosition | null> {
     try {
-      const result = await this.hiro.callReadOnlyFunction(
+      const assetConfig = this.getAssetConfig(asset);
+
+      // Supply: read LP token balance
+      const lpBalanceResult = await this.hiro.callReadOnlyFunction(
+        assetConfig.lpToken,
+        "get-balance",
+        [principalCV(userAddress)],
+        userAddress
+      );
+
+      // Borrow: read from pool-borrow reserve data
+      const reserveResult = await this.hiro.callReadOnlyFunction(
         this.getContracts().poolBorrow,
         "get-user-reserve-data",
         [
           principalCV(userAddress),
-          contractPrincipalCV(...parseContractIdTuple(asset)),
+          contractPrincipalCV(...parseContractIdTuple(assetConfig.token)),
         ],
         userAddress
       );
 
-      if (!result.okay || !result.result) {
-        return null;
+      let supplied = "0";
+      if (lpBalanceResult.okay && lpBalanceResult.result) {
+        const decoded = cvToJSON(hexToCV(lpBalanceResult.result));
+        supplied = decoded?.value?.value ?? decoded?.value ?? "0";
       }
 
-      const decoded = cvToJSON(hexToCV(result.result));
-
-      if (decoded && typeof decoded === "object") {
-        return {
-          asset,
-          supplied: decoded["current-a-token-balance"]?.value || "0",
-          borrowed: decoded["current-variable-debt"]?.value || "0",
-        };
+      let borrowed = "0";
+      if (reserveResult.okay && reserveResult.result) {
+        const decoded = cvToJSON(hexToCV(reserveResult.result));
+        if (decoded && typeof decoded === "object") {
+          borrowed = decoded["principal-borrow-balance"]?.value || "0";
+        }
       }
 
-      return null;
+      return { asset, supplied, borrowed };
     } catch {
       return null;
     }


### PR DESCRIPTION
## Summary

- `getUserPosition()` was reading `current-a-token-balance` from `get-user-reserve-data` — a field that doesn't exist in the Zest pool-borrow response and always returns `0`
- Zest supply positions are LP token balances (e.g. `zsbtc-v2-0`), not a field in the reserve data struct
- Borrow field was also wrong: `current-variable-debt` → `principal-borrow-balance`

## Changes

- **Supply**: now calls `get-balance` on `assetConfig.lpToken` (the LP token contract) instead of reading from reserve data
- **Borrow**: reads `principal-borrow-balance` from `get-user-reserve-data` (correct field)
- `getAssetConfig()` is now called first so both symbol and contract-ID inputs work consistently

## Reference

Same fix confirmed in [aibtcdev/aibtc-mcp-server v1.33.3](https://github.com/aibtcdev/aibtc-mcp-server) commits #283 and #285.

## Test plan

- [ ] Call `getUserPosition("sBTC", <address>)` for an address with a known sBTC supply on Zest — supplied should be non-zero
- [ ] Call `getUserPosition("aeUSDC", <address>)` for an address with a borrow position — borrowed should be non-zero
- [ ] Address with no position returns `{ supplied: "0", borrowed: "0" }`

🤖 Generated with [Claude Code](https://claude.com/claude-code)