### PR TITLE
feat(maximumsats-wot): add MaximumSats Web of Trust skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Each skill is a self-contained directory with a `SKILL.md` (used by Claude Code 
 | [taproot-multisig](./taproot-multisig/) | `taproot-multisig/taproot-multisig.ts` | Bitcoin Taproot M-of-N multisig coordination — share x-only pubkeys, verify co-signer Schnorr signatures, and navigate the OP_CHECKSIGADD workflow. Proven on mainnet: 2-of-2 (block 937,849) and 3-of-3 (block 938,206). |
 | [onboarding](./onboarding/) | `onboarding/onboarding.ts` | First-hour AIBTC onboarding automation — doctor checks, registration/heartbeat helpers, curated skill-pack installs, and non-blocking community guidance. |
 | [agent-lookup](./agent-lookup/) | `agent-lookup/agent-lookup.ts` | AIBTC agent registry queries — look up agents by address or name, view network-wide stats, and rank agents by check-ins, achievements, or level. |
+| [maximumsats-wot](./maximumsats-wot/) | `maximumsats-wot/maximumsats-wot.ts` | MaximumSats Web of Trust — query Nostr WoT trust scores for counterparty risk assessment. 52K+ pubkeys, 2.4M+ trust edges, zap-weighted scores. 100 sats per lookup via L402. |
 
 ## Workflow Discovery (what-to-do/)
 

--- a/maximumsats-wot/AGENT.md
+++ b/maximumsats-wot/AGENT.md
@@ -1,0 +1,72 @@
+---
+name: maximumsats-wot-agent
+skill: maximumsats-wot
+description: MaximumSats Web of Trust — query Nostr WoT trust scores for counterparty risk assessment before on-chain interactions.
+---
+
+# MaximumSats WoT — Agent Instructions
+
+## Purpose
+
+Use this skill to assess counterparty trust before on-chain interactions (payments, DeFi, contract calls). Check a Nostr pubkey's WoT rank to detect sybil accounts, new accounts with no history, or low-trust actors.
+
+## Prerequisites
+
+- No wallet required for `check` (pubkey/npub lookup)
+- Unlocked wallet required for `check-agent` (self-lookup via BTC-shared derivation)
+- L402 Lightning payment capability required for live API calls (100 sats per request)
+- Without L402, the API returns HTTP 402 and the skill surfaces a clear error
+
+## Decision Logic
+
+```
+Before transacting with a counterparty:
+  1. Obtain their Nostr pubkey (npub or hex)
+  2. Run: bun run maximumsats-wot/maximumsats-wot.ts check --npub <npub>
+  3. If trusted: true → proceed
+  4. If trusted: false → investigate reason before proceeding
+     - reason: "Not in top 100" → high bar; consider --require-top100 config
+     - reason: "Rank exceeds minRank" → adjust threshold or decline
+  5. If L402 error → cache miss; requires Lightning payment; note and proceed with caution
+```
+
+## Safety Checks
+
+- **Never bypass L402 errors silently** — surface them to the caller
+- **Cache is 1 hour TTL** — trust scores are relatively stable; re-check on long-lived engagements
+- **WoT is Nostr-specific** — a pubkey with no Nostr activity may be trustworthy off-Nostr; use as one signal among many
+- **Config thresholds are tuneable** — defaults (minRank=10000, requireTop100=false) are conservative for general use
+
+## Error Handling
+
+| Error | Action |
+|-------|--------|
+| `L402 payment required` | Log, note payment needed, surface to caller |
+| `Invalid npub` | Validate input format before calling |
+| `API error 5xx` | Retry once; if fails, surface error |
+| `Wallet not unlocked` | Run `bun run wallet/wallet.ts unlock` first |
+
+## Integration Pattern
+
+```typescript
+// Before a payment or trade, check counterparty trust
+const result = JSON.parse(
+  await $`bun run maximumsats-wot/maximumsats-wot.ts check --npub ${counterpartyNpub}`
+);
+
+if (!result.success) {
+  // Handle L402 or API error — proceed with caution
+  console.warn("WoT check failed:", result.error);
+} else if (!result.trusted) {
+  // Low-trust counterparty
+  console.warn(`Low trust: ${result.reason} (rank: ${result.rank})`);
+  // Decision: decline, require escrow, or proceed with reduced exposure
+} else {
+  // Trusted — proceed
+  console.log(`Trusted counterparty (rank: ${result.rank})`);
+}
+```
+
+## Cache Management
+
+Results are cached at `~/.aibtc/maximumsats-cache.json` with a 1-hour TTL. Use `cache-status` to inspect. Expired entries are pruned on each write. No manual cache clearing is needed.

--- a/maximumsats-wot/SKILL.md
+++ b/maximumsats-wot/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: maximumsats-wot
+description: "MaximumSats Web of Trust — query Nostr trust scores for counterparty risk assessment. 52K+ pubkeys, 2.4M+ trust edges. Scores are weighted by zap receipts. Payment: 100 sats via L402 per lookup."
+metadata:
+  author: "joelklabo"
+  author-agent: "SATMAX Agent"
+  user-invocable: "false"
+  arguments: "check | check-agent | config | cache-status"
+  entry: "maximumsats-wot/maximumsats-wot.ts"
+  requires: ""
+  tags: "read-only"
+---
+
+# MaximumSats Web of Trust Skill
+
+Pre-transaction counterparty risk assessment using MaximumSats Web of Trust scores. Check a Nostr pubkey's trust rank before committing to on-chain interactions.
+
+- **52K+ pubkeys** indexed with **2.4M+ trust edges**
+- Scores weighted by zap receipts (economic signal, harder to fake)
+- Sybil-resistant: high-rank requires real economic activity on Nostr
+- 100 sats per lookup via L402 Lightning payment
+
+## Usage
+
+```
+bun run maximumsats-wot/maximumsats-wot.ts <subcommand> [options]
+```
+
+## Subcommands
+
+### check
+
+Look up WoT trust score for a Nostr pubkey. Accepts hex pubkey or `npub1...` bech32.
+
+```bash
+bun run maximumsats-wot/maximumsats-wot.ts check --npub npub1abc...
+bun run maximumsats-wot/maximumsats-wot.ts check --pubkey 2b4603d2...
+```
+
+Output:
+```json
+{
+  "success": true,
+  "cached": false,
+  "pubkey": "2b4603d2...",
+  "trusted": true,
+  "rank": 142,
+  "in_top_100": false,
+  "thresholds": { "minRank": 10000, "requireTop100": false },
+  "report": "...",
+  "graph": { "nodes": 52000, "edges": 2400000 }
+}
+```
+
+**Note:** The API requires a 100-sat L402 Lightning payment per request. Without an L402 client, the API returns HTTP 402.
+
+### check-agent
+
+Derive a Nostr pubkey from a wallet's BIP84 path and look up its WoT score. Requires an unlocked wallet (uses BTC-shared derivation path `m/84'/0'/0'/0/0`).
+
+```bash
+bun run maximumsats-wot/maximumsats-wot.ts check-agent
+```
+
+Output: Same as `check` with an additional `derivationPath` field.
+
+### config
+
+View or update trust thresholds. Thresholds are stored at `~/.aibtc/maximumsats-config.json`.
+
+```bash
+bun run maximumsats-wot/maximumsats-wot.ts config                # view current config
+bun run maximumsats-wot/maximumsats-wot.ts config --min-rank 5000
+bun run maximumsats-wot/maximumsats-wot.ts config --require-top100
+bun run maximumsats-wot/maximumsats-wot.ts config --no-require-top100
+```
+
+Threshold fields:
+- `minRank` — Maximum acceptable rank (lower number = more trusted). Default: `10000`
+- `requireTop100` — If `true`, reject any pubkey not in top 100. Default: `false`
+
+### cache-status
+
+Show in-memory cache statistics. Results are cached for 1 hour to avoid redundant L402 payments.
+
+```bash
+bun run maximumsats-wot/maximumsats-wot.ts cache-status
+```
+
+## API Details
+
+**Endpoint:** `POST https://maximumsats.com/api/wot-report`
+**Payment:** 100 sats via L402 (Lightning Network)
+**Request body:** `{"pubkey": "<64-char hex>"}`
+**Response:** `{pubkey, rank, position, in_top_100, report, graph: {nodes, edges}}`
+
+No API key needed. Payment is per-request via L402 protocol.
+
+## Trust Thresholds
+
+| Rank | Meaning |
+|------|---------|
+| 1–100 | Elite (top 100 Nostr users by WoT) |
+| 101–1000 | Well-connected, high economic activity |
+| 1001–10000 | Active community member |
+| >10000 | Low trust, new account, or no Nostr activity |
+
+Use `config --min-rank <n>` to tune the threshold for your risk tolerance.
+
+## Key Derivation (check-agent)
+
+Uses BTC-shared path: `BIP39 mnemonic → BIP32 seed → m/84'/0'/0'/0/0 → secp256k1 private key → x-only pubkey (Nostr)`
+
+This is the same path used by the `nostr` skill — agents get a shared Nostr identity from their BTC wallet.

--- a/maximumsats-wot/maximumsats-wot.ts
+++ b/maximumsats-wot/maximumsats-wot.ts
@@ -1,0 +1,401 @@
+#!/usr/bin/env bun
+/**
+ * MaximumSats Web of Trust skill CLI
+ * Nostr WoT trust scoring for counterparty risk assessment.
+ * API: POST https://maximumsats.com/api/wot-report (100 sats via L402)
+ *
+ * Usage: bun run maximumsats-wot/maximumsats-wot.ts <subcommand> [options]
+ */
+
+import { Command } from "commander";
+import fs from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import { secp256k1 } from "@noble/curves/secp256k1";
+import { printJson, handleError } from "../src/lib/utils/cli.js";
+import { getWalletManager } from "../src/lib/services/wallet-manager.js";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const WOT_API_URL = "https://maximumsats.com/api/wot-report";
+const CONFIG_DIR = path.join(os.homedir(), ".aibtc");
+const CACHE_FILE = path.join(CONFIG_DIR, "maximumsats-cache.json");
+const CONFIG_FILE = path.join(CONFIG_DIR, "maximumsats-config.json");
+const CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface WotReport {
+  pubkey: string;
+  rank: number;
+  position: number;
+  in_top_100: boolean;
+  report: string;
+  graph: { nodes: number; edges: number };
+}
+
+interface CacheEntry {
+  data: WotReport;
+  fetchedAt: number;
+}
+
+interface WotCache {
+  [hexPubkey: string]: CacheEntry;
+}
+
+interface WotConfig {
+  minRank: number;
+  requireTop100: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Config helpers
+// ---------------------------------------------------------------------------
+
+async function loadConfig(): Promise<WotConfig> {
+  try {
+    const raw = await fs.readFile(CONFIG_FILE, "utf-8");
+    return JSON.parse(raw) as WotConfig;
+  } catch {
+    return { minRank: 10000, requireTop100: false };
+  }
+}
+
+async function saveConfig(config: WotConfig): Promise<void> {
+  await fs.mkdir(CONFIG_DIR, { recursive: true });
+  await fs.writeFile(CONFIG_FILE, JSON.stringify(config, null, 2));
+}
+
+// ---------------------------------------------------------------------------
+// Cache helpers
+// ---------------------------------------------------------------------------
+
+async function loadCache(): Promise<WotCache> {
+  try {
+    const raw = await fs.readFile(CACHE_FILE, "utf-8");
+    return JSON.parse(raw) as WotCache;
+  } catch {
+    return {};
+  }
+}
+
+async function saveCache(cache: WotCache): Promise<void> {
+  await fs.mkdir(CONFIG_DIR, { recursive: true });
+  await fs.writeFile(CACHE_FILE, JSON.stringify(cache, null, 2));
+}
+
+async function getCached(hexPubkey: string): Promise<WotReport | null> {
+  const cache = await loadCache();
+  const entry = cache[hexPubkey];
+  if (!entry) return null;
+  if (Date.now() - entry.fetchedAt > CACHE_TTL_MS) return null;
+  return entry.data;
+}
+
+async function setCache(hexPubkey: string, data: WotReport): Promise<void> {
+  const cache = await loadCache();
+  cache[hexPubkey] = { data, fetchedAt: Date.now() };
+  // Prune expired entries
+  const now = Date.now();
+  for (const key of Object.keys(cache)) {
+    if (now - cache[key].fetchedAt > CACHE_TTL_MS) {
+      delete cache[key];
+    }
+  }
+  await saveCache(cache);
+}
+
+// ---------------------------------------------------------------------------
+// Pubkey helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Convert npub (bech32) to hex pubkey.
+ * npub is bech32-encoded with HRP "npub" containing a 32-byte x-only pubkey.
+ */
+function npubToHex(npub: string): string {
+  if (!npub.startsWith("npub1")) {
+    throw new Error('Invalid npub: must start with "npub1"');
+  }
+  const CHARSET = "qpzry9x8gf2tvdw0s3jn54khce6mua7l";
+  const data = npub.slice(5); // remove "npub1"
+
+  // Decode bech32 to 5-bit words
+  const words: number[] = [];
+  for (const c of data) {
+    const idx = CHARSET.indexOf(c);
+    if (idx === -1) throw new Error(`Invalid bech32 character: ${c}`);
+    words.push(idx);
+  }
+
+  // Remove checksum (last 6 words), convert 5-bit to 8-bit
+  const payload = words.slice(0, -6);
+  let acc = 0;
+  let bits = 0;
+  const bytes: number[] = [];
+  for (const word of payload) {
+    acc = (acc << 5) | word;
+    bits += 5;
+    while (bits >= 8) {
+      bits -= 8;
+      bytes.push((acc >> bits) & 0xff);
+    }
+  }
+
+  if (bytes.length !== 32) {
+    throw new Error(`Invalid npub: expected 32 bytes, got ${bytes.length}`);
+  }
+  return bytes.map((b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+/** Resolve npub bech32 or hex pubkey to lowercase hex. */
+function resolveHexPubkey(input: string): string {
+  if (input.startsWith("npub1")) {
+    return npubToHex(input);
+  }
+  if (!/^[0-9a-f]{64}$/i.test(input)) {
+    throw new Error("Invalid pubkey: expected 64-char hex or npub1... bech32");
+  }
+  return input.toLowerCase();
+}
+
+// ---------------------------------------------------------------------------
+// API
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetch WoT report from MaximumSats API.
+ * Requires L402 Lightning payment (100 sats) — returns HTTP 402 without payment.
+ */
+async function fetchWotReport(hexPubkey: string): Promise<WotReport> {
+  const response = await fetch(WOT_API_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ pubkey: hexPubkey }),
+  });
+
+  if (response.status === 402) {
+    const wwwAuth = response.headers.get("www-authenticate") ?? "";
+    throw new Error(
+      `L402 payment required (100 sats via Lightning). ` +
+        `An L402 client is needed to pay for this request. ` +
+        `WWW-Authenticate: ${wwwAuth.substring(0, 200)}`
+    );
+  }
+
+  if (!response.ok) {
+    const body = await response.text().catch(() => "");
+    throw new Error(`API error ${response.status}: ${body.substring(0, 500)}`);
+  }
+
+  return (await response.json()) as WotReport;
+}
+
+// ---------------------------------------------------------------------------
+// Threshold check
+// ---------------------------------------------------------------------------
+
+function checkThresholds(
+  report: WotReport,
+  config: WotConfig
+): { trusted: boolean; reason?: string; rank: number; in_top_100: boolean; thresholds: WotConfig } {
+  if (config.requireTop100 && !report.in_top_100) {
+    return {
+      trusted: false,
+      reason: `Not in top 100 (rank: ${report.rank})`,
+      rank: report.rank,
+      in_top_100: report.in_top_100,
+      thresholds: config,
+    };
+  }
+  if (report.rank > config.minRank) {
+    return {
+      trusted: false,
+      reason: `Rank ${report.rank} exceeds minRank threshold ${config.minRank}`,
+      rank: report.rank,
+      in_top_100: report.in_top_100,
+      thresholds: config,
+    };
+  }
+  return {
+    trusted: true,
+    rank: report.rank,
+    in_top_100: report.in_top_100,
+    thresholds: config,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Program
+// ---------------------------------------------------------------------------
+
+const program = new Command()
+  .name("maximumsats-wot")
+  .description("MaximumSats Web of Trust — Nostr trust scoring for counterparty risk assessment")
+  .version("1.0.0");
+
+program
+  .command("check")
+  .description("Look up WoT trust score for a Nostr pubkey (hex or npub)")
+  .option("--npub <npub>", "Nostr npub bech32 (npub1...)")
+  .option("--pubkey <hex>", "Nostr pubkey (64-char hex)")
+  .action(async (options: { npub?: string; pubkey?: string }) => {
+    try {
+      const input = options.npub ?? options.pubkey;
+      if (!input) {
+        throw new Error("Either --npub or --pubkey is required");
+      }
+
+      const hexPubkey = resolveHexPubkey(input);
+
+      const cached = await getCached(hexPubkey);
+      if (cached) {
+        const config = await loadConfig();
+        const threshold = checkThresholds(cached, config);
+        printJson({
+          success: true,
+          cached: true,
+          pubkey: hexPubkey,
+          ...threshold,
+          report: cached.report,
+          graph: cached.graph,
+        });
+        return;
+      }
+
+      const report = await fetchWotReport(hexPubkey);
+      await setCache(hexPubkey, report);
+      const config = await loadConfig();
+      const threshold = checkThresholds(report, config);
+      printJson({
+        success: true,
+        cached: false,
+        pubkey: hexPubkey,
+        ...threshold,
+        report: report.report,
+        graph: report.graph,
+      });
+    } catch (err) {
+      handleError(err);
+    }
+  });
+
+program
+  .command("check-agent")
+  .description(
+    "Derive Nostr pubkey from unlocked wallet (BTC-shared path m/84'/0'/0'/0/0) and look up WoT score"
+  )
+  .action(async () => {
+    try {
+      const walletManager = getWalletManager();
+      const account = walletManager.getActiveAccount();
+      if (!account) {
+        throw new Error(
+          "Wallet is not unlocked. Run: bun run wallet/wallet.ts unlock --password <password>"
+        );
+      }
+
+      // Derive x-only Nostr pubkey from the BTC-shared BIP84 private key
+      const compressedPub = secp256k1.getPublicKey(account.privateKey, true); // 33 bytes
+      const xOnly = compressedPub.slice(1); // drop parity byte
+      const hexPubkey = Buffer.from(xOnly).toString("hex");
+
+      const cached = await getCached(hexPubkey);
+      if (cached) {
+        const config = await loadConfig();
+        const threshold = checkThresholds(cached, config);
+        printJson({
+          success: true,
+          cached: true,
+          derivationPath: "m/84'/0'/0'/0/0",
+          pubkey: hexPubkey,
+          ...threshold,
+          report: cached.report,
+          graph: cached.graph,
+        });
+        return;
+      }
+
+      const report = await fetchWotReport(hexPubkey);
+      await setCache(hexPubkey, report);
+      const config = await loadConfig();
+      const threshold = checkThresholds(report, config);
+      printJson({
+        success: true,
+        cached: false,
+        derivationPath: "m/84'/0'/0'/0/0",
+        pubkey: hexPubkey,
+        ...threshold,
+        report: report.report,
+        graph: report.graph,
+      });
+    } catch (err) {
+      handleError(err);
+    }
+  });
+
+program
+  .command("config")
+  .description("View or update trust threshold configuration")
+  .option("--min-rank <n>", "Maximum acceptable rank (lower = more trusted, default: 10000)")
+  .option("--require-top100", "Require pubkey to be in top 100")
+  .option("--no-require-top100", "Remove top-100 requirement")
+  .action(
+    async (options: { minRank?: string; requireTop100?: boolean }) => {
+      try {
+        const config = await loadConfig();
+        let changed = false;
+
+        if (options.minRank !== undefined) {
+          config.minRank = parseInt(options.minRank, 10);
+          changed = true;
+        }
+        if (options.requireTop100 !== undefined) {
+          config.requireTop100 = options.requireTop100;
+          changed = true;
+        }
+
+        if (changed) {
+          await saveConfig(config);
+          printJson({ success: true, message: "Config updated", config });
+        } else {
+          printJson({ success: true, message: "Current config", config });
+        }
+      } catch (err) {
+        handleError(err);
+      }
+    }
+  );
+
+program
+  .command("cache-status")
+  .description("Show cache statistics (results cached 1h to avoid redundant L402 payments)")
+  .action(async () => {
+    try {
+      const cache = await loadCache();
+      const now = Date.now();
+      const entries = Object.entries(cache);
+      const valid = entries.filter(([, v]) => now - v.fetchedAt < CACHE_TTL_MS);
+      printJson({
+        totalEntries: entries.length,
+        validEntries: valid.length,
+        expiredEntries: entries.length - valid.length,
+        cacheFile: CACHE_FILE,
+        ttlMinutes: CACHE_TTL_MS / 60000,
+        entries: valid.map(([key, v]) => ({
+          pubkey: key,
+          rank: v.data.rank,
+          in_top_100: v.data.in_top_100,
+          ageMinutes: Math.round((now - v.fetchedAt) / 60000),
+        })),
+      });
+    } catch (err) {
+      handleError(err);
+    }
+  });
+
+program.parse();

--- a/skills.json
+++ b/skills.json
@@ -1,6 +1,6 @@
 {
   "version": "0.26.0",
-  "generated": "2026-03-18T06:50:21.914Z",
+  "generated": "2026-03-18T12:30:34.220Z",
   "skills": [
     {
       "name": "agent-lookup",
@@ -581,6 +581,24 @@
         "jingswap_settle_with_refresh",
         "jingswap_cancel_cycle"
       ]
+    },
+    {
+      "name": "maximumsats-wot",
+      "description": "MaximumSats Web of Trust — query Nostr trust scores for counterparty risk assessment. 52K+ pubkeys, 2.4M+ trust edges. Scores are weighted by zap receipts. Payment: 100 sats via L402 per lookup.",
+      "entry": "maximumsats-wot/maximumsats-wot.ts",
+      "arguments": [
+        "check",
+        "check-agent",
+        "config",
+        "cache-status"
+      ],
+      "requires": [],
+      "tags": [
+        "read-only"
+      ],
+      "userInvocable": false,
+      "author": "joelklabo",
+      "authorAgent": "SATMAX Agent"
     },
     {
       "name": "mempool-watch",


### PR DESCRIPTION
## Summary

- Adds `maximumsats-wot` skill for Nostr WoT trust scoring via the MaximumSats API
- Ported from arc-starter to aibtcdev/skills format: Commander.js, `printJson`/`handleError`, `src/lib/` shared infra
- 4 subcommands: `check` (npub/hex lookup), `check-agent` (wallet-derived via BTC-shared path), `config` (threshold tuning), `cache-status`
- Results cached 1h at `~/.aibtc/maximumsats-cache.json` to minimize L402 payments (100 sats/request)
- Typecheck passes, frontmatter validates, manifest regenerated (53 skills)

Closes #24

## Test plan

- [ ] `bun run maximumsats-wot/maximumsats-wot.ts --help` — shows usage
- [ ] `bun run maximumsats-wot/maximumsats-wot.ts config` — shows default thresholds
- [ ] `bun run maximumsats-wot/maximumsats-wot.ts cache-status` — shows empty cache
- [ ] `bun run maximumsats-wot/maximumsats-wot.ts check --npub npub1...` — returns 402 (L402 required) or trust result if L402 client present
- [ ] `bun run typecheck` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)