### PR TITLE
docs(nostr): add mcp-tools field to SKILL.md frontmatter

### DIFF
--- a/nostr/SKILL.md
+++ b/nostr/SKILL.md
@@ -7,6 +7,7 @@ metadata:
   user-invocable: "false"
   arguments: "post | read-feed | search-tags | get-profile | set-profile | get-pubkey | relay-list | amplify-signal | amplify-text"
   entry: "nostr/nostr.ts"
+  mcp-tools: "nostr_get_profile, nostr_get_pubkey, nostr_post, nostr_read_feed, nostr_relay_list, nostr_search_tags, nostr_set_profile"
   requires: "wallet, signing"
   tags: "write"
 ---

--- a/skills.json
+++ b/skills.json
@@ -1,6 +1,6 @@
 {
-  "version": "0.27.0",
-  "generated": "2026-03-19T18:57:58.983Z",
+  "version": "0.28.0",
+  "generated": "2026-03-19T19:31:29.152Z",
   "skills": [
     {
       "name": "agent-lookup",
@@ -856,6 +856,15 @@
       "authorAgent": [
         "Fluid Briar",
         "Sonic Mast"
+      ],
+      "mcpTools": [
+        "nostr_get_profile",
+        "nostr_get_pubkey",
+        "nostr_post",
+        "nostr_read_feed",
+        "nostr_relay_list",
+        "nostr_search_tags",
+        "nostr_set_profile"
       ]
     },
     {


### PR DESCRIPTION
## Summary

Adds the `mcp-tools` metadata field to `nostr/SKILL.md` linking the 7 corresponding MCP tools from `aibtc-mcp-server`:

- `nostr_get_profile`
- `nostr_get_pubkey`
- `nostr_post`
- `nostr_read_feed`
- `nostr_relay_list`
- `nostr_search_tags`
- `nostr_set_profile`

Also regenerates `skills.json` to reflect the new field.

## Changes

- `nostr/SKILL.md`: add `mcp-tools` field to metadata frontmatter
- `skills.json`: regenerated with `bun run manifest`

## Test plan

- [x] `bun run validate` passes (79 tests, 0 failures)
- [x] `bun run manifest` regenerates `skills.json` cleanly
- [x] `skills.json` contains `mcp-tools` array for the nostr skill

Closes #193