### PR TITLE
fix(rune-transfer-builder): only set changeOutput pointer when change output is included

### DIFF
--- a/src/lib/transactions/rune-transfer-builder.ts
+++ b/src/lib/transactions/rune-transfer-builder.ts
@@ -10,8 +10,8 @@
  * - P2TR output: rune change back to sender (if partial transfer)
  * - P2WPKH output: BTC change back to sender
  *
- * The Runestone always includes an explicit change pointer to avoid
- * burning remaining runes.
+ * The Runestone includes a change pointer only when the change output is
+ * actually included in the transaction.
  */
 
 import * as btc from "@scure/btc-signer";
@@ -183,6 +183,10 @@ export function buildRuneTransfer(options: RuneTransferOptions): RuneTransferRes
   //   Output 2: Rune change (remaining runes back to sender taproot)
   //   Output 3: BTC change (fee remainder back to sender segwit)
 
+  // Compute rune change sats BEFORE building Runestone so we know whether to include change pointer
+  const runeSats = runeUtxos.reduce((sum, u) => sum + u.value, 0);
+  const runeChangeSats = runeSats - DUST_THRESHOLD; // recipient gets dust from rune sats
+
   // Build Runestone
   const edict: RuneEdict = {
     block,
@@ -193,7 +197,7 @@ export function buildRuneTransfer(options: RuneTransferOptions): RuneTransferRes
 
   const runestoneScript = buildRunestoneScript({
     edict,
-    changeOutput: 2, // rune change is output 2
+    changeOutput: runeChangeSats >= DUST_THRESHOLD ? 2 : undefined, // only set when change output is included
   });
 
   // Output 0: OP_RETURN
@@ -206,9 +210,7 @@ export function buildRuneTransfer(options: RuneTransferOptions): RuneTransferRes
   tx.addOutputAddress(recipientAddress, BigInt(DUST_THRESHOLD), btcNetwork);
 
   // Output 2: Rune change back to sender taproot
-  // Carries remaining rune balance (Runestone change pointer = 2)
-  const runeSats = runeUtxos.reduce((sum, u) => sum + u.value, 0);
-  const runeChangeSats = runeSats - DUST_THRESHOLD; // recipient gets dust from rune sats
+  // Carries remaining rune balance (Runestone change pointer = 2, only when included)
   if (runeChangeSats >= DUST_THRESHOLD) {
     tx.addOutputAddress(senderTaprootAddress, BigInt(runeChangeSats), btcNetwork);
   }

--- a/src/lib/transactions/runestone-builder.ts
+++ b/src/lib/transactions/runestone-builder.ts
@@ -59,14 +59,14 @@ export interface RuneEdict {
 export interface RunestoneOptions {
   /** The edict (single transfer) */
   edict: RuneEdict;
-  /** Output index for remaining rune balance (change pointer) */
-  changeOutput: number;
+  /** Output index for remaining rune balance (change pointer) — omit to burn change (not recommended); set when change output is included */
+  changeOutput?: number;
 }
 
 /**
  * Build a Runestone OP_RETURN script for a single-edict rune transfer.
  *
- * Always includes an explicit change pointer to avoid burning remaining runes.
+ * Includes a change pointer only when the change output is actually included in the transaction.
  */
 export function buildRunestoneScript(options: RunestoneOptions): Uint8Array {
   const { edict, changeOutput } = options;
@@ -88,10 +88,12 @@ export function buildRunestoneScript(options: RunestoneOptions): Uint8Array {
   parts.push(tag0, edictAmount);
   parts.push(tag0, edictOutput);
 
-  // Tag 22: default output (change pointer)
-  const tag22 = encodeLEB128(22n);
-  const changeIdx = encodeLEB128(BigInt(changeOutput));
-  parts.push(tag22, changeIdx);
+  // Tag 22: default output (change pointer) — only when change output is included
+  if (changeOutput !== undefined) {
+    const tag22 = encodeLEB128(22n);
+    const changeIdx = encodeLEB128(BigInt(changeOutput));
+    parts.push(tag22, changeIdx);
+  }
 
   // Calculate total payload length
   const payloadLength = parts.reduce((sum, p) => sum + p.length, 0);


### PR DESCRIPTION
## Summary

- Fix `buildRuneTransfer` to only set the Runestone `changeOutput` pointer when the rune change output is actually included in the transaction
- Make `RunestoneOptions.changeOutput` optional (`number | undefined`) to enforce correct usage at the type level

Fixes #229

## Root cause

`buildRunestoneScript` was always called with `changeOutput: 2`, but output index 2 is only conditionally added when `runeChangeSats >= DUST_THRESHOLD`. For typical rune UTXOs at dust value (546 sats), `runeChangeSats` is often below the threshold. The Runestone then pointed at either a non-existent output or the wrong output, causing the protocol to burn the remaining runes.

## Fix

Compute `runeChangeSats` before building the Runestone, then pass `changeOutput: runeChangeSats >= DUST_THRESHOLD ? 2 : undefined`. When `changeOutput` is `undefined`, the Runestone encodes no Tag 22 change pointer — correct behavior when there is no change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)