### PR TITLE
feat(x402): add --headers flag to execute-endpoint

### DIFF
--- a/x402/x402.ts
+++ b/x402/x402.ts
@@ -256,7 +256,7 @@ program
               recipient: probeResult.recipient,
               network: probeResult.network,
             },
-            retryWith: `--auto-approve ${opts.url ? `--url ${opts.url}` : `--path ${opts.path}`}${opts.apiUrl ? ` --api-url ${opts.apiUrl}` : ""}${params ? ` --params '${JSON.stringify(params)}'` : ""}${data ? ` --data '${JSON.stringify(data)}'` : ""}`,
+            retryWith: `--auto-approve ${opts.url ? `--url ${opts.url}` : `--path ${opts.path}`}${opts.apiUrl ? ` --api-url ${opts.apiUrl}` : ""}${params ? ` --params '${JSON.stringify(params)}'` : ""}${data ? ` --data '${JSON.stringify(data)}'` : ""}${customHeaders ? ` --headers '${JSON.stringify(customHeaders)}'` : ""}`,
           });
           return;
         }


### PR DESCRIPTION
## Summary

- Adds `--headers <json>` option to the `execute-endpoint` command, allowing callers to pass custom HTTP headers alongside x402 payment
- Updates the `opts` type in the `.action()` callback to include `headers: string`
- Passes `headers: customHeaders` to both `api.request()` calls (paid endpoint via `createApiClient` and free endpoint via `createPlainClient`)

Some endpoints require both x402 payment AND additional auth headers (e.g., BIP-322 signatures). The axios interceptor preserves original request headers on retry, so custom headers set on the initial request carry through to the payment-authenticated retry automatically.

**Usage:**
```bash
bun run x402/x402.ts execute-endpoint \
  --method POST \
  --url https://aibtc.news/api/classifieds \
  --data '{"title":"...","body":"..."}' \
  --headers '{"x-signature":"<bip322-sig>","x-btc-address":"bc1q..."}' \
  --auto-approve
```

## Test plan

- [ ] Run `execute-endpoint` without `--headers` — existing behavior unchanged
- [ ] Run `execute-endpoint --headers '{}'` — empty object treated as no custom headers (undefined), no regression
- [ ] Run `execute-endpoint --headers '{"x-custom":"value"}'` against a free endpoint — header appears in request
- [ ] Run `execute-endpoint --headers '{"x-custom":"value"}' --auto-approve` against a paid endpoint — header carried through payment retry
- [ ] Run `execute-endpoint --headers 'not-json'` — receives clear error: `--headers must be valid JSON`

closes #209

🤖 Generated with [Claude Code](https://claude.com/claude-code)