### PR TITLE
fix: update scaffold, docs, and bounty-scanner for nested metadata format

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,19 +28,22 @@ Steps to add a new skill:
    ---
    name: <name>
    description: One-line description of what the skill does
-   author: your-github-username
-   author_agent: Your Agent Name
-   user-invocable: false
-   arguments: subcommand1 | subcommand2 | subcommand3
-   entry: <name>/<name>.ts
-   requires: [wallet]
-   tags: [l2, write]
+   metadata:
+     author: your-github-username
+     author-agent: Your Agent Name
+     user-invocable: "false"
+     arguments: subcommand1 | subcommand2 | subcommand3
+     entry: <name>/<name>.ts
+     requires: "wallet"
+     tags: "l2, write"
    ---
    ```
 
    **Author fields:**
-   - `author` (required for new skills) — GitHub username of the skill creator. Used for attribution on aibtc.com/skills.
-   - `author_agent` (optional) — Display name of the agent that built the skill (e.g. "Tiny Marten", "Fluid Briar"). When present, the skills page links the skill to the agent's profile.
+   - `metadata.author` (required for new skills) — GitHub username of the skill creator. Used for attribution on aibtc.com/skills.
+   - `metadata.author-agent` (optional) — Display name of the agent that built the skill (e.g. "Tiny Marten", "Fluid Briar"). When present, the skills page links the skill to the agent's profile.
+
+   **Valid tag values:** `l1`, `l2`, `read-only`, `write`, `mainnet-only`, `requires-funds`, `sensitive`, `infrastructure`, `defi`
 3. Add `AGENT.md` covering prerequisites, safety checks, and error-handling patterns
 4. Add `<name>/<name>.ts` — a Commander CLI where every subcommand prints a JSON object to stdout
 5. Add an entry to the Skills table in `README.md`

--- a/bounty-scanner/bounty-scanner.ts
+++ b/bounty-scanner/bounty-scanner.ts
@@ -185,20 +185,38 @@ function parseFrontmatter(content: string): SkillInfo | null {
   }
 
   const fields: Record<string, string> = {};
+  let inMetadata = false;
   for (const line of frontmatterLines) {
+    // Detect nested `metadata:` block (agentskills.io spec format)
+    if (line.trim() === "metadata:") {
+      inMetadata = true;
+      continue;
+    }
+    // Exit metadata block on next top-level key (no leading whitespace)
+    if (inMetadata && line.length > 0 && !line.startsWith(" ") && !line.startsWith("\t")) {
+      inMetadata = false;
+    }
     const colonIdx = line.indexOf(":");
     if (colonIdx === -1) continue;
     const key = line.slice(0, colonIdx).trim();
     const value = line.slice(colonIdx + 1).trim();
-    fields[key] = value;
+    // Store with metadata. prefix when inside metadata block, plain otherwise
+    if (inMetadata) {
+      fields[`metadata.${key}`] = value;
+    } else {
+      fields[key] = value;
+    }
   }
 
   if (!fields.name) return null;
 
+  // Support both flat (legacy) and nested (agentskills.io) tag formats
+  const rawTags = fields["metadata.tags"] ?? fields.tags ?? "";
+
   return {
     name: fields.name,
-    description: fields.description ?? "",
-    tags: parseBracketList(fields.tags ?? "[]"),
+    description: fields.description ?? fields["metadata.description"] ?? "",
+    tags: parseBracketList(rawTags),
   };
 }
 

--- a/scripts/scaffold-skill.ts
+++ b/scripts/scaffold-skill.ts
@@ -34,23 +34,23 @@ function skillMd(name: string): string {
   return `---
 name: ${name}
 description: TODO — one-line description of what ${title} does
-author: TODO — your GitHub username
-author_agent: TODO — your agent name (or remove this line)
-user-invocable: false
-arguments: TODO — list subcommands separated by |
-entry: ${name}/${name}.ts
-requires: []
-tags: []
+metadata:
+  author: TODO — your GitHub username
+  author-agent: TODO — your agent name (or remove this line)
+  user-invocable: "false"
+  arguments: TODO — list subcommands separated by |
+  entry: ${name}/${name}.ts
+  requires: ""
+  tags: ""
 ---
 
 # ${title}
 
 TODO — describe what this skill does and when an agent should use it.
 
-> **Before committing:** Update the \`requires\` and \`tags\` fields in the
-> frontmatter above. Common values — requires: \`[wallet]\`; tags: \`l1\`,
-> \`l2\`, \`read-only\`, \`write\`, \`requires-funds\`, \`sensitive\`,
-> \`defi\`, \`infrastructure\`, \`mainnet-only\`.
+> **Before committing:** Update the \`metadata.requires\` and \`metadata.tags\` fields in the
+> frontmatter above. Common values — requires: \`"wallet"\`, \`"wallet, signing"\`;
+> tags: \`"l2, write"\`, \`"l2, read-only"\`, \`"l1, requires-funds"\`.
 
 ## Usage
 


### PR DESCRIPTION
Fixes three pre-existing issues flagged by Devin code review:

## Changes

### fix(scaffold-skill): generate correct nested metadata format
`scripts/scaffold-skill.ts` was generating SKILL.md with the old flat YAML format (`user-invocable`, `arguments`, `entry`, `requires`, `tags` at top-level). The validator (`validate-frontmatter.ts`) now requires these under `metadata:`. Any agent using the scaffold tool would immediately fail validation.

### fix(contributing): update SKILL.md frontmatter example
CONTRIBUTING.md documented the old flat format. Updated to show the correct nested `metadata:` structure with valid tag values reference.

### fix(bounty-scanner): handle nested metadata in parseFrontmatter
`parseFrontmatter()` used a simple key-value parser that only read top-level YAML keys. Since all SKILL.md files now use `metadata.tags` nesting, the bounty scanner was missing tags entirely — causing incorrect skill matching results. Now handles both flat (legacy) and nested (agentskills.io) formats.

## Testing
- `bun run typecheck` passes
- `bun run manifest` generates 65 skills
- `bun run scripts/validate-frontmatter.ts` passes on all skills