### PR TITLE
fix(stackspot): add mcp-tools metadata field (closes #145)

### DIFF
--- a/stackspot/SKILL.md
+++ b/stackspot/SKILL.md
@@ -7,6 +7,7 @@ metadata:
   user-invocable: "false"
   arguments: "list-pots | get-pot-state | join-pot | start-pot | claim-rewards | cancel-pot"
   entry: "stackspot/stackspot.ts"
+  mcp-tools: "stackspot_list_pots, stackspot_get_pot_state, stackspot_join_pot, stackspot_start_pot, stackspot_claim_rewards, stackspot_cancel_pot"
   requires: "wallet"
   tags: "l2, write, mainnet-only, requires-funds"
 ---


### PR DESCRIPTION
## Summary

Closes #145 — adds `mcp-tools` metadata field to `stackspot/SKILL.md`, linking the skill to its MCP server counterpart (`stacking-lottery.tools.ts`).

**Change:** One-line addition to `stackspot/SKILL.md` metadata:
```yaml
mcp-tools: "stackspot_list_pots, stackspot_get_pot_state, stackspot_join_pot, stackspot_start_pot, stackspot_claim_rewards, stackspot_cancel_pot"
```

This follows the same pattern used in `stacking/SKILL.md` and other skills with MCP tool counterparts.

Note: The naming mismatch between `stackspot/` (skill directory) and `stacking-lottery.tools.ts` (MCP file) is tracked separately in the same issue — Option A (minimal) is implemented here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)