### PR TITLE
fix: replace bare catch-return-null with selective 404 guards

### DIFF
--- a/src/lib/services/defi.service.ts
+++ b/src/lib/services/defi.service.ts
@@ -270,8 +270,11 @@ export class AlexDexService {
       }
 
       return null;
-    } catch {
-      return null;
+    } catch (error) {
+      if (error instanceof Error && (error.message.includes("404") || error.message.includes("not found"))) {
+        return null;
+      }
+      throw error;
     }
   }
 
@@ -500,8 +503,11 @@ export class ZestProtocolService {
       }
 
       return { asset, supplied, borrowed };
-    } catch {
-      return null;
+    } catch (error) {
+      if (error instanceof Error && (error.message.includes("404") || error.message.includes("not found"))) {
+        return null;
+      }
+      throw error;
     }
   }
 

--- a/src/lib/services/hiro-api.ts
+++ b/src/lib/services/hiro-api.ts
@@ -431,8 +431,11 @@ export class HiroApiService {
   async getTokenMetadata(contractId: string): Promise<TokenMetadata | null> {
     try {
       return await this.fetch<TokenMetadata>(`/metadata/v1/ft/${contractId}`);
-    } catch {
-      return null;
+    } catch (error) {
+      if (error instanceof Error && error.message.includes("404")) {
+        return null;
+      }
+      throw error;
     }
   }
 
@@ -691,8 +694,11 @@ export class HiroApiService {
     try {
       const info = await this.getBnsNameInfo(name);
       return info.address;
-    } catch {
-      return null;
+    } catch (error) {
+      if (error instanceof Error && (error.message.includes("404") || error.message.includes("not found"))) {
+        return null;
+      }
+      throw error;
     }
   }
 
@@ -839,8 +845,11 @@ export class BnsV2ApiService {
         return info.data.owner;
       }
       return null;
-    } catch {
-      return null;
+    } catch (error) {
+      if (error instanceof Error && (error.message.includes("404") || error.message.includes("Name not found"))) {
+        return null;
+      }
+      throw error;
     }
   }
 }


### PR DESCRIPTION
## Summary

Replaces five bare `catch { return null }` blocks with selective 404 guards. Rate limits, network timeouts, and API errors are now re-thrown instead of silently returning null.

### Changes

**`src/lib/services/hiro-api.ts`:**
- `getTokenMetadata()` — catch only 404, rethrow others
- `resolveBnsName()` — catch only 404/"not found", rethrow others
- `BnsV2ApiService.resolveName()` — catch only 404/"Name not found", rethrow others

**`src/lib/services/defi.service.ts`:**
- `AlexDexService.getPoolInfo()` — catch only 404/"not found", rethrow others
- `ZestProtocolService.getUserPosition()` — catch only 404/"not found", rethrow others

### Pattern

Matches the existing correct pattern in `getTransactionStatus()` and `BnsV2ApiService.nameExists()` in the same codebase. No new patterns introduced — just consistency.

### Not changed

`AlexDexService.listPools()` catch-break is intentional enumeration sentinel (pool ID doesn't exist = no more pools). Left as-is.

Closes #154

## Test Plan

- [x] TypeScript compiles cleanly (`npx tsc --noEmit`)
- [ ] Verify `getTokenMetadata` returns null for nonexistent contract
- [ ] Verify `resolveBnsName` returns null for nonexistent name
- [ ] Verify API errors (e.g., rate limit simulation) now throw instead of returning null

🤖 Generated with [Claude Code](https://claude.com/claude-code)