### PR TITLE
fix(stacking-lottery): correct mcp-tools field names

### DIFF
--- a/skills.json
+++ b/skills.json
@@ -1,6 +1,6 @@
 {
   "version": "0.27.0",
-  "generated": "2026-03-19T18:21:50.826Z",
+  "generated": "2026-03-19T18:57:58.983Z",
   "skills": [
     {
       "name": "agent-lookup",
@@ -1348,12 +1348,12 @@
       "author": "whoabuddy",
       "authorAgent": "Trustless Indra",
       "mcpTools": [
-        "stackspot_list_pots",
-        "stackspot_get_pot_state",
-        "stackspot_join_pot",
-        "stackspot_start_pot",
-        "stackspot_claim_rewards",
-        "stackspot_cancel_pot"
+        "stacking_lottery_list_pots",
+        "stacking_lottery_get_pot_state",
+        "stacking_lottery_join_pot",
+        "stacking_lottery_start_pot",
+        "stacking_lottery_claim_rewards",
+        "stacking_lottery_cancel_pot"
       ]
     },
     {

--- a/stacking-lottery/SKILL.md
+++ b/stacking-lottery/SKILL.md
@@ -7,7 +7,7 @@ metadata:
   user-invocable: "false"
   arguments: "list-pots | get-pot-state | join-pot | start-pot | claim-rewards | cancel-pot"
   entry: "stacking-lottery/stacking-lottery.ts"
-  mcp-tools: "stackspot_list_pots, stackspot_get_pot_state, stackspot_join_pot, stackspot_start_pot, stackspot_claim_rewards, stackspot_cancel_pot"
+  mcp-tools: "stacking_lottery_list_pots, stacking_lottery_get_pot_state, stacking_lottery_join_pot, stacking_lottery_start_pot, stacking_lottery_claim_rewards, stacking_lottery_cancel_pot"
   requires: "wallet"
   tags: "l2, write, mainnet-only, requires-funds"
 ---


### PR DESCRIPTION
## Summary
- Updates `stacking-lottery/SKILL.md` mcp-tools from `stackspot_*` to `stacking_lottery_*` so each skill maps to its own MCP tools
- Regenerates `skills.json` manifest

Closes #190

## Test plan
- [x] `bun run typecheck` passes
- [x] `bun run manifest` regenerates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)