### PR TITLE
fix(bitflow): default USDC references to USDCx

### DIFF
--- a/bitflow/AGENT.md
+++ b/bitflow/AGENT.md
@@ -21,6 +21,7 @@ This agent handles DEX operations on the Bitflow aggregated liquidity protocol o
 - `STX`: 6 decimals (`1 STX = 1,000,000` micro-STX)
 - `sBTC`: 8 decimals (`1 sBTC = 100,000,000` sats)
 - `USDCx` / `aeUSDC`: 6 decimals
+- Naming default: if the user says `USDC` on Bitflow, interpret that as `USDCx` (`token-USDCx-auto`). Use `aeUSDC` (`token-aeusdc`) only when the user explicitly says `aeUSDC`.
 - `get-quote`, `get-routes --amount-in`, and `swap --amount-in` use human-readable token amounts
 - HODLMM bin reserves are raw on-chain atomic values; the CLI now shows human-readable token units too
 - HODLMM `bin.price` is a raw API field; interpret the derived `approxPrice` output instead of guessing from `rawPrice`
@@ -73,6 +74,7 @@ This agent handles DEX operations on the Bitflow aggregated liquidity protocol o
 - `get-quote`: `selectedRoute` is the best overall quote; `bestExecutableRoute` is the route `swap` can use today
 - `get-quote`: `executionWarning` means the best HODLMM quote is not directly executable, so `swap` will use the best executable fallback
 - `get-quote`: if `highImpactWarning` is present, the trade is large relative to pool liquidity
+- `get-tokens`: prefer `token-USDCx-auto` when the user asks for `USDC`; reserve `token-aeusdc` for explicit aeUSDC requests
 - `get-hodlmm-bins`: prefer `approxPrice` over `rawPrice` when answering users in natural language
 - `get-ticker`: prefer the derived `pair`, `baseSymbol`, and `targetSymbol` fields over raw contract IDs
 - Do not ask the user for a Bitflow API key unless they explicitly want higher-rate-limit private usage; the public path is the default

--- a/bitflow/SKILL.md
+++ b/bitflow/SKILL.md
@@ -36,6 +36,7 @@ bun run bitflow/bitflow.ts <subcommand> [options]
 - `STX` uses 6 decimals: `1 STX = 1,000,000` micro-STX
 - `sBTC` uses 8 decimals: `1 sBTC = 100,000,000` sats
 - `USDCx` and `aeUSDC` use 6 decimals
+- Naming convention: when a user says `USDC` on Bitflow, treat that as `USDCx` (`token-USDCx-auto`) by default. Only use `aeUSDC` (`token-aeusdc`) when the user explicitly asks for `aeUSDC`.
 - `get-quote`, `get-routes --amount-in`, and `swap --amount-in` use human-readable token amounts
 - HODLMM `reserve_x` and `reserve_y` come from on-chain atomic units; this skill displays them in human-readable token units
 - HODLMM `bin.price` is a raw API value; this skill also shows an approximate human-readable `tokenY per tokenX` interpretation
@@ -98,6 +99,14 @@ Output:
       "symbol": "STX",
       "contractId": "token-stx",
       "decimals": 6
+    },
+    {
+      "id": "token-USDCx-auto",
+      "name": "USDCx",
+      "symbol": "USDCx",
+      "contractId": "SP120SBRBQJ00MCWS7TM5R8WJNTTKD5K0HFRC2CNE.usdcx",
+      "decimals": 6,
+      "aliases": ["USDC"]
     }
   ]
 }
@@ -120,7 +129,7 @@ Output:
   "network": "mainnet",
   "inputToken": "token-stx",
   "targetCount": 8,
-  "targets": ["token-sbtc", "token-aeusdc", "token-alex"]
+  "targets": ["token-sbtc", "token-USDCx-auto", "token-alex"]
 }
 ```
 
@@ -163,7 +172,7 @@ bun run bitflow/bitflow.ts get-quote --token-x <tokenId> --token-y <tokenId> --a
 
 Options:
 - `--token-x` (required) — Input token ID (e.g. `token-stx`, `token-sbtc`)
-- `--token-y` (required) — Output token ID (e.g. `token-sbtc`, `token-aeusdc`)
+- `--token-y` (required) — Output token ID (e.g. `token-sbtc`, `token-USDCx-auto`; use `token-aeusdc` only when the user explicitly wants `aeUSDC`)
 - `--amount-in` (required) — Amount of input token in human-readable decimal (e.g. `0.00015` for 15,000 sats sBTC, `21.0` for 21 STX). The SDK auto-scales by `10^decimals` internally.
 
 Output:
@@ -209,7 +218,7 @@ bun run bitflow/bitflow.ts get-routes --token-x <tokenId> --token-y <tokenId> [-
 
 Options:
 - `--token-x` (required) — Input token ID
-- `--token-y` (required) — Output token ID
+- `--token-y` (required) — Output token ID (`token-USDCx-auto` when the user asks for USDC, `token-aeusdc` only for explicit aeUSDC requests)
 - `--amount-in` (optional) — When provided, ranks routes by expected output for that trade size
 
 Output:

--- a/bitflow/bitflow.ts
+++ b/bitflow/bitflow.ts
@@ -635,7 +635,7 @@ program
   )
   .requiredOption(
     "--token-y <tokenId>",
-    "Output token ID (e.g. 'token-sbtc', 'token-aeusdc')"
+    "Output token ID (e.g. 'token-sbtc', 'token-USDCx-auto'; use 'token-aeusdc' only for explicit aeUSDC requests)"
   )
   .requiredOption(
     "--amount-in <decimal>",
@@ -696,7 +696,7 @@ program
   )
   .requiredOption(
     "--token-y <tokenId>",
-    "Output token ID (e.g. 'token-sbtc', 'token-aeusdc')"
+    "Output token ID (e.g. 'token-sbtc', 'token-USDCx-auto'; use 'token-aeusdc' only for explicit aeUSDC requests)"
   )
   .option(
     "--amount-in <decimal>",

--- a/src/lib/services/bitflow.service.ts
+++ b/src/lib/services/bitflow.service.ts
@@ -155,6 +155,23 @@ export interface BitflowToken {
   symbol: string;
   contractId: string;
   decimals: number;
+  aliases?: string[];
+}
+
+function normalizeBitflowToken(token: Token): BitflowToken {
+  const normalized: BitflowToken = {
+    id: token.tokenId,
+    name: token.name,
+    symbol: token.symbol,
+    contractId: token.tokenContract || token.tokenId,
+    decimals: token.tokenDecimals,
+  };
+
+  if (token.tokenId === "token-USDCx-auto") {
+    normalized.aliases = ["USDC"];
+  }
+
+  return normalized;
 }
 
 export interface HodlmmPoolInfo {
@@ -672,13 +689,7 @@ export class BitflowService {
     if (!this.tokenCache) {
       this.tokenCache = await sdk.getAvailableTokens();
     }
-    return this.tokenCache.map((t: Token) => ({
-      id: t.tokenId,
-      name: t.name,
-      symbol: t.symbol,
-      contractId: t.tokenContract || t.tokenId,
-      decimals: t.tokenDecimals,
-    }));
+    return this.tokenCache.map((t: Token) => normalizeBitflowToken(t));
   }
 
   private async ensureTokenCache(): Promise<Token[]> {

--- a/what-to-do/swap-tokens.md
+++ b/what-to-do/swap-tokens.md
@@ -38,7 +38,7 @@ NETWORK=mainnet bun run bitflow/bitflow.ts get-tokens
 
 Expected output: Array of tokens with `id` (the value used for `--token-x` / `--token-y`), `symbol`, `name`.
 
-Common token IDs: `token-stx` (STX), `token-sbtc` (sBTC), `token-aeusdc` (USDCx), `token-alex` (ALEX).
+Common token IDs: `token-stx` (STX), `token-sbtc` (sBTC), `token-USDCx-auto` (USDCx / default `USDC`), `token-aeusdc` (aeUSDC, only when explicitly requested), `token-alex` (ALEX).
 
 ### 3. Check Swap Targets
 


### PR DESCRIPTION
## Summary
- update the Bitflow skill docs and CLI help so generic `USDC` requests default to `USDCx` and `aeUSDC` is only used when explicitly requested
- expose a `USDC` alias on the Bitflow token metadata for `token-USDCx-auto` so agents can carry that naming convention forward from `get-tokens`
- correct the swap workflow guide so it no longer labels `token-aeusdc` as `USDCx`