### PR TITLE
fix(skills): correct SKILL.md validation failures in openrouter and relay-diagnostic

### DIFF
--- a/openrouter/SKILL.md
+++ b/openrouter/SKILL.md
@@ -4,12 +4,12 @@ description: "OpenRouter AI integration — list available models, get integrati
 metadata:
   author: "tfibtcagent"
   author-agent: "Secret Dome"
-  user-invocable: "true"
+  user-invocable: "false"
   arguments: "models | guide | chat"
   entry: "openrouter/openrouter.ts"
   mcp-tools: "openrouter_integration_guide, openrouter_models"
   requires: ""
-  tags: "ai, read-only"
+  tags: "read-only"
 ---
 
 # OpenRouter Skill

--- a/relay-diagnostic/SKILL.md
+++ b/relay-diagnostic/SKILL.md
@@ -9,7 +9,7 @@ metadata:
   entry: "relay-diagnostic/relay-diagnostic.ts"
   mcp-tools: "check_relay_health, recover_sponsor_nonce"
   requires: "wallet"
-  tags: "l2, diagnostic"
+  tags: "l2, infrastructure"
 ---
 
 # Relay Diagnostic Skill

--- a/skills.json
+++ b/skills.json
@@ -1,6 +1,6 @@
 {
   "version": "0.23.1",
-  "generated": "2026-03-16T16:45:48.341Z",
+  "generated": "2026-03-16T16:48:06.515Z",
   "skills": [
     {
       "name": "agent-lookup",
@@ -597,10 +597,9 @@
       ],
       "requires": [],
       "tags": [
-        "ai",
         "read-only"
       ],
-      "userInvocable": true,
+      "userInvocable": false,
       "author": "tfibtcagent",
       "authorAgent": "Secret Dome",
       "mcpTools": [
@@ -837,7 +836,7 @@
       ],
       "tags": [
         "l2",
-        "diagnostic"
+        "infrastructure"
       ],
       "userInvocable": false,
       "author": "tfibtcagent",


### PR DESCRIPTION
## Summary

Post-merge validation fixes found by `bun run validate`:

- **openrouter**: `user-invocable` was `"true"` (must always be `"false"` per CLAUDE.md — Claude Code invokes skills, not end users), and `tags` had invalid value `ai` (not in the allowed set)
- **relay-diagnostic**: `tags` had invalid value `diagnostic` (changed to `infrastructure`)

Both issues were introduced in the original PR submissions (#148 and #150).

## Changes

- `openrouter/SKILL.md`: Set `user-invocable: "false"`, changed tags to `read-only`
- `relay-diagnostic/SKILL.md`: Changed tag from `diagnostic` to `infrastructure`
- `skills.json`: Regenerated via `bun run manifest`

## Verification

```
bun run validate  # Results: 92 passed, 0 failed, 92 total
bun run typecheck # No errors
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)