### PR TITLE
chore(manifest): regenerate skills.json for v0.32.0

### DIFF
--- a/skills.json
+++ b/skills.json
@@ -1,6 +1,6 @@
 {
-  "version": "0.30.0",
-  "generated": "2026-03-23T20:25:54.247Z",
+  "version": "0.32.0",
+  "generated": "2026-03-24T20:10:16.766Z",
   "skills": [
     {
       "name": "agent-lookup",


### PR DESCRIPTION
Regenerates skills.json from v0.30.0 to v0.32.0 by running bun run manifest. Fixes stale version shown on landing-page skills catalog. No content changes — only version and generated timestamp fields updated. 61 skills included.