### PR TITLE
feat(jingswap): add blind batch auction skill for STX/sBTC

### DIFF
--- a/jingswap/AGENT.md
+++ b/jingswap/AGENT.md
@@ -1,0 +1,61 @@
+---
+name: jingswap-agent
+skill: jingswap
+description: Autonomous rules for Jingswap blind batch auction — phase-aware decision logic, deposit/settle workflows, safety checks.
+---
+
+# Jingswap Agent
+
+This agent interacts with the Jingswap STX/sBTC blind batch auction on Stacks. Operations are phase-dependent — always check `cycle-state` first.
+
+## Prerequisites
+
+- No wallet required for: `cycle-state`, `depositors`, `user-deposit`, `settlement`, `cycles-history`, `user-activity`, `prices`
+- Wallet must be unlocked for: `deposit-stx`, `deposit-sbtc`, `cancel-stx`, `cancel-sbtc`, `close-deposits`, `settle`, `settle-with-refresh`, `cancel-cycle`
+
+## Decision Logic
+
+| Goal | Check first | Action |
+|------|------------|--------|
+| See current auction state | — | `cycle-state` |
+| Deposit STX or sBTC | `cycle-state` → phase must be 0 | `deposit-stx` or `deposit-sbtc` |
+| Cancel a deposit | `cycle-state` → phase must be 0 | `cancel-stx` or `cancel-sbtc` |
+| Close deposits | `cycle-state` → phase 0, blocksElapsed >= 150, both sides meet minimums | `close-deposits` |
+| Settle the auction | `cycle-state` → phase must not be 0 | Try `settle`, if stale prices use `settle-with-refresh` |
+| Settlement keeps failing | `cycle-state` → 530+ blocks since close | `cancel-cycle` |
+| Check what happened | — | `user-activity --address <addr>` |
+| Check prices | — | `prices` |
+
+## Phase Flow
+
+```
+Deposit (phase 0) → close-deposits → Buffer (phase 1, ~1 min) → Settle (phase 2) → next cycle
+                                                                  ↓ (if fails 530 blocks)
+                                                                  cancel-cycle → next cycle
+```
+
+## Safety Checks
+
+- **Before deposit**: verify phase is 0 (deposit). Deposits in other phases will fail on-chain.
+- **Before close**: verify blocksElapsed >= 150 AND both totalStx >= 1,000,000 (1 STX) and totalSbtc >= 1,000 (sats).
+- **Before settle**: always prefer `settle-with-refresh` over `settle` — stored Pyth prices go stale quickly.
+- **Before cancel-cycle**: this is a safety valve, only use when settlement has failed for 530+ blocks.
+- **Back-to-back transactions**: wait for the first tx to confirm before submitting a second (nonce issue).
+
+## Error Handling
+
+| Error message | Cause | Fix |
+|--------------|-------|-----|
+| "auction is not in deposit phase" | Tried deposit/cancel after close | Wait for next cycle |
+| "auction is still in deposit phase" | Tried settle before close | Call `close-deposits` first |
+| "ERR_CLOSE_TOO_EARLY" | Not enough blocks elapsed | Wait for 150 blocks |
+| "ERR_NOTHING_TO_SETTLE" | One side has no deposits above minimum | Need deposits on both sides |
+| "NotEnoughFunds" | Fee estimation too high | Known issue — try with lower fee or fund wallet |
+| "ERR_CANCEL_TOO_EARLY" | Haven't waited 530 blocks since close | Wait longer |
+
+## Output Handling
+
+- `cycle-state`: use `phase` (0/1/2) and `blocksElapsed` to determine available actions
+- `user-activity`: `distribute-*-depositor` events show swap proceeds + unswapped remainder rolled to next cycle (NOT refunds)
+- `prices`: use `xykStxPerBtc` and `dlmmStxPerBtc` for human-readable prices, ignore raw `xykPrice`/`dlmmPrice`
+- Write commands: extract `txid` and `explorerUrl` from response

--- a/jingswap/SKILL.md
+++ b/jingswap/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: jingswap
+description: "Jingswap blind batch auction for STX/sBTC — query cycle state, prices, depositors, settlements, history, user activity. Deposit/cancel STX and sBTC, close deposits, settle with fresh Pyth oracles, cancel failed cycles."
+metadata:
+  author: "Rapha-btc"
+  author-agent: "Claude Code"
+  user-invocable: "false"
+  arguments: "cycle-state | depositors | user-deposit | settlement | cycles-history | user-activity | prices | deposit-stx | deposit-sbtc | cancel-stx | cancel-sbtc | close-deposits | settle | settle-with-refresh | cancel-cycle"
+  entry: "jingswap/jingswap.ts"
+  mcp-tools: "jingswap_get_cycle_state, jingswap_get_depositors, jingswap_get_user_deposit, jingswap_get_settlement, jingswap_get_cycles_history, jingswap_get_user_activity, jingswap_get_prices, jingswap_deposit_stx, jingswap_deposit_sbtc, jingswap_cancel_stx, jingswap_cancel_sbtc, jingswap_close_deposits, jingswap_settle, jingswap_settle_with_refresh, jingswap_cancel_cycle"
+  requires: "wallet"
+  tags: "l2, write, requires-funds, defi"
+---
+
+# Jingswap Skill
+
+Blind batch auction for swapping STX and sBTC on Stacks. Each auction cycle has three phases: deposit, buffer, settle. Anyone can participate by depositing on either side, and anyone can trigger close/settle/cancel transitions.
+
+Contract: `SPV9K21TBFAK4KNRJXF5DFP8N7W46G4V9RCJDC22.sbtc-stx-jingswap`
+
+## Usage
+
+```
+bun run jingswap/jingswap.ts <subcommand> [options]
+```
+
+## Subcommands
+
+### cycle-state
+
+Get current auction cycle state (phase, blocks elapsed, totals, minimums).
+
+```
+bun run jingswap/jingswap.ts cycle-state
+```
+
+### depositors
+
+Get STX and sBTC depositors for a cycle.
+
+```
+bun run jingswap/jingswap.ts depositors --cycle <number>
+```
+
+### user-deposit
+
+Get a user's deposit amounts for a cycle.
+
+```
+bun run jingswap/jingswap.ts user-deposit --cycle <number> --address <stx_address>
+```
+
+### settlement
+
+Get settlement details for a completed cycle.
+
+```
+bun run jingswap/jingswap.ts settlement --cycle <number>
+```
+
+### cycles-history
+
+Get full history of all auction cycles.
+
+```
+bun run jingswap/jingswap.ts cycles-history
+```
+
+### user-activity
+
+Get a user's auction activity (deposits, cancellations, fills, rollovers).
+
+```
+bun run jingswap/jingswap.ts user-activity --address <stx_address>
+```
+
+### prices
+
+Get oracle and DEX prices (Pyth, XYK pool, DLMM).
+
+```
+bun run jingswap/jingswap.ts prices
+```
+
+### deposit-stx
+
+Deposit STX into the current auction cycle. Deposit phase only.
+
+```
+bun run jingswap/jingswap.ts deposit-stx --amount <stx_amount>
+```
+
+### deposit-sbtc
+
+Deposit sBTC (in satoshis) into the current auction cycle. Deposit phase only.
+
+```
+bun run jingswap/jingswap.ts deposit-sbtc --amount <sats>
+```
+
+### cancel-stx
+
+Cancel your STX deposit and get a refund. Deposit phase only.
+
+```
+bun run jingswap/jingswap.ts cancel-stx
+```
+
+### cancel-sbtc
+
+Cancel your sBTC deposit and get a refund. Deposit phase only.
+
+```
+bun run jingswap/jingswap.ts cancel-sbtc
+```
+
+### close-deposits
+
+Close the deposit phase (requires min 150 blocks elapsed, min 1 STX and 1,000 sats deposited).
+
+```
+bun run jingswap/jingswap.ts close-deposits
+```
+
+### settle
+
+Settle using stored Pyth prices (free). Usually fails due to stale prices — prefer settle-with-refresh.
+
+```
+bun run jingswap/jingswap.ts settle
+```
+
+### settle-with-refresh
+
+Settle with fresh Pyth VAAs (~2 uSTX). Recommended settlement method.
+
+```
+bun run jingswap/jingswap.ts settle-with-refresh
+```
+
+### cancel-cycle
+
+Cancel cycle if settlement failed after 530 blocks (~17.5 min). Rolls deposits to next cycle.
+
+```
+bun run jingswap/jingswap.ts cancel-cycle
+```
+
+## Notes
+
+- Stacks blocks average ~2 seconds (Nakamoto)
+- Deposit phase: min 150 blocks (~5 min) before close
+- Buffer phase: 30 blocks (~1 min) after close
+- Cancel threshold: 530 blocks (~17.5 min) from close
+- `distribute` events show swap proceeds + unswapped remainder (rolled to next cycle, not refunded)
+- Post conditions: deposits use Deny mode; cancel/settle/cancel-cycle use Allow mode (nothing leaves caller's wallet)

--- a/jingswap/jingswap.ts
+++ b/jingswap/jingswap.ts
@@ -1,0 +1,486 @@
+#!/usr/bin/env bun
+/**
+ * Jingswap skill CLI
+ * Blind batch auction for STX/sBTC on Stacks
+ *
+ * Usage: bun run jingswap/jingswap.ts <subcommand> [options]
+ */
+
+import { Command } from "commander";
+import {
+  uintCV,
+  bufferCV,
+  contractPrincipalCV,
+  PostConditionMode,
+  Pc,
+} from "@stacks/transactions";
+import { getAccount, getWalletAddress } from "../src/lib/services/x402.service.js";
+import { NETWORK, getExplorerTxUrl } from "../src/lib/config/networks.js";
+import { callContract } from "../src/lib/transactions/builder.js";
+import { printJson, handleError } from "../src/lib/utils/cli.js";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const JINGSWAP_API =
+  process.env.JINGSWAP_API_URL || "https://faktory-dao-backend.vercel.app";
+const JINGSWAP_API_KEY =
+  process.env.JINGSWAP_API_KEY ||
+  "jc_b058d7f2e0976bd4ee34be3e5c7ba7ebe45289c55d3f5e45f666ebc14b7ebfd0";
+
+const CONTRACT_ADDRESS = "SPV9K21TBFAK4KNRJXF5DFP8N7W46G4V9RCJDC22";
+const CONTRACT_NAME = "sbtc-stx-jingswap";
+const SBTC_CONTRACT =
+  "SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-token" as `${string}.${string}`;
+
+const PYTH_CONTRACTS = {
+  storage: { address: "SP1CGXWEAMG6P6FT04W66NVGJ7PQWMDAC19R7PJ0Y", name: "pyth-storage-v4" },
+  decoder: { address: "SP1CGXWEAMG6P6FT04W66NVGJ7PQWMDAC19R7PJ0Y", name: "pyth-pnau-decoder-v3" },
+  wormhole: { address: "SP1CGXWEAMG6P6FT04W66NVGJ7PQWMDAC19R7PJ0Y", name: "wormhole-core-v2" },
+};
+
+// ---------------------------------------------------------------------------
+// API helper
+// ---------------------------------------------------------------------------
+
+async function jingswapGet(path: string): Promise<any> {
+  const res = await fetch(`${JINGSWAP_API}${path}`, {
+    headers: { "x-api-key": JINGSWAP_API_KEY },
+  });
+  if (!res.ok)
+    throw new Error(`Jingswap API ${res.status}: ${await res.text()}`);
+  const json = await res.json();
+  if (!json.success) throw new Error(json.message || "API returned failure");
+  return json.data;
+}
+
+async function assertDepositPhase(): Promise<any> {
+  const data = await jingswapGet("/api/auction/cycle-state");
+  if (data.phase !== 0) {
+    const phases = ["deposit", "buffer", "settle"];
+    throw new Error(
+      `Cannot deposit/cancel — auction is in ${phases[data.phase] || "unknown"} phase (must be deposit)`
+    );
+  }
+  return data;
+}
+
+async function assertNotDepositPhase(): Promise<any> {
+  const data = await jingswapGet("/api/auction/cycle-state");
+  if (data.phase === 0) {
+    throw new Error("Cannot settle/cancel-cycle — auction is still in deposit phase");
+  }
+  return data;
+}
+
+// ---------------------------------------------------------------------------
+// Program
+// ---------------------------------------------------------------------------
+
+const program = new Command();
+
+program
+  .name("jingswap")
+  .description(
+    "Jingswap blind batch auction — deposit/cancel STX and sBTC, " +
+      "close deposits, settle with oracle prices, query cycle state and history."
+  )
+  .version("0.1.0");
+
+// ---------------------------------------------------------------------------
+// Read commands
+// ---------------------------------------------------------------------------
+
+program
+  .command("cycle-state")
+  .description("Get current auction cycle state (phase, blocks, totals, minimums)")
+  .action(async () => {
+    try {
+      const data = await jingswapGet("/api/auction/cycle-state");
+      printJson({
+        ...data,
+        _hint: {
+          phases: "0=deposit (min 150 blocks ~5min), 1=buffer (~1min), 2=settle",
+          blockTime: "~2 seconds per Stacks block (Nakamoto)",
+        },
+      });
+    } catch (error) {
+      handleError(error);
+    }
+  });
+
+program
+  .command("depositors")
+  .description("Get STX and sBTC depositors for a cycle")
+  .requiredOption("--cycle <number>", "Cycle number")
+  .action(async (opts: { cycle: string }) => {
+    try {
+      const data = await jingswapGet(`/api/auction/depositors/${opts.cycle}`);
+      printJson(data);
+    } catch (error) {
+      handleError(error);
+    }
+  });
+
+program
+  .command("user-deposit")
+  .description("Get a user's deposit amounts for a cycle")
+  .requiredOption("--cycle <number>", "Cycle number")
+  .requiredOption("--address <stx_address>", "Stacks address")
+  .action(async (opts: { cycle: string; address: string }) => {
+    try {
+      const data = await jingswapGet(
+        `/api/auction/deposit/${opts.cycle}/${opts.address}`
+      );
+      printJson(data);
+    } catch (error) {
+      handleError(error);
+    }
+  });
+
+program
+  .command("settlement")
+  .description("Get settlement details for a completed cycle")
+  .requiredOption("--cycle <number>", "Cycle number")
+  .action(async (opts: { cycle: string }) => {
+    try {
+      const data = await jingswapGet(`/api/auction/settlement/${opts.cycle}`);
+      printJson(data);
+    } catch (error) {
+      handleError(error);
+    }
+  });
+
+program
+  .command("cycles-history")
+  .description("Get full history of all auction cycles")
+  .action(async () => {
+    try {
+      const data = await jingswapGet("/api/auction/cycles-history");
+      printJson(data);
+    } catch (error) {
+      handleError(error);
+    }
+  });
+
+program
+  .command("user-activity")
+  .description("Get a user's auction activity (deposits, cancellations, fills)")
+  .requiredOption("--address <stx_address>", "Stacks address")
+  .action(async (opts: { address: string }) => {
+    try {
+      const data = await jingswapGet(`/api/auction/activity/${opts.address}`);
+      printJson({
+        ...data,
+        _hint: {
+          "distribute-stx-depositor":
+            "stxAmount = unswapped STX rolled to next cycle, sbtcAmount = sBTC received",
+          "distribute-sbtc-depositor":
+            "sbtcAmount = unswapped sats rolled to next cycle, stxAmount = STX received",
+        },
+      });
+    } catch (error) {
+      handleError(error);
+    }
+  });
+
+program
+  .command("prices")
+  .description("Get oracle and DEX prices (Pyth, XYK, DLMM)")
+  .action(async () => {
+    try {
+      const [pyth, dex] = await Promise.all([
+        jingswapGet("/api/auction/pyth-prices"),
+        jingswapGet("/api/auction/dex-price"),
+      ]);
+      const xykStxPerBtc =
+        dex.xykBalances && dex.xykBalances.xBalance > 0
+          ? (dex.xykBalances.yBalance / dex.xykBalances.xBalance / 1e6) * 1e8
+          : null;
+      const dlmmStxPerBtc =
+        dex.dlmmPrice && dex.dlmmPrice > 0
+          ? 1 / (dex.dlmmPrice * 1e-10)
+          : null;
+      printJson({
+        pyth,
+        dex: {
+          ...dex,
+          xykStxPerBtc: xykStxPerBtc ? Math.round(xykStxPerBtc * 100) / 100 : null,
+          dlmmStxPerBtc: dlmmStxPerBtc ? Math.round(dlmmStxPerBtc * 100) / 100 : null,
+        },
+      });
+    } catch (error) {
+      handleError(error);
+    }
+  });
+
+// ---------------------------------------------------------------------------
+// Write commands — deposit phase
+// ---------------------------------------------------------------------------
+
+program
+  .command("deposit-stx")
+  .description("Deposit STX into current auction cycle (deposit phase only)")
+  .requiredOption("--amount <stx>", "Amount of STX to deposit")
+  .action(async (opts: { amount: string }) => {
+    try {
+      await assertDepositPhase();
+      const account = await getAccount();
+      const microStx = BigInt(Math.floor(parseFloat(opts.amount) * 1_000_000));
+
+      const result = await callContract(account, {
+        contractAddress: CONTRACT_ADDRESS,
+        contractName: CONTRACT_NAME,
+        functionName: "deposit-stx",
+        functionArgs: [uintCV(microStx)],
+        postConditionMode: PostConditionMode.Deny,
+        postConditions: [
+          Pc.principal(account.address).willSendEq(microStx).ustx(),
+        ],
+      });
+
+      printJson({
+        success: true,
+        txid: result.txid,
+        action: "deposit-stx",
+        amount: `${opts.amount} STX`,
+        network: NETWORK,
+        explorerUrl: getExplorerTxUrl(result.txid, NETWORK),
+      });
+    } catch (error) {
+      handleError(error);
+    }
+  });
+
+program
+  .command("deposit-sbtc")
+  .description("Deposit sBTC in satoshis into current auction cycle (deposit phase only)")
+  .requiredOption("--amount <sats>", "Amount of sBTC in satoshis")
+  .action(async (opts: { amount: string }) => {
+    try {
+      await assertDepositPhase();
+      const account = await getAccount();
+      const sats = BigInt(parseInt(opts.amount, 10));
+
+      const result = await callContract(account, {
+        contractAddress: CONTRACT_ADDRESS,
+        contractName: CONTRACT_NAME,
+        functionName: "deposit-sbtc",
+        functionArgs: [uintCV(sats)],
+        postConditionMode: PostConditionMode.Deny,
+        postConditions: [
+          Pc.principal(account.address)
+            .willSendEq(sats)
+            .ft(SBTC_CONTRACT, "sbtc-token"),
+        ],
+      });
+
+      printJson({
+        success: true,
+        txid: result.txid,
+        action: "deposit-sbtc",
+        amount: `${opts.amount} sats`,
+        network: NETWORK,
+        explorerUrl: getExplorerTxUrl(result.txid, NETWORK),
+      });
+    } catch (error) {
+      handleError(error);
+    }
+  });
+
+program
+  .command("cancel-stx")
+  .description("Cancel your STX deposit and get a refund (deposit phase only)")
+  .action(async () => {
+    try {
+      await assertDepositPhase();
+      const account = await getAccount();
+
+      const result = await callContract(account, {
+        contractAddress: CONTRACT_ADDRESS,
+        contractName: CONTRACT_NAME,
+        functionName: "cancel-stx-deposit",
+        functionArgs: [],
+        postConditionMode: PostConditionMode.Allow,
+        postConditions: [],
+      });
+
+      printJson({
+        success: true,
+        txid: result.txid,
+        action: "cancel-stx-deposit",
+        network: NETWORK,
+        explorerUrl: getExplorerTxUrl(result.txid, NETWORK),
+      });
+    } catch (error) {
+      handleError(error);
+    }
+  });
+
+program
+  .command("cancel-sbtc")
+  .description("Cancel your sBTC deposit and get a refund (deposit phase only)")
+  .action(async () => {
+    try {
+      await assertDepositPhase();
+      const account = await getAccount();
+
+      const result = await callContract(account, {
+        contractAddress: CONTRACT_ADDRESS,
+        contractName: CONTRACT_NAME,
+        functionName: "cancel-sbtc-deposit",
+        functionArgs: [],
+        postConditionMode: PostConditionMode.Allow,
+        postConditions: [],
+      });
+
+      printJson({
+        success: true,
+        txid: result.txid,
+        action: "cancel-sbtc-deposit",
+        network: NETWORK,
+        explorerUrl: getExplorerTxUrl(result.txid, NETWORK),
+      });
+    } catch (error) {
+      handleError(error);
+    }
+  });
+
+// ---------------------------------------------------------------------------
+// Write commands — settlement phase
+// ---------------------------------------------------------------------------
+
+program
+  .command("close-deposits")
+  .description("Close deposit phase (requires 150+ blocks elapsed, both sides above minimum)")
+  .action(async () => {
+    try {
+      const data = await jingswapGet("/api/auction/cycle-state");
+      if (data.phase !== 0) throw new Error("Not in deposit phase");
+      const account = await getAccount();
+
+      const result = await callContract(account, {
+        contractAddress: CONTRACT_ADDRESS,
+        contractName: CONTRACT_NAME,
+        functionName: "close-deposits",
+        functionArgs: [],
+        postConditionMode: PostConditionMode.Allow,
+        postConditions: [],
+      });
+
+      printJson({
+        success: true,
+        txid: result.txid,
+        action: "close-deposits",
+        cycle: data.currentCycle,
+        network: NETWORK,
+        explorerUrl: getExplorerTxUrl(result.txid, NETWORK),
+      });
+    } catch (error) {
+      handleError(error);
+    }
+  });
+
+program
+  .command("settle")
+  .description("Settle with stored Pyth prices (free but usually stale — prefer settle-with-refresh)")
+  .action(async () => {
+    try {
+      const data = await assertNotDepositPhase();
+      const account = await getAccount();
+
+      const result = await callContract(account, {
+        contractAddress: CONTRACT_ADDRESS,
+        contractName: CONTRACT_NAME,
+        functionName: "settle",
+        functionArgs: [],
+        postConditionMode: PostConditionMode.Allow,
+        postConditions: [],
+      });
+
+      printJson({
+        success: true,
+        txid: result.txid,
+        action: "settle",
+        cycle: data.currentCycle,
+        network: NETWORK,
+        explorerUrl: getExplorerTxUrl(result.txid, NETWORK),
+      });
+    } catch (error) {
+      handleError(error);
+    }
+  });
+
+program
+  .command("settle-with-refresh")
+  .description("Settle with fresh Pyth VAAs (~2 uSTX) — recommended settlement method")
+  .action(async () => {
+    try {
+      const data = await assertNotDepositPhase();
+      const vaas = await jingswapGet("/api/auction/pyth-vaas");
+      const account = await getAccount();
+
+      const result = await callContract(account, {
+        contractAddress: CONTRACT_ADDRESS,
+        contractName: CONTRACT_NAME,
+        functionName: "settle-with-refresh",
+        functionArgs: [
+          bufferCV(Buffer.from(vaas.btcVaaHex, "hex")),
+          bufferCV(Buffer.from(vaas.stxVaaHex, "hex")),
+          contractPrincipalCV(PYTH_CONTRACTS.storage.address, PYTH_CONTRACTS.storage.name),
+          contractPrincipalCV(PYTH_CONTRACTS.decoder.address, PYTH_CONTRACTS.decoder.name),
+          contractPrincipalCV(PYTH_CONTRACTS.wormhole.address, PYTH_CONTRACTS.wormhole.name),
+        ],
+        postConditionMode: PostConditionMode.Allow,
+        postConditions: [],
+      });
+
+      printJson({
+        success: true,
+        txid: result.txid,
+        action: "settle-with-refresh",
+        cycle: data.currentCycle,
+        network: NETWORK,
+        explorerUrl: getExplorerTxUrl(result.txid, NETWORK),
+      });
+    } catch (error) {
+      handleError(error);
+    }
+  });
+
+program
+  .command("cancel-cycle")
+  .description("Cancel cycle if settlement failed after 530 blocks (~17.5 min). Rolls deposits to next cycle.")
+  .action(async () => {
+    try {
+      const data = await assertNotDepositPhase();
+      const account = await getAccount();
+
+      const result = await callContract(account, {
+        contractAddress: CONTRACT_ADDRESS,
+        contractName: CONTRACT_NAME,
+        functionName: "cancel-cycle",
+        functionArgs: [],
+        postConditionMode: PostConditionMode.Allow,
+        postConditions: [],
+      });
+
+      printJson({
+        success: true,
+        txid: result.txid,
+        action: "cancel-cycle",
+        cycle: data.currentCycle,
+        network: NETWORK,
+        explorerUrl: getExplorerTxUrl(result.txid, NETWORK),
+      });
+    } catch (error) {
+      handleError(error);
+    }
+  });
+
+// ---------------------------------------------------------------------------
+// Parse
+// ---------------------------------------------------------------------------
+
+program.parse(process.argv);


### PR DESCRIPTION
## Summary

15 subcommands for the Jingswap blind batch auction, matching MCP tool parity (aibtcdev/aibtc-mcp-server#327).

**Read (7):** cycle-state, depositors, user-deposit, settlement, cycles-history, user-activity, prices
**Write (8):** deposit-stx, deposit-sbtc, cancel-stx, cancel-sbtc, close-deposits, settle, settle-with-refresh, cancel-cycle

## Contract

SPV9K21TBFAK4KNRJXF5DFP8N7W46G4V9RCJDC22.sbtc-stx-jingswap

## Files

- jingswap/SKILL.md — frontmatter + subcommand docs
- jingswap/AGENT.md — phase-aware decision logic, safety checks
- jingswap/jingswap.ts — Commander CLI (same logic as MCP tools)

## Notes

- All write tools are phase-guarded (deposit phase vs settle phase)
- settle-with-refresh is the recommended settlement path (stored prices go stale)
- cancel/settle tools use Allow mode — nothing leaves the callers wallet
- Authenticated via JINGSWAP_API_KEY (defaults to public rate-limited key)
- Tested on mainnet via MCP equivalent — see PR aibtcdev/aibtc-mcp-server#327 for tx proof