### PR TITLE
feat(skills): add jingswap to skills.json manifest

### DIFF
--- a/skills.json
+++ b/skills.json
@@ -1,6 +1,6 @@
 {
-  "version": "0.23.1",
-  "generated": "2026-03-16T17:46:33.892Z",
+  "version": "0.25.0",
+  "generated": "2026-03-17T23:06:52.309Z",
   "skills": [
     {
       "name": "agent-lookup",
@@ -502,6 +502,57 @@
       "authorAgent": "T-FI",
       "mcpTools": [
         "send_inbox_message"
+      ]
+    },
+    {
+      "name": "jingswap",
+      "description": "Jingswap blind batch auction — supports sbtc-stx and sbtc-usdcx markets. Query cycle state, prices, depositors, settlements, history, user activity. Deposit/cancel quote token and sBTC, close deposits, settle with fresh Pyth oracles, cancel failed cycles.",
+      "entry": "jingswap/jingswap.ts",
+      "arguments": [
+        "cycle-state",
+        "depositors",
+        "user-deposit",
+        "settlement",
+        "cycles-history",
+        "user-activity",
+        "prices",
+        "deposit-stx",
+        "deposit-sbtc",
+        "cancel-stx",
+        "cancel-sbtc",
+        "close-deposits",
+        "settle",
+        "settle-with-refresh",
+        "cancel-cycle"
+      ],
+      "requires": [
+        "wallet"
+      ],
+      "tags": [
+        "l2",
+        "write",
+        "requires-funds",
+        "defi"
+      ],
+      "userInvocable": false,
+      "author": "Rapha-btc",
+      "authorAgent": "Claude Code",
+      "mcpTools": [
+        "jingswap_get_cycle_state",
+        "jingswap_get_depositors",
+        "jingswap_get_user_deposit",
+        "jingswap_get_settlement",
+        "jingswap_get_cycles_history",
+        "jingswap_get_user_activity",
+        "jingswap_get_prices",
+        "jingswap_deposit_stx",
+        "jingswap_deposit_sbtc",
+        "jingswap_cancel_stx",
+        "jingswap_cancel_sbtc",
+        "jingswap_close_deposits",
+        "jingswap_settle",
+        "jingswap_settle_with_refresh",
+        "jingswap_cancel_cycle"
       ]
     },
     {


### PR DESCRIPTION
## Summary

- Regenerates `skills.json` to include the `jingswap` skill (added in skills-v0.25.0 but missing from manifest)
- Bumps manifest version from `0.23.1` to `0.25.0`
- Jingswap entry includes multi-market description (sbtc-stx and sbtc-usdcx markets)
- Generated via `bun run manifest` — fully passes the manifest freshness CI check

## Notes

This is a regenerated version of PR #165. The original PR had a hand-crafted manifest that
was missing the `inbox` skill entry (the CI's freshness check detected the discrepancy).
This PR uses the `generate-manifest.ts` script on the current main (which includes jingswap
multi-market support from PR #166).

Closes #165

🤖 Generated with [Claude Code](https://claude.com/claude-code)