### PR TITLE
fix: migrate wrangler.jsonc template to use JSONC comments (closes #115)

### DIFF
--- a/src/lib/services/scaffold.service.ts
+++ b/src/lib/services/scaffold.service.ts
@@ -555,17 +555,30 @@ function getWranglerTemplate(projectName: string, network: string, relayUrl: str
   const mainnetRelay = "https://x402-relay.aibtc.com";
   const testnetRelay = "https://x402-relay.aibtc.dev";
   return `{
+  // wrangler.jsonc — Cloudflare Workers configuration
+  // Docs: https://developers.cloudflare.com/workers/wrangler/configuration/
   "$schema": "node_modules/wrangler/config-schema.json",
+
+  // Worker identity
   "name": "${projectName}",
   "main": "src/index.ts",
+
+  // Runtime compatibility
   "compatibility_date": "2026-01-14",
   "compatibility_flags": ["nodejs_compat_v2"],
+
+  // Default: deploy to workers.dev subdomain
   "workers_dev": true,
+
+  // Default environment variables (development)
   "vars": {
     "NETWORK": "${network}",
     "RELAY_URL": "${relayUrl}"
   },
+
+  // Named environments — override vars and worker name per target
   "env": {
+    // Staging: testnet payments, workers.dev URL
     "staging": {
       "name": "${projectName}-staging",
       "workers_dev": true,
@@ -574,6 +587,7 @@ function getWranglerTemplate(projectName: string, network: string, relayUrl: str
         "RELAY_URL": "${testnetRelay}"
       }
     },
+    // Production: mainnet payments, custom domain
     "production": {
       "name": "${projectName}",
       "workers_dev": false,

--- a/x402/SKILL.md
+++ b/x402/SKILL.md
@@ -148,7 +148,7 @@ Output:
 
 ### scaffold-endpoint
 
-Create a complete x402 paid API project as a Cloudflare Worker. Generates a new project folder with Hono.js app, x402 payment middleware, wrangler config, and README.
+Create a complete x402 paid API project as a Cloudflare Worker. Generates a new project folder with Hono.js app, x402 payment middleware, wrangler.jsonc config, and README.
 
 ```
 bun run x402/x402.ts scaffold-endpoint \

--- a/x402/x402.ts
+++ b/x402/x402.ts
@@ -561,7 +561,7 @@ program
   .command("scaffold-endpoint")
   .description(
     "Create a complete x402 paid API project as a Cloudflare Worker. " +
-      "Generates a new project folder with Hono.js app, x402 payment middleware, wrangler config, and README."
+      "Generates a new project folder with Hono.js app, x402 payment middleware, wrangler.jsonc config, and README."
   )
   .requiredOption("--output-dir <dir>", "Directory where the project folder will be created")
   .requiredOption(
@@ -666,7 +666,7 @@ program
   .command("scaffold-ai-endpoint")
   .description(
     "Create a complete x402 paid AI API project with OpenRouter integration as a Cloudflare Worker. " +
-      "Generates a new project folder with Hono.js app, x402 middleware, OpenRouter client, and wrangler config."
+      "Generates a new project folder with Hono.js app, x402 middleware, OpenRouter client, and wrangler.jsonc config."
   )
   .requiredOption("--output-dir <dir>", "Directory where the project folder will be created")
   .requiredOption(


### PR DESCRIPTION
## Summary

Closes #115 — migrate from plain JSON to proper JSONC in the scaffold service's wrangler config template.

- The scaffold service already wrote output files named `wrangler.jsonc`, but the template content was plain JSON with no comments — not leveraging the JSONC format
- Added inline `//` comments as section headers throughout the template: worker identity, runtime compatibility, vars, and per-environment overrides
- Updated description strings in `x402/x402.ts` and `x402/SKILL.md` to explicitly reference `wrangler.jsonc` instead of the generic "wrangler config"

No functional behaviour changes — only the generated file content gains inline documentation.

## Files changed

- `src/lib/services/scaffold.service.ts` — `getWranglerTemplate()` now emits JSONC with section comments
- `x402/x402.ts` — description strings for `scaffold-endpoint` and `scaffold-ai-endpoint` updated
- `x402/SKILL.md` — `scaffold-endpoint` description updated to name the config format explicitly

## Test plan

- [ ] Run `bun run x402/x402.ts scaffold-endpoint --output-dir /tmp --project-name test-x402 --endpoints '[{"path":"/api/data","method":"GET","description":"Test","amount":"0.001","tokenType":"STX"}]'` and confirm the generated `wrangler.jsonc` contains `//` comments
- [ ] Verify wrangler parses the file without errors: `cd /tmp/test-x402 && npm install && npx wrangler types`
- [ ] `bun run typecheck` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)