### PR TITLE
refactor(bitcoin): extract deriveHDKey helper to eliminate repeated seed derivation

### DIFF
--- a/src/lib/utils/bitcoin.ts
+++ b/src/lib/utils/bitcoin.ts
@@ -4,6 +4,24 @@ import * as btc from "@scure/btc-signer";
 import type { Network } from "../config/networks.js";
 
 /**
+ * Private helper: derive an HDKey from mnemonic + BIP path.
+ *
+ * Accepts an optional pre-computed seed so callers that derive multiple keys
+ * from the same mnemonic (e.g. wallet unlock: BTC + Taproot + Nostr) can run
+ * the expensive PBKDF2 step once and reuse the result.
+ *
+ * Not exported — all callers go through the typed public functions.
+ *
+ * @param mnemonic - BIP39 mnemonic phrase
+ * @param path - BIP32 derivation path (e.g. "m/84'/0'/0'/0/0")
+ * @param seed - Optional pre-computed seed (skips mnemonicToSeedSync if provided)
+ */
+function deriveHDKey(mnemonic: string, path: string, seed?: Uint8Array): HDKey {
+  const masterSeed = seed ?? mnemonicToSeedSync(mnemonic);
+  return HDKey.fromMasterSeed(masterSeed).derive(path);
+}
+
+/**
  * Bitcoin address derivation result
  */
 export interface BitcoinAddress {
@@ -105,24 +123,9 @@ export function deriveBitcoinAddress(
   mnemonic: string,
   network: Network
 ): BitcoinAddress {
-  // Convert mnemonic to seed
-  const seed = mnemonicToSeedSync(mnemonic);
-
-  // Create master key from seed
-  const masterKey = HDKey.fromMasterSeed(seed);
-
-  // BIP84 derivation path
-  // m / purpose' / coin_type' / account' / change / address_index
-  // Purpose: 84 (native SegWit)
-  // Coin type: 0 (Bitcoin mainnet) or 1 (Bitcoin testnet)
-  // Account: 0 (first account)
-  // Change: 0 (external/receiving addresses)
-  // Address index: 0 (first address)
+  // BIP84: m/84'/coin_type'/0'/0/0 — coin_type 0=mainnet, 1=testnet
   const coinType = network === "mainnet" ? 0 : 1;
-  const derivationPath = `m/84'/${coinType}'/0'/0/0`;
-
-  // Derive key at path
-  const derivedKey = masterKey.derive(derivationPath);
+  const derivedKey = deriveHDKey(mnemonic, `m/84'/${coinType}'/0'/0/0`);
 
   if (!derivedKey.publicKey) {
     throw new Error("Failed to derive public key");
@@ -190,24 +193,9 @@ export function deriveBitcoinKeyPair(
   mnemonic: string,
   network: Network
 ): BitcoinKeyPair {
-  // Convert mnemonic to seed
-  const seed = mnemonicToSeedSync(mnemonic);
-
-  // Create master key from seed
-  const masterKey = HDKey.fromMasterSeed(seed);
-
-  // BIP84 derivation path
-  // m / purpose' / coin_type' / account' / change / address_index
-  // Purpose: 84 (native SegWit)
-  // Coin type: 0 (Bitcoin mainnet) or 1 (Bitcoin testnet)
-  // Account: 0 (first account)
-  // Change: 0 (external/receiving addresses)
-  // Address index: 0 (first address)
+  // BIP84: m/84'/coin_type'/0'/0/0 — coin_type 0=mainnet, 1=testnet
   const coinType = network === "mainnet" ? 0 : 1;
-  const derivationPath = `m/84'/${coinType}'/0'/0/0`;
-
-  // Derive key at path
-  const derivedKey = masterKey.derive(derivationPath);
+  const derivedKey = deriveHDKey(mnemonic, `m/84'/${coinType}'/0'/0/0`);
 
   if (!derivedKey.publicKey) {
     throw new Error("Failed to derive public key");
@@ -268,24 +256,9 @@ export function deriveTaprootAddress(
   mnemonic: string,
   network: Network
 ): TaprootAddress {
-  // Convert mnemonic to seed
-  const seed = mnemonicToSeedSync(mnemonic);
-
-  // Create master key from seed
-  const masterKey = HDKey.fromMasterSeed(seed);
-
-  // BIP86 derivation path for Taproot
-  // m / purpose' / coin_type' / account' / change / address_index
-  // Purpose: 86 (Taproot)
-  // Coin type: 0 (Bitcoin mainnet) or 1 (Bitcoin testnet)
-  // Account: 0 (first account)
-  // Change: 0 (external/receiving addresses)
-  // Address index: 0 (first address)
+  // BIP86: m/86'/coin_type'/0'/0/0 — coin_type 0=mainnet, 1=testnet
   const coinType = network === "mainnet" ? 0 : 1;
-  const derivationPath = `m/86'/${coinType}'/0'/0/0`;
-
-  // Derive key at path
-  const derivedKey = masterKey.derive(derivationPath);
+  const derivedKey = deriveHDKey(mnemonic, `m/86'/${coinType}'/0'/0/0`);
 
   if (!derivedKey.publicKey) {
     throw new Error("Failed to derive public key");
@@ -363,17 +336,8 @@ export interface NostrKeyPair {
  * ```
  */
 export function deriveNostrKeyPair(mnemonic: string): NostrKeyPair {
-  // Convert mnemonic to seed
-  const seed = mnemonicToSeedSync(mnemonic);
-
-  // Create master key from seed
-  const masterKey = HDKey.fromMasterSeed(seed);
-
-  // NIP-06 derivation path: m/44'/1237'/0'/0/0
-  // Purpose: 44 (BIP-44 multi-account hierarchy)
-  // Coin type: 1237 (Nostr — registered coin type, never changes by network)
-  // Account: 0, Change: 0, Address index: 0
-  const derivedKey = masterKey.derive("m/44'/1237'/0'/0/0");
+  // NIP-06: m/44'/1237'/0'/0/0 — coin_type 1237 is the registered Nostr type
+  const derivedKey = deriveHDKey(mnemonic, "m/44'/1237'/0'/0/0");
 
   if (!derivedKey.privateKey) {
     throw new Error("Failed to derive NIP-06 private key");
@@ -425,24 +389,9 @@ export function deriveTaprootKeyPair(
   mnemonic: string,
   network: Network
 ): TaprootKeyPair {
-  // Convert mnemonic to seed
-  const seed = mnemonicToSeedSync(mnemonic);
-
-  // Create master key from seed
-  const masterKey = HDKey.fromMasterSeed(seed);
-
-  // BIP86 derivation path for Taproot
-  // m / purpose' / coin_type' / account' / change / address_index
-  // Purpose: 86 (Taproot)
-  // Coin type: 0 (Bitcoin mainnet) or 1 (Bitcoin testnet)
-  // Account: 0 (first account)
-  // Change: 0 (external/receiving addresses)
-  // Address index: 0 (first address)
+  // BIP86: m/86'/coin_type'/0'/0/0 — coin_type 0=mainnet, 1=testnet
   const coinType = network === "mainnet" ? 0 : 1;
-  const derivationPath = `m/86'/${coinType}'/0'/0/0`;
-
-  // Derive key at path
-  const derivedKey = masterKey.derive(derivationPath);
+  const derivedKey = deriveHDKey(mnemonic, `m/86'/${coinType}'/0'/0/0`);
 
   if (!derivedKey.publicKey) {
     throw new Error("Failed to derive public key");


### PR DESCRIPTION
## Summary

Implements the refactor proposed in #191.

- Adds a private `deriveHDKey(mnemonic, path, seed?)` helper consolidating the 3-line seed expansion pattern that was duplicated across all 5 derivation functions
- The optional `seed?: Uint8Array` parameter (suggested by @tfireubs-ui) allows wallet-manager.ts to run PBKDF2 once and pass the result to BTC + Taproot + Nostr derivations — reducing from 3× PBKDF2 to 1× on wallet unlock
- No behavior changes, no interface or export changes, no new dependencies
- Scope: `src/lib/utils/bitcoin.ts` only as specified in #191

## Changes

`src/lib/utils/bitcoin.ts`:
- Added `deriveHDKey(mnemonic, path, seed?)` private helper (not exported)
- Removed the duplicated 3-line seed block from all 5 derivation functions
- Inline path comments replace verbose derivation-step comments
- Net: -51 lines in function bodies

## Optional seed usage

wallet-manager.ts unlock path can be optimized in a follow-up by passing the pre-computed seed through the public function signatures. This PR just adds the internal helper — single-call callers work exactly as before.

## Test plan

- [ ] Existing wallet derivation tests pass (no behavior change)
- [ ] TypeScript strict mode passes
- [ ] Manual: wallet unlock produces same BTC/Taproot/Nostr addresses as before

Closes #191

🤖 Generated with [Claude Code](https://claude.com/claude-code)