### PR TITLE
fix(rune-transfer): only set changeOutput pointer when change output is included

### DIFF
--- a/src/lib/transactions/rune-transfer-builder.ts
+++ b/src/lib/transactions/rune-transfer-builder.ts
@@ -191,9 +191,15 @@ export function buildRuneTransfer(options: RuneTransferOptions): RuneTransferRes
     outputIndex: 1, // recipient is output 1
   };
 
+  // Only set the change pointer when the rune change output will actually be
+  // added to the transaction (i.e. when runeChangeSats >= DUST_THRESHOLD).
+  // Pointing to a non-existent output index burns the remaining runes.
+  const runeChangeSatsEstimate = runeUtxos.reduce((sum, u) => sum + u.value, 0) - DUST_THRESHOLD;
+  const changeOutputIndex = runeChangeSatsEstimate >= DUST_THRESHOLD ? 2 : undefined;
+
   const runestoneScript = buildRunestoneScript({
     edict,
-    changeOutput: 2, // rune change is output 2
+    changeOutput: changeOutputIndex,
   });
 
   // Output 0: OP_RETURN

--- a/src/lib/transactions/runestone-builder.ts
+++ b/src/lib/transactions/runestone-builder.ts
@@ -59,14 +59,20 @@ export interface RuneEdict {
 export interface RunestoneOptions {
   /** The edict (single transfer) */
   edict: RuneEdict;
-  /** Output index for remaining rune balance (change pointer) */
-  changeOutput: number;
+  /**
+   * Output index for remaining rune balance (change pointer).
+   * Only set this when the change output is actually included in the
+   * transaction. Omitting it (or passing undefined) when there is no change
+   * output prevents the Runestone from pointing to a non-existent output,
+   * which would otherwise cause the remaining runes to be burned.
+   */
+  changeOutput?: number;
 }
 
 /**
  * Build a Runestone OP_RETURN script for a single-edict rune transfer.
  *
- * Always includes an explicit change pointer to avoid burning remaining runes.
+ * Includes an explicit change pointer only when a change output is present.
  */
 export function buildRunestoneScript(options: RunestoneOptions): Uint8Array {
   const { edict, changeOutput } = options;
@@ -88,10 +94,13 @@ export function buildRunestoneScript(options: RunestoneOptions): Uint8Array {
   parts.push(tag0, edictAmount);
   parts.push(tag0, edictOutput);
 
-  // Tag 22: default output (change pointer)
-  const tag22 = encodeLEB128(22n);
-  const changeIdx = encodeLEB128(BigInt(changeOutput));
-  parts.push(tag22, changeIdx);
+  // Tag 22: default output (change pointer) — only encoded when a change
+  // output is actually present in the transaction.
+  if (changeOutput !== undefined) {
+    const tag22 = encodeLEB128(22n);
+    const changeIdx = encodeLEB128(BigInt(changeOutput));
+    parts.push(tag22, changeIdx);
+  }
 
   // Calculate total payload length
   const payloadLength = parts.reduce((sum, p) => sum + p.length, 0);


### PR DESCRIPTION
## Summary

- **Bug**: `buildRuneTransfer` always set `changeOutput: 2` in the Runestone, but output index 2 (rune change back to sender) is only conditionally added when `runeChangeSats >= DUST_THRESHOLD`. When change falls below dust (common with 546-sat UTXOs), the change output is skipped but the Runestone still contains Tag 22 pointing to index 2 — a non-existent output — causing the protocol to burn the remaining runes.
- **Fix**: Compute `changeOutputIndex` before building the Runestone; set it to `2` only when the change output will actually be present, otherwise pass `undefined` so Tag 22 is omitted from the encoded Runestone.
- **Also**: Made `RunestoneOptions.changeOutput` optional (`number | undefined`) and guarded the Tag 22 encoding in `buildRunestoneScript` to only emit the pointer field when a value is provided.

## Affected files

- `src/lib/transactions/rune-transfer-builder.ts`
- `src/lib/transactions/runestone-builder.ts`

## Test plan

- [ ] Transfer runes with a single 546-sat rune UTXO — `runeChangeSats` will be 0 (below dust); verify no Tag 22 in Runestone and runes arrive at recipient without burning
- [ ] Transfer runes with a larger rune UTXO (e.g. 2000 sats) — `runeChangeSats` = 1454 (>= dust); verify Tag 22 = 2 is present and the change output is included
- [ ] Existing unit tests for `buildRunestoneScript` and `buildRuneTransfer` pass

closes #229

🤖 Generated with [Claude Code](https://claude.com/claude-code)