### PR TITLE
fix(child-inscription): add tapInternalKey to parent input

### DIFF
--- a/src/lib/transactions/child-inscription-builder.ts
+++ b/src/lib/transactions/child-inscription-builder.ts
@@ -588,6 +588,7 @@ export function buildChildRevealTransaction(
       script: parentP2tr.script,
       amount: BigInt(parentUtxo.value),
     },
+    tapInternalKey: xOnlyParentPubKey,
   });
 
   // Output 0: child inscription (dust amount, inscription is in the witness of input 0)


### PR DESCRIPTION
## Summary

- Adds missing `tapInternalKey: xOnlyParentPubKey` to the parent UTXO `addInput` call in `buildChildRevealTransaction` (~line 584)
- Without it, `@scure/btc-signer` cannot match the private key to the key-path spend input — `tx.sign()` silently signs zero inputs and `finalize()` throws `'finalize/taproot: unknown input'`
- This is a one-line sync with the identical fix already present in `aibtcdev/aibtc-mcp-server` at `src/transactions/child-inscription-builder.ts:391`

## Test plan

- [ ] Build compiles cleanly (`bun build`)
- [ ] `buildChildRevealTransaction` signs and finalizes without error when called with a valid parent UTXO and key pair
- [ ] Child inscription reveal TX broadcasts successfully end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)