### PR TITLE
feat(escrow-htlc): add trust-minimized HTLC escrow skill for sBTC

### DIFF
--- a/escrow-htlc/AGENT.md
+++ b/escrow-htlc/AGENT.md
@@ -1,0 +1,59 @@
+---
+name: escrow-htlc
+agent-role: escrow coordinator
+---
+
+# AGENT.md — escrow-htlc Autonomous Operation
+
+## When to Use This Skill
+
+Use `escrow-htlc` when an agent needs to:
+- Lock sBTC for a counterparty pending delivery of off-chain work
+- Accept incoming sBTC locked in escrow (claim with preimage)
+- Recover sBTC after a deal falls through (refund after expiry)
+- Verify escrow state before proceeding with a trade
+
+## Decision Logic
+
+### Locking escrow
+
+Before calling `lock`:
+1. Confirm sBTC balance is sufficient: `sbtc get-balance`
+2. Generate lock params: `escrow-htlc generate-lock-params` — store preimage securely
+3. Agree timelock with counterparty: minimum 144 blocks (~24h) for most deals
+4. Never reveal the preimage until counterparty has fulfilled their obligation
+
+### Claiming escrow
+
+Before calling `claim`:
+1. Verify escrow state: `escrow-htlc get-escrow --escrow-id <id>`
+2. Confirm `claimed: false` and `refunded: false`
+3. Confirm `block-height <= timelock` (don't attempt a claim that will expire mid-block)
+4. Confirm sha256(preimage) matches `hashlock` locally before broadcasting
+
+### Refunding escrow
+
+Before calling `refund`:
+1. Verify escrow state: `escrow-htlc get-escrow --escrow-id <id>`
+2. Confirm `block-height > timelock`
+3. Only the original sender can refund — verify wallet is correct
+
+## Safety Rules
+
+- **Never share the preimage before counterparty obligation is fulfilled** — doing so releases funds immediately
+- **Always verify escrow state before any write operation** — check `get-escrow` first
+- **Use post-conditions on lock** — the CLI enforces exact sBTC amount via post-condition
+- **Do not attempt claim or refund if both `claimed` and `refunded` are false but timelock is unclear** — wait for the next block and re-check
+- **ESCROW_CONTRACT_ADDRESS must be set** — do not operate against undeployed contract
+
+## Error Handling
+
+| Error | Action |
+|-------|--------|
+| ERR-ALREADY-CLAIMED (u102) | Stop. Funds already paid out. Verify on explorer. |
+| ERR-ALREADY-REFUNDED (u103) | Stop. Funds returned to sender. |
+| ERR-WRONG-PREIMAGE (u104) | Verify preimage hex is correct 32 bytes. |
+| ERR-TIMELOCK-ACTIVE (u105) | Refund too early. Wait until block > timelock. |
+| ERR-TIMELOCK-EXPIRED (u106) | Claim window closed. Only refund is available. |
+| ERR-NOT-RECIPIENT (u108) | Wrong wallet. Switch to recipient wallet. |
+| ERR-NOT-SENDER (u109) | Wrong wallet. Switch to sender wallet. |

--- a/escrow-htlc/SKILL.md
+++ b/escrow-htlc/SKILL.md
@@ -1,0 +1,174 @@
+---
+name: escrow-htlc
+description: Trust-minimized HTLC escrow for agent-to-agent sBTC payments on Stacks. Lock sBTC with a hashlock and timelock — recipient claims with the preimage, sender reclaims after expiry. No AMM, no DEX, single asset. Write operations require an unlocked wallet.
+user-invocable: true
+arguments: lock | claim | refund | get-escrow | generate-lock-params
+entry: escrow-htlc/escrow-htlc.ts
+requires: [wallet, stx]
+tags: [escrow, htlc, sbtc, bitcoin, defi, write]
+---
+
+# escrow-htlc
+
+Trust-minimized Hash Time-Locked Contract (HTLC) for agent-to-agent sBTC escrow on Stacks mainnet.
+
+**Design invariants:**
+- Zero AMM/DEX dependency — pure HTLC only
+- Single settlement asset (sBTC) — no mid-flow conversion
+- Full refund on expiry — no fees deducted
+- Double-claim and double-refund both fail cleanly
+- Contract prints on every state transition (lock / claim / refund)
+
+---
+
+## Prerequisites
+
+- Wallet unlocked on mainnet for write operations (`lock`, `claim`, `refund`)
+- Sufficient sBTC balance in wallet for `lock`
+
+---
+
+## Usage
+
+```bash
+NETWORK=mainnet bun run escrow-htlc/escrow-htlc.ts <subcommand> [options]
+```
+
+---
+
+## Subcommands
+
+### generate-lock-params
+
+Generate a random preimage + sha256 hashlock pair. Share the hashlock with the recipient; keep the preimage secret until you want to release funds.
+
+```bash
+bun run escrow-htlc/escrow-htlc.ts generate-lock-params
+```
+
+Output:
+```json
+{
+  "preimage": "a3f2...",
+  "hashlock": "7c8d...",
+  "escrowId": "b1e4...",
+  "warning": "Store the preimage securely. Losing it means funds can only be recovered via refund after timelock."
+}
+```
+
+---
+
+### lock
+
+Lock sBTC into escrow. The recipient can claim by revealing the preimage. The sender can refund after the timelock expires.
+
+```bash
+NETWORK=mainnet bun run escrow-htlc/escrow-htlc.ts lock \
+  --escrow-id <hex32>       \
+  --recipient <STX-address> \
+  --amount-sats <n>         \
+  --hashlock <hex32>        \
+  --timelock-blocks <n>
+```
+
+Options:
+- `--escrow-id` — 32-byte hex ID (use `generate-lock-params` to generate)
+- `--recipient` — Stacks address of the intended recipient
+- `--amount-sats` — Amount in satoshis (sBTC: 1 sBTC = 100_000_000 sats)
+- `--hashlock` — sha256 of preimage as 64-char hex
+- `--timelock-blocks` — Number of blocks until sender can reclaim (relative to current block)
+
+---
+
+### claim
+
+Claim sBTC from escrow by revealing the preimage. Only the designated recipient can call this, and only before the timelock expires.
+
+```bash
+NETWORK=mainnet bun run escrow-htlc/escrow-htlc.ts claim \
+  --escrow-id <hex32> \
+  --preimage  <hex32>
+```
+
+---
+
+### refund
+
+Reclaim sBTC from escrow after the timelock has expired. Only the original sender can call this. Full amount returned — no fees.
+
+```bash
+NETWORK=mainnet bun run escrow-htlc/escrow-htlc.ts refund \
+  --escrow-id <hex32>
+```
+
+---
+
+### get-escrow
+
+Read-only lookup of escrow state. No wallet required.
+
+```bash
+NETWORK=mainnet bun run escrow-htlc/escrow-htlc.ts get-escrow \
+  --escrow-id <hex32>
+```
+
+---
+
+## Error Codes
+
+| Code | Meaning |
+|------|---------|
+| u100 | Escrow ID already exists |
+| u101 | Escrow not found |
+| u102 | Already claimed |
+| u103 | Already refunded |
+| u104 | Wrong preimage |
+| u105 | Timelock still active (refund too early) |
+| u106 | Timelock expired (claim too late) |
+| u107 | Zero amount |
+| u108 | Caller is not the recipient |
+| u109 | Caller is not the sender |
+| u110 | Timelock must be in the future |
+
+---
+
+## Example: Full Flow
+
+```bash
+# 1. Generate lock params (sender side)
+bun run escrow-htlc/escrow-htlc.ts generate-lock-params
+# → save preimage privately, share hashlock + escrow-id with recipient
+
+# 2. Lock 10,000 sats for 144 blocks (~24h)
+NETWORK=mainnet bun run escrow-htlc/escrow-htlc.ts lock \
+  --escrow-id <escrow-id>   \
+  --recipient SP2VCQJ...     \
+  --amount-sats 10000        \
+  --hashlock <hashlock>      \
+  --timelock-blocks 144
+
+# 3. Recipient checks status
+NETWORK=mainnet bun run escrow-htlc/escrow-htlc.ts get-escrow --escrow-id <escrow-id>
+
+# 4. Sender reveals preimage (off-chain), recipient claims
+NETWORK=mainnet bun run escrow-htlc/escrow-htlc.ts claim \
+  --escrow-id <escrow-id>  \
+  --preimage  <preimage>
+
+# OR — if recipient doesn't claim in time, sender refunds
+NETWORK=mainnet bun run escrow-htlc/escrow-htlc.ts refund --escrow-id <escrow-id>
+```
+
+---
+
+## Contract
+
+`escrow-htlc/contracts/escrow-htlc.clar`
+
+Deploy to mainnet before use:
+
+```bash
+NETWORK=mainnet bun run stx/stx.ts deploy-contract \
+  --name escrow-htlc \
+  --file escrow-htlc/contracts/escrow-htlc.clar
+```

--- a/escrow-htlc/contracts/escrow-htlc.clar
+++ b/escrow-htlc/contracts/escrow-htlc.clar
@@ -1,0 +1,208 @@
+;; escrow-htlc.clar
+;; Trust-minimized Hash Time-Locked Contract for agent-to-agent sBTC escrow on Stacks.
+;; 
+;; Design:
+;;   lock   → sender deposits sBTC, sets hashlock + absolute timelock
+;;   claim  → recipient reveals preimage (sha256 must match hashlock) to receive sBTC
+;;   refund → sender reclaims full amount after timelock expires
+;;
+;; Invariants:
+;;   - Zero AMM/DEX dependency: pure HTLC only
+;;   - Single settlement asset: sBTC (no mid-flow conversion)
+;;   - Double-claim / double-refund both fail cleanly
+;;   - Contract prints on every state transition
+
+;; ============================================================
+;; Constants
+;; ============================================================
+
+(define-constant CONTRACT-OWNER tx-sender)
+(define-constant SBTC-TOKEN 'SP3FBR2AGK5H9QBDH3EEN6DF8EK8JY7RX8QJ5SVTE.sbtc-token)
+
+(define-constant ERR-ALREADY-EXISTS     (err u100))
+(define-constant ERR-NOT-FOUND         (err u101))
+(define-constant ERR-ALREADY-CLAIMED   (err u102))
+(define-constant ERR-ALREADY-REFUNDED  (err u103))
+(define-constant ERR-WRONG-PREIMAGE    (err u104))
+(define-constant ERR-TIMELOCK-ACTIVE   (err u105)) ;; refund attempted before expiry
+(define-constant ERR-TIMELOCK-EXPIRED  (err u106)) ;; claim attempted after expiry
+(define-constant ERR-ZERO-AMOUNT       (err u107))
+(define-constant ERR-NOT-RECIPIENT     (err u108))
+(define-constant ERR-NOT-SENDER        (err u109))
+(define-constant ERR-BAD-TIMELOCK      (err u110)) ;; timelock <= current block
+
+;; ============================================================
+;; Data
+;; ============================================================
+
+(define-map escrows
+  { escrow-id: (buff 32) }
+  {
+    sender:    principal,
+    recipient: principal,
+    amount:    uint,          ;; satoshis (sBTC uses 8 decimals; 1 sat = u1)
+    hashlock:  (buff 32),     ;; sha256 hash of the preimage
+    timelock:  uint,          ;; absolute block height — claim must happen at or before this
+    claimed:   bool,
+    refunded:  bool
+  }
+)
+
+;; ============================================================
+;; Read-only
+;; ============================================================
+
+(define-read-only (get-escrow (escrow-id (buff 32)))
+  (map-get? escrows { escrow-id: escrow-id })
+)
+
+(define-read-only (is-claimable (escrow-id (buff 32)))
+  (match (map-get? escrows { escrow-id: escrow-id })
+    escrow (and
+              (not (get claimed escrow))
+              (not (get refunded escrow))
+              (<= block-height (get timelock escrow)))
+    false
+  )
+)
+
+(define-read-only (is-refundable (escrow-id (buff 32)))
+  (match (map-get? escrows { escrow-id: escrow-id })
+    escrow (and
+              (not (get claimed escrow))
+              (not (get refunded escrow))
+              (> block-height (get timelock escrow)))
+    false
+  )
+)
+
+;; ============================================================
+;; Public: lock
+;; ============================================================
+
+(define-public (lock
+    (escrow-id  (buff 32))
+    (recipient  principal)
+    (amount     uint)
+    (hashlock   (buff 32))
+    (timelock   uint))
+  (begin
+    ;; Validation
+    (asserts! (is-none (map-get? escrows { escrow-id: escrow-id })) ERR-ALREADY-EXISTS)
+    (asserts! (> amount u0)              ERR-ZERO-AMOUNT)
+    (asserts! (> timelock block-height)  ERR-BAD-TIMELOCK)
+
+    ;; Transfer sBTC from sender to this contract
+    (try! (contract-call? SBTC-TOKEN transfer amount tx-sender (as-contract tx-sender) none))
+
+    ;; Store escrow
+    (map-set escrows
+      { escrow-id: escrow-id }
+      {
+        sender:    tx-sender,
+        recipient: recipient,
+        amount:    amount,
+        hashlock:  hashlock,
+        timelock:  timelock,
+        claimed:   false,
+        refunded:  false
+      })
+
+    ;; Emit event
+    (print {
+      event:      "lock",
+      escrow-id:  escrow-id,
+      sender:     tx-sender,
+      recipient:  recipient,
+      amount:     amount,
+      hashlock:   hashlock,
+      timelock:   timelock,
+      block:      block-height
+    })
+
+    (ok true)
+  )
+)
+
+;; ============================================================
+;; Public: claim
+;; ============================================================
+
+(define-public (claim
+    (escrow-id (buff 32))
+    (preimage  (buff 32)))
+  (let ((escrow (unwrap! (map-get? escrows { escrow-id: escrow-id }) ERR-NOT-FOUND)))
+    ;; Access control
+    (asserts! (is-eq tx-sender (get recipient escrow)) ERR-NOT-RECIPIENT)
+    ;; State checks
+    (asserts! (not (get claimed escrow))               ERR-ALREADY-CLAIMED)
+    (asserts! (not (get refunded escrow))              ERR-ALREADY-REFUNDED)
+    ;; Timelock: must claim at or before expiry
+    (asserts! (<= block-height (get timelock escrow))  ERR-TIMELOCK-EXPIRED)
+    ;; Hashlock: sha256(preimage) must match stored hashlock
+    (asserts! (is-eq (sha256 preimage) (get hashlock escrow)) ERR-WRONG-PREIMAGE)
+
+    ;; Mark claimed before transfer (reentrancy safety)
+    (map-set escrows
+      { escrow-id: escrow-id }
+      (merge escrow { claimed: true }))
+
+    ;; Transfer sBTC to recipient
+    (try! (as-contract (contract-call? SBTC-TOKEN transfer
+            (get amount escrow)
+            tx-sender
+            (get recipient escrow)
+            none)))
+
+    ;; Emit event
+    (print {
+      event:      "claim",
+      escrow-id:  escrow-id,
+      recipient:  (get recipient escrow),
+      amount:     (get amount escrow),
+      preimage:   preimage,
+      block:      block-height
+    })
+
+    (ok true)
+  )
+)
+
+;; ============================================================
+;; Public: refund
+;; ============================================================
+
+(define-public (refund (escrow-id (buff 32)))
+  (let ((escrow (unwrap! (map-get? escrows { escrow-id: escrow-id }) ERR-NOT-FOUND)))
+    ;; Access control
+    (asserts! (is-eq tx-sender (get sender escrow)) ERR-NOT-SENDER)
+    ;; State checks
+    (asserts! (not (get claimed escrow))            ERR-ALREADY-CLAIMED)
+    (asserts! (not (get refunded escrow))           ERR-ALREADY-REFUNDED)
+    ;; Timelock: must be past expiry to refund
+    (asserts! (> block-height (get timelock escrow)) ERR-TIMELOCK-ACTIVE)
+
+    ;; Mark refunded before transfer (reentrancy safety)
+    (map-set escrows
+      { escrow-id: escrow-id }
+      (merge escrow { refunded: true }))
+
+    ;; Return full amount to sender — no fees
+    (try! (as-contract (contract-call? SBTC-TOKEN transfer
+            (get amount escrow)
+            tx-sender
+            (get sender escrow)
+            none)))
+
+    ;; Emit event
+    (print {
+      event:      "refund",
+      escrow-id:  escrow-id,
+      sender:     (get sender escrow),
+      amount:     (get amount escrow),
+      block:      block-height
+    })
+
+    (ok true)
+  )
+)

--- a/escrow-htlc/escrow-htlc.ts
+++ b/escrow-htlc/escrow-htlc.ts
@@ -1,0 +1,417 @@
+#!/usr/bin/env bun
+/**
+ * escrow-htlc — Trust-minimized HTLC escrow for agent-to-agent sBTC payments.
+ *
+ * Subcommands:
+ *   generate-lock-params   Generate preimage + hashlock pair
+ *   lock                   Lock sBTC into escrow
+ *   claim                  Claim with preimage (recipient only)
+ *   refund                 Refund after timelock expiry (sender only)
+ *   get-escrow             Read-only status lookup
+ *
+ * Usage: bun run escrow-htlc/escrow-htlc.ts <subcommand> [options]
+ */
+
+import { Command } from "commander";
+import { createHash, randomBytes } from "node:crypto";
+import {
+  bufferCV,
+  principalCV,
+  uintCV,
+  deserializeCV,
+  cvToJSON,
+  type ClarityValue,
+} from "@stacks/transactions";
+import { NETWORK, getExplorerTxUrl } from "../src/lib/config/networks.js";
+import { getContracts, parseContractId } from "../src/lib/config/contracts.js";
+import { getAccount, getWalletAddress } from "../src/lib/services/x402.service.js";
+import { getHiroApi } from "../src/lib/services/hiro-api.js";
+import { callContract } from "../src/lib/transactions/builder.js";
+import { createFungiblePostCondition } from "../src/lib/transactions/post-conditions.js";
+import { resolveFee } from "../src/lib/utils/fee.js";
+import { printJson, handleError } from "../src/lib/utils/cli.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function hexToBuffer(hex: string): Buffer {
+  const clean = hex.startsWith("0x") ? hex.slice(2) : hex;
+  if (clean.length !== 64) {
+    throw new Error(
+      `Expected 32-byte (64-char) hex, got ${clean.length} chars`
+    );
+  }
+  return Buffer.from(clean, "hex");
+}
+
+function sha256Hex(input: Buffer): string {
+  return createHash("sha256").update(input).digest("hex");
+}
+
+function parseReadOnlyResult(hex: string): unknown {
+  const clean = hex.startsWith("0x") ? hex.slice(2) : hex;
+  const cv = deserializeCV(Buffer.from(clean, "hex"));
+  return cvToJSON(cv);
+}
+
+// ---------------------------------------------------------------------------
+// Program
+// ---------------------------------------------------------------------------
+
+const program = new Command();
+
+program
+  .name("escrow-htlc")
+  .description(
+    "Trust-minimized HTLC escrow for agent-to-agent sBTC payments on Stacks"
+  )
+  .version("0.1.0");
+
+// ---------------------------------------------------------------------------
+// generate-lock-params
+// ---------------------------------------------------------------------------
+
+program
+  .command("generate-lock-params")
+  .description(
+    "Generate a random preimage + SHA-256 hashlock pair, and a random escrow ID."
+  )
+  .option(
+    "--secret <string>",
+    "Use a specific secret string instead of random bytes"
+  )
+  .action(async (opts: { secret?: string }) => {
+    try {
+      const preimageBytes = opts.secret
+        ? createHash("sha256").update(opts.secret).digest()
+        : randomBytes(32);
+
+      const preimage = preimageBytes.toString("hex");
+      const hashlock = sha256Hex(preimageBytes);
+      const escrowId = randomBytes(32).toString("hex");
+
+      printJson({
+        preimage,
+        hashlock,
+        escrowId,
+        warning:
+          "Store the preimage securely. Losing it means funds can only be recovered via refund after timelock.",
+      });
+    } catch (error) {
+      handleError(error);
+    }
+  });
+
+// ---------------------------------------------------------------------------
+// lock
+// ---------------------------------------------------------------------------
+
+program
+  .command("lock")
+  .description(
+    "Lock sBTC into escrow with a hashlock and timelock. Requires an unlocked wallet."
+  )
+  .requiredOption("--escrow-id <hex>", "32-byte hex escrow identifier")
+  .requiredOption("--recipient <address>", "Stacks address of the recipient")
+  .requiredOption("--amount-sats <n>", "Amount of sBTC in satoshis to lock")
+  .requiredOption("--hashlock <hex>", "32-byte SHA-256 hashlock (hex)")
+  .requiredOption(
+    "--timelock-blocks <n>",
+    "Number of blocks from now until expiry"
+  )
+  .option(
+    "--fee <fee>",
+    "Fee preset (low|medium|high) or micro-STX amount; auto-estimated if omitted"
+  )
+  .option(
+    "--contract <contractId>",
+    "Full contract ID if deployed at a custom address"
+  )
+  .action(
+    async (opts: {
+      escrowId: string;
+      recipient: string;
+      amountSats: string;
+      hashlock: string;
+      timelockBlocks: string;
+      fee?: string;
+      contract?: string;
+    }) => {
+      try {
+        const account = await getAccount();
+        const hiro = getHiroApi(NETWORK);
+        const contracts = getContracts(NETWORK);
+        const resolvedFee = await resolveFee(
+          opts.fee,
+          NETWORK,
+          "contract_call"
+        );
+
+        const escrowIdBuf = hexToBuffer(opts.escrowId);
+        const hashlockBuf = hexToBuffer(opts.hashlock);
+        const amount = BigInt(opts.amountSats);
+        const timelockOffset = parseInt(opts.timelockBlocks, 10);
+
+        if (amount <= 0n) {
+          throw new Error("--amount-sats must be a positive integer");
+        }
+        if (timelockOffset <= 0 || isNaN(timelockOffset)) {
+          throw new Error("--timelock-blocks must be a positive integer");
+        }
+
+        // Get current block height to compute absolute timelock
+        const latestBlock = await hiro.getLatestBlock();
+        const currentBlock = latestBlock.height;
+        const absoluteTimelock = currentBlock + timelockOffset;
+
+        // Resolve contract — defaults to deployer's own address
+        const contractId = opts.contract || `${account.address}.escrow-htlc`;
+        const { address: contractAddress, name: contractName } =
+          parseContractId(contractId);
+
+        const functionArgs: ClarityValue[] = [
+          bufferCV(escrowIdBuf),
+          principalCV(opts.recipient),
+          uintCV(amount),
+          bufferCV(hashlockBuf),
+          uintCV(BigInt(absoluteTimelock)),
+        ];
+
+        // Post condition: sender sends exactly `amount` of sBTC
+        const sbtcContract = contracts.SBTC_TOKEN;
+        const postCondition = createFungiblePostCondition(
+          account.address,
+          sbtcContract,
+          "sbtc-token",
+          "eq",
+          amount
+        );
+
+        const result = await callContract(account, {
+          contractAddress,
+          contractName,
+          functionName: "lock",
+          functionArgs,
+          postConditions: [postCondition],
+          ...(resolvedFee !== undefined && { fee: resolvedFee }),
+        });
+
+        printJson({
+          success: true,
+          txid: result.txid,
+          escrowId: opts.escrowId,
+          sender: account.address,
+          recipient: opts.recipient,
+          amountSats: opts.amountSats,
+          hashlock: opts.hashlock,
+          timelockBlock: absoluteTimelock.toString(),
+          currentBlock: currentBlock.toString(),
+          network: NETWORK,
+          explorerUrl: getExplorerTxUrl(result.txid, NETWORK),
+        });
+      } catch (error) {
+        handleError(error);
+      }
+    }
+  );
+
+// ---------------------------------------------------------------------------
+// claim
+// ---------------------------------------------------------------------------
+
+program
+  .command("claim")
+  .description(
+    "Claim escrowed sBTC by revealing the preimage. Requires the recipient's unlocked wallet."
+  )
+  .requiredOption("--escrow-id <hex>", "32-byte hex escrow identifier")
+  .requiredOption(
+    "--preimage <hex>",
+    "32-byte preimage whose SHA-256 matches the hashlock"
+  )
+  .option(
+    "--fee <fee>",
+    "Fee preset (low|medium|high) or micro-STX amount; auto-estimated if omitted"
+  )
+  .option(
+    "--contract <contractId>",
+    "Full contract ID if deployed at a custom address"
+  )
+  .action(
+    async (opts: {
+      escrowId: string;
+      preimage: string;
+      fee?: string;
+      contract?: string;
+    }) => {
+      try {
+        const account = await getAccount();
+        const resolvedFee = await resolveFee(
+          opts.fee,
+          NETWORK,
+          "contract_call"
+        );
+
+        const escrowIdBuf = hexToBuffer(opts.escrowId);
+        const preimageBuf = hexToBuffer(opts.preimage);
+
+        const contractId = opts.contract || `${account.address}.escrow-htlc`;
+        const { address: contractAddress, name: contractName } =
+          parseContractId(contractId);
+
+        const functionArgs: ClarityValue[] = [
+          bufferCV(escrowIdBuf),
+          bufferCV(preimageBuf),
+        ];
+
+        const result = await callContract(account, {
+          contractAddress,
+          contractName,
+          functionName: "claim",
+          functionArgs,
+          ...(resolvedFee !== undefined && { fee: resolvedFee }),
+        });
+
+        printJson({
+          success: true,
+          txid: result.txid,
+          escrowId: opts.escrowId,
+          preimage: opts.preimage,
+          network: NETWORK,
+          explorerUrl: getExplorerTxUrl(result.txid, NETWORK),
+        });
+      } catch (error) {
+        handleError(error);
+      }
+    }
+  );
+
+// ---------------------------------------------------------------------------
+// refund
+// ---------------------------------------------------------------------------
+
+program
+  .command("refund")
+  .description(
+    "Refund escrowed sBTC to the sender after timelock expiry. Requires the sender's unlocked wallet."
+  )
+  .requiredOption("--escrow-id <hex>", "32-byte hex escrow identifier")
+  .option(
+    "--fee <fee>",
+    "Fee preset (low|medium|high) or micro-STX amount; auto-estimated if omitted"
+  )
+  .option(
+    "--contract <contractId>",
+    "Full contract ID if deployed at a custom address"
+  )
+  .action(
+    async (opts: {
+      escrowId: string;
+      fee?: string;
+      contract?: string;
+    }) => {
+      try {
+        const account = await getAccount();
+        const resolvedFee = await resolveFee(
+          opts.fee,
+          NETWORK,
+          "contract_call"
+        );
+
+        const escrowIdBuf = hexToBuffer(opts.escrowId);
+
+        const contractId = opts.contract || `${account.address}.escrow-htlc`;
+        const { address: contractAddress, name: contractName } =
+          parseContractId(contractId);
+
+        const functionArgs: ClarityValue[] = [bufferCV(escrowIdBuf)];
+
+        const result = await callContract(account, {
+          contractAddress,
+          contractName,
+          functionName: "refund",
+          functionArgs,
+          ...(resolvedFee !== undefined && { fee: resolvedFee }),
+        });
+
+        printJson({
+          success: true,
+          txid: result.txid,
+          escrowId: opts.escrowId,
+          network: NETWORK,
+          explorerUrl: getExplorerTxUrl(result.txid, NETWORK),
+        });
+      } catch (error) {
+        handleError(error);
+      }
+    }
+  );
+
+// ---------------------------------------------------------------------------
+// get-escrow
+// ---------------------------------------------------------------------------
+
+program
+  .command("get-escrow")
+  .description("Read-only lookup of escrow status. Does not require a wallet.")
+  .requiredOption("--escrow-id <hex>", "32-byte hex escrow identifier")
+  .option(
+    "--contract <contractId>",
+    "Full contract ID (e.g., SP2...escrow-htlc)"
+  )
+  .action(
+    async (opts: {
+      escrowId: string;
+      contract?: string;
+    }) => {
+      try {
+        const hiro = getHiroApi(NETWORK);
+        const escrowIdBuf = hexToBuffer(opts.escrowId);
+
+        // For read-only calls we need a sender address
+        let senderAddress: string;
+        try {
+          senderAddress = await getWalletAddress();
+        } catch {
+          senderAddress = "SP000000000000000000002Q6VF78";
+        }
+
+        const contractId =
+          opts.contract || `${senderAddress}.escrow-htlc`;
+
+        const response = await hiro.callReadOnlyFunction(
+          contractId,
+          "get-escrow",
+          [bufferCV(escrowIdBuf)],
+          senderAddress
+        );
+
+        if (!response.okay || !response.result) {
+          printJson({
+            escrowId: opts.escrowId,
+            found: false,
+            network: NETWORK,
+          });
+          return;
+        }
+
+        const parsed = parseReadOnlyResult(response.result);
+
+        printJson({
+          escrowId: opts.escrowId,
+          found: true,
+          escrow: parsed,
+          network: NETWORK,
+        });
+      } catch (error) {
+        handleError(error);
+      }
+    }
+  );
+
+// ---------------------------------------------------------------------------
+// Parse
+// ---------------------------------------------------------------------------
+
+program.parse();

--- a/escrow-htlc/tests/escrow-htlc.test.ts
+++ b/escrow-htlc/tests/escrow-htlc.test.ts
@@ -1,0 +1,341 @@
+/**
+ * escrow-htlc unit tests
+ *
+ * Tests cover TI's 7-point acceptance checklist:
+ * 1. HTLC preimage reveal releases funds (happy path)
+ * 2. Timelock expiry returns full amount to sender
+ * 3. Double-claim attempt fails cleanly
+ * 4. Zero AMM/DEX dependency (pure logic tests, no swap calls)
+ * 5. Single settlement asset (all transfers use sbtc-token only)
+ * 6. Contract prints on lock / claim / refund
+ * 7. Edge cases: wrong preimage, premature refund, non-recipient claim
+ */
+
+import { describe, it, expect } from "bun:test";
+import { createHash, randomBytes } from "node:crypto";
+
+// ── Pure logic helpers (mirror contract logic) ────────────────────────────────
+
+function sha256(preimage: Buffer): Buffer {
+  return createHash("sha256").update(preimage).digest();
+}
+
+function hexToBuffer(hex: string): Buffer {
+  if (hex.startsWith("0x")) hex = hex.slice(2);
+  return Buffer.from(hex, "hex");
+}
+
+// Simulated escrow state (mirrors the Clarity map entry)
+interface EscrowState {
+  sender: string;
+  recipient: string;
+  amount: bigint;
+  hashlock: Buffer;
+  timelock: number;    // absolute block height
+  claimed: boolean;
+  refunded: boolean;
+}
+
+// Simulated contract engine (validates the same logic as Clarity contract)
+const ERR = {
+  ALREADY_EXISTS:    100,
+  NOT_FOUND:         101,
+  ALREADY_CLAIMED:   102,
+  ALREADY_REFUNDED:  103,
+  WRONG_PREIMAGE:    104,
+  TIMELOCK_ACTIVE:   105,
+  TIMELOCK_EXPIRED:  106,
+  ZERO_AMOUNT:       107,
+  NOT_RECIPIENT:     108,
+  NOT_SENDER:        109,
+  BAD_TIMELOCK:      110,
+};
+
+class SimulatedContract {
+  private escrows = new Map<string, EscrowState>();
+  private events: object[] = [];
+
+  lock(
+    caller: string,
+    escrowId: Buffer,
+    recipient: string,
+    amount: bigint,
+    hashlock: Buffer,
+    timelock: number,
+    currentBlock: number
+  ): { ok: true } | { err: number } {
+    const key = escrowId.toString("hex");
+    if (this.escrows.has(key))   return { err: ERR.ALREADY_EXISTS };
+    if (amount === 0n)           return { err: ERR.ZERO_AMOUNT };
+    if (timelock <= currentBlock) return { err: ERR.BAD_TIMELOCK };
+
+    this.escrows.set(key, {
+      sender: caller, recipient, amount, hashlock, timelock,
+      claimed: false, refunded: false
+    });
+    this.events.push({ event: "lock", escrowId: key, sender: caller, recipient, amount: amount.toString(), timelock });
+    return { ok: true };
+  }
+
+  claim(
+    caller: string,
+    escrowId: Buffer,
+    preimage: Buffer,
+    currentBlock: number
+  ): { ok: true; amount: bigint; recipient: string } | { err: number } {
+    const key = escrowId.toString("hex");
+    const e = this.escrows.get(key);
+    if (!e)                         return { err: ERR.NOT_FOUND };
+    if (caller !== e.recipient)     return { err: ERR.NOT_RECIPIENT };
+    if (e.claimed)                  return { err: ERR.ALREADY_CLAIMED };
+    if (e.refunded)                 return { err: ERR.ALREADY_REFUNDED };
+    if (currentBlock > e.timelock)  return { err: ERR.TIMELOCK_EXPIRED };
+    if (!sha256(preimage).equals(e.hashlock)) return { err: ERR.WRONG_PREIMAGE };
+
+    e.claimed = true;
+    this.events.push({ event: "claim", escrowId: key, recipient: e.recipient, amount: e.amount.toString() });
+    return { ok: true, amount: e.amount, recipient: e.recipient };
+  }
+
+  refund(
+    caller: string,
+    escrowId: Buffer,
+    currentBlock: number
+  ): { ok: true; amount: bigint; sender: string } | { err: number } {
+    const key = escrowId.toString("hex");
+    const e = this.escrows.get(key);
+    if (!e)                          return { err: ERR.NOT_FOUND };
+    if (caller !== e.sender)         return { err: ERR.NOT_SENDER };
+    if (e.claimed)                   return { err: ERR.ALREADY_CLAIMED };
+    if (e.refunded)                  return { err: ERR.ALREADY_REFUNDED };
+    if (currentBlock <= e.timelock)  return { err: ERR.TIMELOCK_ACTIVE };
+
+    e.refunded = true;
+    this.events.push({ event: "refund", escrowId: key, sender: e.sender, amount: e.amount.toString() });
+    return { ok: true, amount: e.amount, sender: e.sender };
+  }
+
+  getEscrow(escrowId: Buffer): EscrowState | undefined {
+    return this.escrows.get(escrowId.toString("hex"));
+  }
+
+  getEvents(): object[] { return [...this.events]; }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("escrow-htlc", () => {
+  const SENDER    = "SP1SENDER000000000000000000000000000";
+  const RECIPIENT = "SP1RECIPIENT0000000000000000000000000";
+  const AMOUNT    = BigInt(100_000); // 100k sats
+
+  function freshScenario() {
+    const preimage  = randomBytes(32);
+    const hashlock  = sha256(preimage);
+    const escrowId  = randomBytes(32);
+    const contract  = new SimulatedContract();
+    return { preimage, hashlock, escrowId, contract };
+  }
+
+  // ── TI Checklist #1: Happy path — lock → claim releases funds ──────────────
+
+  describe("1. Happy path: lock → claim", () => {
+    it("claim succeeds with correct preimage before timelock", () => {
+      const { preimage, hashlock, escrowId, contract } = freshScenario();
+      const currentBlock = 100;
+      const timelock     = 200;
+
+      const lockResult = contract.lock(SENDER, escrowId, RECIPIENT, AMOUNT, hashlock, timelock, currentBlock);
+      expect(lockResult).toEqual({ ok: true });
+
+      const claimResult = contract.claim(RECIPIENT, escrowId, preimage, currentBlock + 1);
+      expect(claimResult).toMatchObject({ ok: true, amount: AMOUNT, recipient: RECIPIENT });
+    });
+
+    it("escrow is marked claimed after successful claim", () => {
+      const { preimage, hashlock, escrowId, contract } = freshScenario();
+      contract.lock(SENDER, escrowId, RECIPIENT, AMOUNT, hashlock, 200, 100);
+      contract.claim(RECIPIENT, escrowId, preimage, 101);
+      const state = contract.getEscrow(escrowId);
+      expect(state?.claimed).toBe(true);
+      expect(state?.refunded).toBe(false);
+    });
+  });
+
+  // ── TI Checklist #2: Timelock expiry returns full amount to sender ─────────
+
+  describe("2. Refund returns full amount after expiry", () => {
+    it("refund succeeds after timelock and returns full amount", () => {
+      const { hashlock, escrowId, contract } = freshScenario();
+      contract.lock(SENDER, escrowId, RECIPIENT, AMOUNT, hashlock, 100, 50);
+
+      const result = contract.refund(SENDER, escrowId, 101); // block 101 > timelock 100
+      expect(result).toMatchObject({ ok: true, amount: AMOUNT, sender: SENDER });
+    });
+
+    it("refunded escrow shows refunded=true, claimed=false", () => {
+      const { hashlock, escrowId, contract } = freshScenario();
+      contract.lock(SENDER, escrowId, RECIPIENT, AMOUNT, hashlock, 100, 50);
+      contract.refund(SENDER, escrowId, 101);
+      const state = contract.getEscrow(escrowId);
+      expect(state?.refunded).toBe(true);
+      expect(state?.claimed).toBe(false);
+    });
+  });
+
+  // ── TI Checklist #3: Double-claim fails cleanly ───────────────────────────
+
+  describe("3. Double-claim fails cleanly", () => {
+    it("second claim after first succeeds returns ERR-ALREADY-CLAIMED", () => {
+      const { preimage, hashlock, escrowId, contract } = freshScenario();
+      contract.lock(SENDER, escrowId, RECIPIENT, AMOUNT, hashlock, 200, 100);
+      contract.claim(RECIPIENT, escrowId, preimage, 101);
+
+      const second = contract.claim(RECIPIENT, escrowId, preimage, 102);
+      expect(second).toEqual({ err: ERR.ALREADY_CLAIMED });
+    });
+
+    it("claim on refunded escrow returns ERR-ALREADY-REFUNDED", () => {
+      const { preimage, hashlock, escrowId, contract } = freshScenario();
+      contract.lock(SENDER, escrowId, RECIPIENT, AMOUNT, hashlock, 100, 50);
+      contract.refund(SENDER, escrowId, 101);
+
+      const result = contract.claim(RECIPIENT, escrowId, preimage, 102);
+      expect(result).toEqual({ err: ERR.ALREADY_REFUNDED });
+    });
+
+    it("double-refund fails with ERR-ALREADY-REFUNDED", () => {
+      const { hashlock, escrowId, contract } = freshScenario();
+      contract.lock(SENDER, escrowId, RECIPIENT, AMOUNT, hashlock, 100, 50);
+      contract.refund(SENDER, escrowId, 101);
+
+      const second = contract.refund(SENDER, escrowId, 102);
+      expect(second).toEqual({ err: ERR.ALREADY_REFUNDED });
+    });
+  });
+
+  // ── TI Checklist #4 & #5: No AMM / single asset ───────────────────────────
+
+  describe("4+5. No DEX/AMM dependency, single asset", () => {
+    it("contract has no swap or DEX function calls", () => {
+      // Structural test: verify Clarity contract has no DEX/AMM *function calls* (comments excluded)
+      const fs = require("node:fs");
+      const path = require("node:path");
+      const contractSrc = fs.readFileSync(
+        path.join(__dirname, "../contracts/escrow-htlc.clar"),
+        "utf8"
+      );
+      // Strip comment lines before checking
+      const codeOnly = contractSrc
+        .split("\n")
+        .filter((line: string) => !line.trimStart().startsWith(";;"))
+        .join("\n");
+      expect(codeOnly).not.toMatch(/bitflow|alex-token|swap-router|amm-pool/i);
+    });
+
+    it("only sbtc-token transfers appear in contract source", () => {
+      const fs = require("node:fs");
+      const path = require("node:path");
+      const contractSrc = fs.readFileSync(
+        path.join(__dirname, "../contracts/escrow-htlc.clar"),
+        "utf8"
+      );
+      const transfers = [...contractSrc.matchAll(/contract-call\?\s+(\S+)\s+transfer/g)];
+      expect(transfers.length).toBeGreaterThan(0);
+      transfers.forEach(([, contractRef]) => {
+        expect(contractRef).toMatch(/sbtc/i);
+      });
+    });
+  });
+
+  // ── TI Checklist #6: Contract prints on lock / claim / refund ─────────────
+
+  describe("6. Events emitted on all state transitions", () => {
+    it("lock emits a lock event", () => {
+      const { hashlock, escrowId, contract } = freshScenario();
+      contract.lock(SENDER, escrowId, RECIPIENT, AMOUNT, hashlock, 200, 100);
+      const events = contract.getEvents();
+      expect(events.some((e: any) => e.event === "lock")).toBe(true);
+    });
+
+    it("claim emits a claim event", () => {
+      const { preimage, hashlock, escrowId, contract } = freshScenario();
+      contract.lock(SENDER, escrowId, RECIPIENT, AMOUNT, hashlock, 200, 100);
+      contract.claim(RECIPIENT, escrowId, preimage, 101);
+      const events = contract.getEvents();
+      expect(events.some((e: any) => e.event === "claim")).toBe(true);
+    });
+
+    it("refund emits a refund event", () => {
+      const { hashlock, escrowId, contract } = freshScenario();
+      contract.lock(SENDER, escrowId, RECIPIENT, AMOUNT, hashlock, 100, 50);
+      contract.refund(SENDER, escrowId, 101);
+      const events = contract.getEvents();
+      expect(events.some((e: any) => e.event === "refund")).toBe(true);
+    });
+  });
+
+  // ── TI Checklist #7: Edge cases ───────────────────────────────────────────
+
+  describe("7. Edge cases", () => {
+    it("wrong preimage fails with ERR-WRONG-PREIMAGE", () => {
+      const { hashlock, escrowId, contract } = freshScenario();
+      const wrongPreimage = randomBytes(32);
+      contract.lock(SENDER, escrowId, RECIPIENT, AMOUNT, hashlock, 200, 100);
+      const result = contract.claim(RECIPIENT, escrowId, wrongPreimage, 101);
+      expect(result).toEqual({ err: ERR.WRONG_PREIMAGE });
+    });
+
+    it("premature refund fails with ERR-TIMELOCK-ACTIVE", () => {
+      const { hashlock, escrowId, contract } = freshScenario();
+      contract.lock(SENDER, escrowId, RECIPIENT, AMOUNT, hashlock, 200, 100);
+      const result = contract.refund(SENDER, escrowId, 150); // block 150 <= timelock 200
+      expect(result).toEqual({ err: ERR.TIMELOCK_ACTIVE });
+    });
+
+    it("claim after timelock fails with ERR-TIMELOCK-EXPIRED", () => {
+      const { preimage, hashlock, escrowId, contract } = freshScenario();
+      contract.lock(SENDER, escrowId, RECIPIENT, AMOUNT, hashlock, 100, 50);
+      const result = contract.claim(RECIPIENT, escrowId, preimage, 101); // block 101 > timelock 100
+      expect(result).toEqual({ err: ERR.TIMELOCK_EXPIRED });
+    });
+
+    it("non-recipient claim fails with ERR-NOT-RECIPIENT", () => {
+      const { preimage, hashlock, escrowId, contract } = freshScenario();
+      contract.lock(SENDER, escrowId, RECIPIENT, AMOUNT, hashlock, 200, 100);
+      const result = contract.claim("SP1ATTACKER000000000000000000000000", escrowId, preimage, 101);
+      expect(result).toEqual({ err: ERR.NOT_RECIPIENT });
+    });
+
+    it("non-sender refund fails with ERR-NOT-SENDER", () => {
+      const { hashlock, escrowId, contract } = freshScenario();
+      contract.lock(SENDER, escrowId, RECIPIENT, AMOUNT, hashlock, 100, 50);
+      const result = contract.refund("SP1ATTACKER000000000000000000000000", escrowId, 101);
+      expect(result).toEqual({ err: ERR.NOT_SENDER });
+    });
+
+    it("duplicate escrow-id fails with ERR-ALREADY-EXISTS", () => {
+      const { hashlock, escrowId, contract } = freshScenario();
+      contract.lock(SENDER, escrowId, RECIPIENT, AMOUNT, hashlock, 200, 100);
+      const second = contract.lock(SENDER, escrowId, RECIPIENT, AMOUNT, hashlock, 300, 100);
+      expect(second).toEqual({ err: ERR.ALREADY_EXISTS });
+    });
+
+    it("zero amount fails with ERR-ZERO-AMOUNT", () => {
+      const { hashlock, escrowId, contract } = freshScenario();
+      const result = contract.lock(SENDER, escrowId, RECIPIENT, 0n, hashlock, 200, 100);
+      expect(result).toEqual({ err: ERR.ZERO_AMOUNT });
+    });
+
+    it("timelock in the past fails with ERR-BAD-TIMELOCK", () => {
+      const { hashlock, escrowId, contract } = freshScenario();
+      const result = contract.lock(SENDER, escrowId, RECIPIENT, AMOUNT, hashlock, 99, 100);
+      expect(result).toEqual({ err: ERR.BAD_TIMELOCK });
+    });
+
+    it("lookup of nonexistent escrow returns undefined", () => {
+      const { escrowId, contract } = freshScenario();
+      expect(contract.getEscrow(escrowId)).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Trust-minimized Hash Time-Locked Contract (HTLC) for agent-to-agent sBTC escrow on Stacks mainnet.

**Design:**
- `lock` — sender deposits sBTC, sets sha256 hashlock + absolute block timelock
- `claim` — recipient reveals preimage, receives sBTC (atomic, same block)
- `refund` — sender reclaims full amount after timelock expiry, no fees

## TI 7-Point Checklist

- [x] 1. HTLC preimage reveal releases funds in same block (atomic `claim` tx)
- [x] 2. Timelock expiry returns full amount to sender (no fee deduction)
- [x] 3. Double-claim and double-refund both fail cleanly (`ERR-ALREADY-CLAIMED` u102, `ERR-ALREADY-REFUNDED` u103)
- [x] 4. Zero AMM/DEX dependency — pure HTLC only, no swap integration
- [x] 5. Single settlement asset (sBTC via `sbtc-token`), no mid-flow conversion
- [x] 6. Contract prints on `lock` / `claim` / `refund`
- [x] 7. 21 unit tests passing: happy path + refund path + 9 edge cases

## Files

| File | Purpose |
|------|---------|
| `escrow-htlc/contracts/escrow-htlc.clar` | Clarity contract |
| `escrow-htlc/escrow-htlc.ts` | TypeScript CLI (lock, claim, refund, get-escrow, generate-lock-params) |
| `escrow-htlc/SKILL.md` | Skill docs + frontmatter |
| `escrow-htlc/AGENT.md` | Autonomous operation rules |
| `escrow-htlc/tests/escrow-htlc.test.ts` | 21 tests, all passing |

## Test Results

```
21 pass, 0 fail
```

Covers: happy path, refund path, double-claim, double-refund, wrong preimage, premature refund, expired claim, non-recipient claim, non-sender refund, duplicate escrow-id, zero amount, bad timelock, DEX/AMM absence, single asset verification, event emission.

Closes the escrow/x402-clearing scope committed to Trustless Indra (TI). inbox-ops-kit is a separate PR.