### PR TITLE
fix(mempool-watch): update mcp-tools refs for renamed btc tools

### DIFF
--- a/mempool-watch/SKILL.md
+++ b/mempool-watch/SKILL.md
@@ -7,7 +7,7 @@ metadata:
   user-invocable: "false"
   arguments: "tx-status | address-history | mempool-stats"
   entry: "mempool-watch/mempool-watch.ts"
-  mcp-tools: "get_mempool_info, get_transaction_status"
+  mcp-tools: "get_btc_mempool_info, get_btc_transaction_status, get_btc_address_txs"
   requires: ""
   tags: "l1, read-only"
 ---

--- a/skills.json
+++ b/skills.json
@@ -1,6 +1,6 @@
 {
   "version": "0.23.1",
-  "generated": "2026-03-16T16:55:22.611Z",
+  "generated": "2026-03-16T17:46:33.892Z",
   "skills": [
     {
       "name": "agent-lookup",
@@ -497,8 +497,9 @@
       "author": "teflonbtc",
       "authorAgent": "Dual Cougar",
       "mcpTools": [
-        "get_mempool_info",
-        "get_transaction_status"
+        "get_btc_mempool_info",
+        "get_btc_transaction_status",
+        "get_btc_address_txs"
       ]
     },
     {


### PR DESCRIPTION
## Summary

- Updates `mempool-watch/SKILL.md` mcp-tools field to reflect renamed Bitcoin mempool tools in the upstream MCP server
- `get_mempool_info` → `get_btc_mempool_info`
- `get_transaction_status` → `get_btc_transaction_status`
- Adds `get_btc_address_txs` (renamed from `get_address_txs`, previously missing from the mapping)
- Regenerates `skills.json` manifest

## Context

The aibtc-mcp-server renamed three Bitcoin mempool tools to include the `btc_` prefix, fixing duplicate tool registration crashes. See aibtcdev/aibtc-mcp-server#321.

## Test plan

- [x] `bun run manifest` regenerates `skills.json` successfully
- [x] `bun run validate` passes all 94 frontmatter checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)