### PR TITLE
fix(aibtc-news): migrate to v2 API auth headers

### DIFF
--- a/aibtc-news-classifieds/aibtc-news-classifieds.ts
+++ b/aibtc-news-classifieds/aibtc-news-classifieds.ts
@@ -26,16 +26,22 @@ const VALID_CATEGORIES = ["ordinals", "services", "agents", "wanted"] as const;
 // ---------------------------------------------------------------------------
 
 /**
- * Build a signing message for write operations.
- * Pattern: SIGNAL|{action}|{context}|{btcAddress}|{timestamp}
+ * Build v2 API auth headers for write operations.
+ * Message format: '{METHOD} /api{path}:{unix_seconds}'
  */
-function buildSigningMessage(
-  action: string,
-  context: string,
-  btcAddress: string,
-  timestamp: number
-): string {
-  return `SIGNAL|${action}|${context}|${btcAddress}|${timestamp}`;
+async function buildAuthHeaders(
+  method: string,
+  path: string
+): Promise<Record<string, string>> {
+  const timestamp = Math.floor(Date.now() / 1000);
+  const message = `${method} /api${path}:${timestamp}`;
+  const { signature, signer } = await signMessage(message);
+  return {
+    "X-BTC-Address": signer,
+    "X-BTC-Signature": signature,
+    "X-BTC-Timestamp": String(timestamp),
+    "Content-Type": "application/json",
+  };
 }
 
 /**
@@ -113,33 +119,6 @@ async function apiGet(
 
   if (!res.ok) {
     throw new Error(`API error ${res.status} from GET ${path}: ${text}`);
-  }
-
-  return data;
-}
-
-/**
- * Make a PATCH request to the aibtc.news API.
- */
-async function apiPatch(path: string, body: unknown): Promise<unknown> {
-  const url = `${NEWS_API_BASE}${path}`;
-
-  const res = await fetch(url, {
-    method: "PATCH",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(body),
-  });
-
-  const text = await res.text();
-  let data: unknown;
-  try {
-    data = JSON.parse(text);
-  } catch {
-    data = { raw: text };
-  }
-
-  if (!res.ok) {
-    throw new Error(`API error ${res.status} from PATCH ${path}: ${text}`);
   }
 
   return data;
@@ -396,12 +375,8 @@ program
   )
   .requiredOption("--id <id>", "Signal ID to correct")
   .requiredOption("--content <text>", "Correction text (max 500 characters)")
-  .requiredOption(
-    "--btc-address <address>",
-    "Your BTC address (must match original author)"
-  )
   .action(
-    async (opts: { id: string; content: string; btcAddress: string }) => {
+    async (opts: { id: string; content: string }) => {
       try {
         if (opts.content.length > 500) {
           throw new Error(
@@ -409,21 +384,28 @@ program
           );
         }
 
-        const timestamp = Date.now();
-        const message = buildSigningMessage(
-          "correct",
-          opts.id,
-          opts.btcAddress,
-          timestamp
-        );
-        const { signature } = await signMessage(message);
+        // v2: auth via headers, only content in body
+        const path = `/signals/${opts.id}`;
+        const headers = await buildAuthHeaders("PATCH", path);
 
-        const data = await apiPatch(`/signals/${opts.id}`, {
-          btcAddress: opts.btcAddress,
-          content: opts.content,
-          signature,
-          timestamp,
+        const url = `${NEWS_API_BASE}${path}`;
+        const res = await fetch(url, {
+          method: "PATCH",
+          headers,
+          body: JSON.stringify({ content: opts.content }),
         });
+
+        const text = await res.text();
+        let data: unknown;
+        try {
+          data = JSON.parse(text);
+        } catch {
+          data = { raw: text };
+        }
+
+        if (!res.ok) {
+          throw new Error(`API error ${res.status}: ${text}`);
+        }
 
         printJson({
           success: true,
@@ -449,16 +431,11 @@ program
       "Requires BIP-322 signing. You must be the beat owner."
   )
   .requiredOption("--beat <slug>", "Beat slug to update")
-  .requiredOption(
-    "--btc-address <address>",
-    "Your BTC address (must own the beat)"
-  )
   .option("--description <text>", "New description (max 500 chars)")
   .option("--color <hex>", "New color (#RRGGBB format)")
   .action(
     async (opts: {
       beat: string;
-      btcAddress: string;
       description?: string;
       color?: string;
     }) => {
@@ -477,25 +454,32 @@ program
           throw new Error("Invalid color format (must be #RRGGBB)");
         }
 
-        const timestamp = Date.now();
-        const message = buildSigningMessage(
-          "update-beat",
-          opts.beat,
-          opts.btcAddress,
-          timestamp
-        );
-        const { signature } = await signMessage(message);
+        // v2: auth via headers, PATCH to /beats/{slug}
+        const path = `/beats/${opts.beat}`;
+        const headers = await buildAuthHeaders("PATCH", path);
 
-        const body: Record<string, unknown> = {
-          slug: opts.beat,
-          btcAddress: opts.btcAddress,
-          signature,
-          timestamp,
-        };
+        const body: Record<string, unknown> = {};
         if (opts.description) body.description = opts.description;
         if (opts.color) body.color = opts.color;
 
-        const data = await apiPatch("/beats", body);
+        const url = `${NEWS_API_BASE}${path}`;
+        const res = await fetch(url, {
+          method: "PATCH",
+          headers,
+          body: JSON.stringify(body),
+        });
+
+        const text = await res.text();
+        let data: unknown;
+        try {
+          data = JSON.parse(text);
+        } catch {
+          data = { raw: text };
+        }
+
+        if (!res.ok) {
+          throw new Error(`API error ${res.status}: ${text}`);
+        }
 
         printJson({
           success: true,
@@ -553,34 +537,21 @@ program
       "Requires BIP-322 signing."
   )
   .requiredOption("--date <date>", "ISO date (YYYY-MM-DD)")
-  .requiredOption(
-    "--btc-address <address>",
-    "Your BTC address (bc1q... or bc1p...)"
-  )
-  .action(async (opts: { date: string; btcAddress: string }) => {
+  .action(async (opts: { date: string }) => {
     try {
       if (!/^\d{4}-\d{2}-\d{2}$/.test(opts.date)) {
         throw new Error("Date must be YYYY-MM-DD format");
       }
 
-      const timestamp = Date.now();
-      const message = buildSigningMessage(
-        "inscribe-brief",
-        opts.date,
-        opts.btcAddress,
-        timestamp
-      );
-      const { signature } = await signMessage(message);
+      // v2: auth via headers, empty body
+      const path = `/brief/${opts.date}/inscribe`;
+      const headers = await buildAuthHeaders("POST", path);
 
-      const url = `${NEWS_API_BASE}/brief/${opts.date}/inscribe`;
+      const url = `${NEWS_API_BASE}${path}`;
       const res = await fetch(url, {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          btcAddress: opts.btcAddress,
-          signature,
-          timestamp,
-        }),
+        headers,
+        body: JSON.stringify({}),
       });
 
       const text = await res.text();
@@ -601,32 +572,6 @@ program
         message: "Brief inscription recorded",
         date: opts.date,
         response: data,
-      });
-    } catch (error) {
-      handleError(error);
-    }
-  });
-
-// ---------------------------------------------------------------------------
-// get-inscription
-// ---------------------------------------------------------------------------
-
-program
-  .command("get-inscription")
-  .description("Check the inscription status of a brief.")
-  .requiredOption("--date <date>", "ISO date (YYYY-MM-DD)")
-  .action(async (opts: { date: string }) => {
-    try {
-      if (!/^\d{4}-\d{2}-\d{2}$/.test(opts.date)) {
-        throw new Error("Date must be YYYY-MM-DD format");
-      }
-
-      const data = await apiGet(`/brief/${opts.date}/inscription`);
-
-      printJson({
-        network: NETWORK,
-        date: opts.date,
-        inscription: data,
       });
     } catch (error) {
       handleError(error);

--- a/aibtc-news/aibtc-news.ts
+++ b/aibtc-news/aibtc-news.ts
@@ -21,16 +21,22 @@ const NEWS_API_BASE = "https://aibtc.news/api";
 // ---------------------------------------------------------------------------
 
 /**
- * Build a signing message for write operations.
- * Pattern: SIGNAL|{action}|{context}|{btcAddress}|{timestamp}
+ * Build v2 API auth headers for write operations.
+ * Message format: '{METHOD} /api{path}:{unix_seconds}'
  */
-function buildSigningMessage(
-  action: string,
-  context: string,
-  btcAddress: string,
-  timestamp: number
-): string {
-  return `SIGNAL|${action}|${context}|${btcAddress}|${timestamp}`;
+async function buildAuthHeaders(
+  method: string,
+  path: string
+): Promise<Record<string, string>> {
+  const timestamp = Math.floor(Date.now() / 1000);
+  const message = `${method} /api${path}:${timestamp}`;
+  const { signature, signer } = await signMessage(message);
+  return {
+    "X-BTC-Address": signer,
+    "X-BTC-Signature": signature,
+    "X-BTC-Timestamp": String(timestamp),
+    "Content-Type": "application/json",
+  };
 }
 
 /**
@@ -110,12 +116,16 @@ async function apiGet(
 /**
  * Make a POST request to the aibtc.news API.
  */
-async function apiPost(path: string, body: unknown): Promise<unknown> {
+async function apiPost(
+  path: string,
+  body: unknown,
+  authHeaders?: Record<string, string>
+): Promise<unknown> {
   const url = `${NEWS_API_BASE}${path}`;
 
   const res = await fetch(url, {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: authHeaders ?? { "Content-Type": "application/json" },
     body: JSON.stringify(body),
   });
 
@@ -214,10 +224,9 @@ program
       "Rate limit: 1 signal per agent per 4 hours. " +
       "Requires an unlocked wallet."
   )
-  .requiredOption("--beat-id <id>", "Beat ID to file the signal under")
+  .requiredOption("--beat-id <id>", "Beat slug to file the signal under")
   .requiredOption("--headline <text>", "Signal headline (max 120 characters)")
   .requiredOption("--content <text>", "Signal content (max 1000 characters)")
-  .requiredOption("--btc-address <address>", "Your Bitcoin address (bc1q... or bc1p...)")
   .option("--sources <json>", "JSON array of source URLs (up to 5)", "[]")
   .option("--tags <json>", "JSON array of tag strings (up to 10)", "[]")
   .action(
@@ -225,7 +234,6 @@ program
       beatId: string;
       headline: string;
       content: string;
-      btcAddress: string;
       sources: string;
       tags: string;
     }) => {
@@ -264,36 +272,25 @@ program
           throw new Error(`Too many tags: max 10, got ${tags.length}`);
         }
 
-        // Build and sign the message
-        const timestamp = Date.now();
-        const message = buildSigningMessage(
-          "file-signal",
-          opts.beatId,
-          opts.btcAddress,
-          timestamp
-        );
+        // v2: auth via headers, snake_case body
+        const headers = await buildAuthHeaders("POST", "/signals");
 
-        const { signature } = await signMessage(message);
-
-        // POST the signal
-        const body = {
-          beatId: opts.beatId,
-          headline: opts.headline,
+        const body: Record<string, unknown> = {
+          beat_slug: opts.beatId,
           content: opts.content,
-          sources,
-          tags,
-          btcAddress: opts.btcAddress,
-          signature,
-          timestamp,
         };
 
-        const data = await apiPost("/signals", body);
+        if (opts.headline) body.headline = opts.headline;
+        if (sources.length > 0) body.sources = sources;
+        if (tags.length > 0) body.tags = tags;
+
+        const data = await apiPost("/signals", body, headers);
 
         printJson({
           success: true,
           network: NETWORK,
           message: "Signal filed successfully",
-          beatId: opts.beatId,
+          beatSlug: opts.beatId,
           headline: opts.headline,
           contentLength: opts.content.length,
           sourcesCount: sources.length,
@@ -390,35 +387,30 @@ program
       "Claiming a beat establishes your agent as the correspondent for that topic. " +
       "Requires an unlocked wallet for BIP-322 signing."
   )
-  .requiredOption("--beat-id <id>", "Beat ID to claim")
-  .requiredOption("--btc-address <address>", "Your Bitcoin address (bc1q... or bc1p...)")
-  .action(async (opts: { beatId: string; btcAddress: string }) => {
+  .requiredOption("--beat-id <id>", "Beat slug to claim")
+  .option("--name <name>", "Display name for the beat")
+  .option("--description <text>", "Beat description")
+  .option("--color <hex>", "Beat color (#RRGGBB)")
+  .action(async (opts: { beatId: string; name?: string; description?: string; color?: string }) => {
     try {
-      const timestamp = Date.now();
-      const message = buildSigningMessage(
-        "claim-beat",
-        opts.beatId,
-        opts.btcAddress,
-        timestamp
-      );
+      // v2: auth via headers, snake_case body
+      const headers = await buildAuthHeaders("POST", "/beats");
 
-      const { signature } = await signMessage(message);
-
-      const body = {
-        beatId: opts.beatId,
-        btcAddress: opts.btcAddress,
-        signature,
-        timestamp,
+      const body: Record<string, unknown> = {
+        beat_slug: opts.beatId,
       };
 
-      const data = await apiPost("/beats", body);
+      if (opts.name) body.name = opts.name;
+      if (opts.description) body.description = opts.description;
+      if (opts.color) body.color = opts.color;
+
+      const data = await apiPost("/beats", body, headers);
 
       printJson({
         success: true,
         network: NETWORK,
         message: "Beat claimed successfully",
-        beatId: opts.beatId,
-        btcAddress: opts.btcAddress,
+        beatSlug: opts.beatId,
         response: data,
       });
     } catch (error) {
@@ -437,39 +429,31 @@ program
       "Requires a correspondent score >= 50. " +
       "Requires an unlocked wallet for BIP-322 signing."
   )
-  .requiredOption("--btc-address <address>", "Your Bitcoin address (bc1q... or bc1p...)")
   .option(
     "--date <date>",
     "ISO date string for the brief (default: today, e.g., 2026-02-26)"
   )
-  .action(async (opts: { btcAddress: string; date?: string }) => {
+  .option("--beat <slug>", "Optional beat slug to compile for")
+  .action(async (opts: { date?: string; beat?: string }) => {
     try {
       const date = opts.date || new Date().toISOString().split("T")[0];
-      const timestamp = Date.now();
-      const message = buildSigningMessage(
-        "compile-brief",
-        date,
-        opts.btcAddress,
-        timestamp
-      );
 
-      const { signature } = await signMessage(message);
+      // v2: auth via headers, snake_case body
+      const headers = await buildAuthHeaders("POST", "/brief");
 
-      const body = {
+      const body: Record<string, unknown> = {
         date,
-        btcAddress: opts.btcAddress,
-        signature,
-        timestamp,
       };
 
-      const data = await apiPost("/brief", body);
+      if (opts.beat) body.beat_slug = opts.beat;
+
+      const data = await apiPost("/brief", body, headers);
 
       printJson({
         success: true,
         network: NETWORK,
         message: "Brief compilation triggered",
         date,
-        btcAddress: opts.btcAddress,
         response: data,
       });
     } catch (error) {


### PR DESCRIPTION
## Summary

- Replace body-based auth (`btcAddress`/`signature`/`timestamp` in request body) with HTTP header-based auth (`X-BTC-Address`, `X-BTC-Signature`, `X-BTC-Timestamp`)
- Migrate request bodies to snake_case (`beat_slug` instead of `beatId`)
- Remove deprecated `apiPatch` helper, `get-inscription` command, and `--btc-address` flags (address now derived from wallet signing)

## Files Changed

- **aibtc-news/aibtc-news.ts** — `file-signal`, `claim-beat`, `compile-brief` migrated
- **aibtc-news-classifieds/aibtc-news-classifieds.ts** — `correct-signal`, `update-beat`, `inscribe-brief` migrated

## Context

Companion to [arc-starter PR #9](https://github.com/aibtcdev/arc-starter/pull/9). The aibtc.news API v2 moved auth from request bodies to HTTP headers with a new signing message format: `'{METHOD} /api{path}:{unix_seconds}'`.

## Test plan

- [ ] Verify `file-signal` sends auth via headers, body uses `beat_slug`
- [ ] Verify `claim-beat` sends auth via headers, body uses `beat_slug`
- [ ] Verify `compile-brief` sends auth via headers
- [ ] Verify `correct-signal` uses PATCH with auth headers
- [ ] Verify `update-beat` PATCHes `/beats/{slug}` instead of `/beats`
- [ ] Verify `inscribe-brief` uses auth headers with empty body

🤖 Generated with [Claude Code](https://claude.com/claude-code)