### PR TITLE
feat: add execution-readiness-guard skill

### DIFF
--- a/execution-readiness-guard/AGENT.md
+++ b/execution-readiness-guard/AGENT.md
@@ -1,0 +1,50 @@
+# Execution Readiness Guard — Agent Guide
+
+## Role
+
+The Execution Readiness Guard is a decision skill responsible for determining whether a route is safe to execute.
+
+It should be used as a final gating step before any execution attempt.
+
+## When to Use
+
+Use this skill:
+
+- After route selection
+- After protocol and route health evaluation
+- Before sending any transaction
+- In any system where execution safety matters
+
+## What It Does
+
+This skill evaluates:
+
+- Route operator decision
+- Route health status
+- Protocol health status
+- Route performance score
+
+It then determines:
+
+- If execution is allowed
+- If execution must be blocked
+- If the route is degraded and should not be executed
+
+## Decision Priority
+
+The evaluation follows strict priority:
+
+1. Route operator (BLOCK)
+2. Route health (blocked)
+3. Protocol health (blocked)
+4. Route performance (degraded)
+
+## How to Integrate
+
+This skill expects:
+
+```json
+{
+  "route": "string",
+  "state": "object"
+}

--- a/execution-readiness-guard/SKILL.md
+++ b/execution-readiness-guard/SKILL.md
@@ -1,0 +1,25 @@
+# Execution Readiness Guard
+
+## Overview
+
+The Execution Readiness Guard is a decision skill that evaluates whether a route is safe and eligible for execution.
+
+It consumes consolidated state from multiple upstream skills and determines if execution should proceed, be blocked, or considered degraded.
+
+## Purpose
+
+This skill acts as a final safety checkpoint before execution.
+
+It ensures that:
+
+- Blocked routes are never executed
+- Degraded routes are identified and prevented from execution
+- Only healthy routes are eligible
+
+## Input
+
+```json
+{
+  "route": "string",
+  "state": "object"
+}

--- a/execution-readiness-guard/execution-readiness-guard.ts
+++ b/execution-readiness-guard/execution-readiness-guard.ts
@@ -1,0 +1,100 @@
+'use strict';
+
+type Input = {
+  route: string;
+  state: any;
+};
+
+type Output = {
+  ok: boolean;
+  route: string;
+  readiness: 'healthy' | 'degraded' | 'blocked';
+  eligible: boolean;
+  reason: string;
+};
+
+function evaluateReadiness(input: Input): Output {
+  const route = input?.route;
+  const state = input?.state || {};
+
+  const routeOperator = state?.routeOperatorByRoute?.[route] || null;
+  const routeHealth = state?.routeHealthByRoute?.[route] || null;
+  const protocol = routeOperator?.protocol;
+  const protocolHealth = state?.protocolHealthByProtocol?.[protocol] || null;
+  const routeScore = state?.routeScoreByRoute?.[route] || null;
+
+  // BLOCK conditions
+  if (!routeOperator || routeOperator?.decision === 'BLOCK') {
+    return {
+      ok: true,
+      route,
+      readiness: 'blocked',
+      eligible: false,
+      reason: 'ROUTE_OPERATOR_BLOCKED'
+    };
+  }
+
+  if (routeHealth?.status === 'blocked') {
+    return {
+      ok: true,
+      route,
+      readiness: 'blocked',
+      eligible: false,
+      reason: routeHealth?.reason || 'ROUTE_BLOCKED'
+    };
+  }
+
+  if (protocolHealth?.status === 'blocked') {
+    return {
+      ok: true,
+      route,
+      readiness: 'blocked',
+      eligible: false,
+      reason: protocolHealth?.reason || 'PROTOCOL_BLOCKED'
+    };
+  }
+
+  // DEGRADED condition
+  if (routeScore?.status === 'degraded') {
+    return {
+      ok: true,
+      route,
+      readiness: 'degraded',
+      eligible: false,
+      reason: routeScore?.reason || 'ROUTE_UNDERPERFORMING'
+    };
+  }
+
+  // HEALTHY
+  return {
+    ok: true,
+    route,
+    readiness: 'healthy',
+    eligible: true,
+    reason: 'READY'
+  };
+}
+
+// CLI execution
+async function main() {
+  try {
+    let input = '';
+
+    process.stdin.on('data', chunk => {
+      input += chunk;
+    });
+
+    process.stdin.on('end', () => {
+      const parsed = JSON.parse(input);
+      const result = evaluateReadiness(parsed);
+      console.log(JSON.stringify(result));
+    });
+  } catch (err) {
+    console.error(JSON.stringify({
+      ok: false,
+      error: 'INVALID_INPUT'
+    }));
+  }
+}
+
+main();


### PR DESCRIPTION
## feat: add execution-readiness-guard skill

### Summary

This PR introduces the `execution-readiness-guard` skill.

This skill evaluates whether a route is eligible for execution based on:

* Route operator decision
* Route health
* Protocol health
* Route performance (score)

### Behavior

The skill returns:

* `healthy` → execution allowed
* `degraded` → execution blocked (risk)
* `blocked` → execution strictly denied

### Why this matters

This acts as a final execution gate, ensuring that:

* Unsafe routes are never executed
* Degraded performance is respected
* Protocol-level risks are enforced

### Files included

* `execution-readiness-guard.ts`
* `SKILL.md`
* `AGENT.md`

### Notes

This skill is designed to be composable within a multi-skill decision pipeline.
