### PR TITLE
feat(x402): nonce tracking and retry logic for inbox messages

### DIFF
--- a/src/lib/services/hiro-api.ts
+++ b/src/lib/services/hiro-api.ts
@@ -28,6 +28,15 @@ export interface AccountInfo {
   nonceProof: string;
 }
 
+/** Extended nonce info from /extended/v1/address/{addr}/nonces */
+export interface NonceInfo {
+  last_mempool_tx_nonce: number | null;
+  last_executed_tx_nonce: number;
+  possible_next_nonce: number;
+  detected_missing_nonces: number[];
+  detected_mempool_nonces: number[];
+}
+
 export interface StxBalance {
   balance: string;
   total_sent: string;
@@ -411,6 +420,15 @@ export class HiroApiService {
   async getAccountNonce(address: string): Promise<number> {
     const info = await this.getAccountInfo(address);
     return info.nonce;
+  }
+
+  /**
+   * Get extended nonce info including mempool and missing nonce detection.
+   * Uses the /extended/v1/address/{addr}/nonces endpoint which accounts for
+   * mempool transactions and detects nonce gaps.
+   */
+  async getNonceInfo(address: string): Promise<NonceInfo> {
+    return this.fetch<NonceInfo>(`/extended/v1/address/${address}/nonces`);
   }
 
   // ==========================================================================

--- a/src/lib/services/nonce-tracker.ts
+++ b/src/lib/services/nonce-tracker.ts
@@ -1,0 +1,378 @@
+/**
+ * Shared Nonce Tracker
+ *
+ * Unified, file-backed nonce tracker that prevents client-side nonce conflicts
+ * across all tx-submitting tools. Ported from aibtc-mcp-server (PR #415).
+ *
+ * Design principles (issue #413):
+ * - Local state is primary — no network calls on the hot path for nonce assignment
+ * - Hiro is periodic reconciliation, not a real-time oracle
+ * - Non-blocking — file read/write on the hot path, no network calls
+ * - Records every submission — nonce + txid + timestamp for debugging
+ * - Shared state file (~/.aibtc/nonce-state.json) for cross-process compatibility
+ *   with MCP server (aibtc-mcp-server#413) and CLI skills (aibtcdev/skills#240)
+ *
+ * @see https://github.com/aibtcdev/aibtc-mcp-server/issues/413
+ * @see https://github.com/aibtcdev/skills/issues/240
+ */
+
+import fs from "fs/promises";
+import path from "path";
+import os from "os";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** A record of a single submitted transaction. */
+export interface PendingTxRecord {
+  nonce: number;
+  txid: string;
+  timestamp: string; // ISO-8601
+}
+
+/** Per-address nonce state. */
+export interface AddressNonceState {
+  /** The highest nonce we have assigned (not yet necessarily confirmed). */
+  lastUsedNonce: number;
+  /** ISO-8601 timestamp of the last nonce assignment. */
+  lastUpdated: string;
+  /** Rolling log of recent submissions (bounded to MAX_PENDING_LOG). */
+  pending: PendingTxRecord[];
+}
+
+/** On-disk file format. */
+export interface NonceStateFile {
+  version: number;
+  addresses: Record<string, AddressNonceState>;
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const DEFAULT_STORAGE_DIR = path.join(os.homedir(), ".aibtc");
+const DEFAULT_NONCE_STATE_FILE = path.join(DEFAULT_STORAGE_DIR, "nonce-state.json");
+
+/** Mutable path — overridable via _testing.setStateFilePath() for test isolation. */
+let NONCE_STATE_FILE = DEFAULT_NONCE_STATE_FILE;
+const CURRENT_VERSION = 1;
+
+/**
+ * How long a locally-tracked nonce is considered fresh. After this window the
+ * tracker falls back to the chain value on the next getNextNonce() call.
+ *
+ * Set to 90 seconds (~15-30 Stacks blocks post-Nakamoto, where blocks are 3-5s).
+ * Previously 10 minutes (calibrated for Bitcoin block times). The shorter window
+ * ensures the tracker detects external sends and chain advances promptly.
+ */
+export const STALE_NONCE_MS = 90 * 1000;
+
+/**
+ * Maximum pending tx records kept per address. Older entries are evicted FIFO.
+ */
+const MAX_PENDING_LOG = 50;
+
+/**
+ * Maximum addresses tracked in the state file. Oldest (by lastUpdated) are
+ * evicted when this limit is reached, preventing unbounded file growth.
+ */
+const MAX_ADDRESSES = 100;
+
+// ---------------------------------------------------------------------------
+// In-memory cache
+// ---------------------------------------------------------------------------
+
+/** In-memory mirror of the on-disk state. Loaded lazily on first access. */
+let _memoryState: NonceStateFile | null = null;
+
+/**
+ * Serializes concurrent file writes within this process.
+ * Cross-process safety is handled by atomic temp+rename writes.
+ */
+let _writeLock: Promise<void> = Promise.resolve();
+
+// ---------------------------------------------------------------------------
+// File I/O (atomic temp+rename, 0o600 perms)
+// ---------------------------------------------------------------------------
+
+async function readStateFile(): Promise<NonceStateFile> {
+  try {
+    const content = await fs.readFile(NONCE_STATE_FILE, "utf8");
+    const parsed = JSON.parse(content) as NonceStateFile;
+    // Basic validation
+    if (parsed.version !== CURRENT_VERSION || typeof parsed.addresses !== "object") {
+      return createDefaultState();
+    }
+    return parsed;
+  } catch {
+    return createDefaultState();
+  }
+}
+
+/**
+ * Merge on-disk state into in-memory state to prevent cross-process write
+ * races from silently regressing a nonce.
+ *
+ * For each address:
+ * - Takes the higher lastUsedNonce (never regress)
+ * - In-memory pending log is authoritative (disk entries are stale copies of
+ *   our own prior writes); we only pull in disk-only addresses that another
+ *   process (MCP server) may have created.
+ */
+function mergeStates(disk: NonceStateFile, memory: NonceStateFile): NonceStateFile {
+  const merged: NonceStateFile = { version: CURRENT_VERSION, addresses: { ...memory.addresses } };
+
+  for (const [addr, diskEntry] of Object.entries(disk.addresses)) {
+    const memEntry = merged.addresses[addr];
+    if (!memEntry) {
+      // Address exists on disk but not in memory — another process wrote it
+      merged.addresses[addr] = diskEntry;
+      continue;
+    }
+
+    // Both exist: take the higher nonce to prevent regression
+    if (diskEntry.lastUsedNonce > memEntry.lastUsedNonce) {
+      memEntry.lastUsedNonce = diskEntry.lastUsedNonce;
+      memEntry.lastUpdated = diskEntry.lastUpdated;
+    }
+  }
+
+  return merged;
+}
+
+async function writeStateFile(state: NonceStateFile): Promise<void> {
+  const dir = path.dirname(NONCE_STATE_FILE);
+  await fs.mkdir(dir, { recursive: true, mode: 0o700 });
+  const tempFile = `${NONCE_STATE_FILE}.tmp`;
+  await fs.writeFile(tempFile, JSON.stringify(state, null, 2), { mode: 0o600 });
+  await fs.rename(tempFile, NONCE_STATE_FILE);
+}
+
+function createDefaultState(): NonceStateFile {
+  return { version: CURRENT_VERSION, addresses: {} };
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/** Load state into memory if not already loaded. */
+async function ensureLoaded(): Promise<NonceStateFile> {
+  if (!_memoryState) {
+    _memoryState = await readStateFile();
+  }
+  return _memoryState;
+}
+
+/** Persist the in-memory state to disk (serialized to prevent interleaving). */
+function persistToDisk(): void {
+  if (!_memoryState) return;
+  const stateSnapshot = _memoryState;
+  _writeLock = _writeLock
+    .then(() => writeStateFile(stateSnapshot))
+    .catch((err) => {
+      console.error("[nonce-tracker] Failed to persist nonce state:", err);
+    });
+}
+
+/** Evict oldest addresses if over MAX_ADDRESSES. */
+function evictOldestAddresses(state: NonceStateFile): void {
+  const entries = Object.entries(state.addresses);
+  if (entries.length <= MAX_ADDRESSES) return;
+
+  // Sort by lastUpdated ascending (oldest first)
+  entries.sort((a, b) => new Date(a[1].lastUpdated).getTime() - new Date(b[1].lastUpdated).getTime());
+
+  // Keep only the newest MAX_ADDRESSES entries
+  const toKeep = entries.slice(entries.length - MAX_ADDRESSES);
+  state.addresses = Object.fromEntries(toKeep);
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Get the next nonce to use for an address.
+ *
+ * This is the HOT PATH — no network calls. Returns the locally tracked
+ * next nonce, or null if no state exists or the local state is stale
+ * (caller should then fall back to chain query).
+ */
+export async function getTrackedNonce(address: string): Promise<number | null> {
+  const state = await ensureLoaded();
+  const entry = state.addresses[address];
+  if (!entry) return null;
+
+  // Stale check
+  const lastUpdated = new Date(entry.lastUpdated).getTime();
+  if (Date.now() - lastUpdated > STALE_NONCE_MS) {
+    return null; // Stale — caller should query chain
+  }
+
+  return entry.lastUsedNonce + 1;
+}
+
+/**
+ * Record that a nonce was used for a transaction.
+ *
+ * Called after successful broadcast. Updates both in-memory and on-disk state.
+ *
+ * @param address - The sender STX address
+ * @param nonce - The nonce that was used
+ * @param txid - The transaction ID from broadcast
+ */
+export async function recordNonceUsed(
+  address: string,
+  nonce: number,
+  txid: string
+): Promise<void> {
+  const state = await ensureLoaded();
+  const now = new Date().toISOString();
+
+  const existing = state.addresses[address];
+  if (existing) {
+    // Only advance — never regress
+    if (nonce > existing.lastUsedNonce) {
+      existing.lastUsedNonce = nonce;
+    }
+    existing.lastUpdated = now;
+
+    // Append to pending log
+    existing.pending.push({ nonce, txid, timestamp: now });
+    // Trim to MAX_PENDING_LOG (FIFO)
+    if (existing.pending.length > MAX_PENDING_LOG) {
+      existing.pending = existing.pending.slice(-MAX_PENDING_LOG);
+    }
+  } else {
+    state.addresses[address] = {
+      lastUsedNonce: nonce,
+      lastUpdated: now,
+      pending: [{ nonce, txid, timestamp: now }],
+    };
+    evictOldestAddresses(state);
+  }
+
+  persistToDisk();
+}
+
+/**
+ * Reconcile local state with chain data.
+ *
+ * If the chain's `possibleNextNonce` is ahead of our local state, update
+ * to match (txs confirmed or external sends happened). If our local state
+ * is ahead, keep it (chain is lagging behind mempool propagation).
+ *
+ * @param address - The STX address
+ * @param chainNextNonce - The `possible_next_nonce` value from Hiro API
+ */
+export async function reconcileWithChain(
+  address: string,
+  chainNextNonce: number
+): Promise<void> {
+  const state = await ensureLoaded();
+  const entry = state.addresses[address];
+
+  if (!entry) {
+    // No local state — initialize from chain
+    state.addresses[address] = {
+      lastUsedNonce: chainNextNonce - 1,
+      lastUpdated: new Date().toISOString(),
+      pending: [],
+    };
+    evictOldestAddresses(state);
+    persistToDisk();
+    return;
+  }
+
+  let changed = false;
+
+  // Chain advanced past us — update (txs confirmed or external sends)
+  if (chainNextNonce - 1 > entry.lastUsedNonce) {
+    entry.lastUsedNonce = chainNextNonce - 1;
+    entry.lastUpdated = new Date().toISOString();
+    changed = true;
+  }
+
+  // Prune pending entries whose nonces are now confirmed on-chain
+  const beforeLen = entry.pending.length;
+  entry.pending = entry.pending.filter((p) => p.nonce >= chainNextNonce);
+  if (entry.pending.length !== beforeLen) {
+    changed = true;
+  }
+
+  if (changed) {
+    persistToDisk();
+  }
+}
+
+/**
+ * Reset (clear) nonce state for an address.
+ * Called on wallet unlock/lock/switch so the tracker re-syncs from chain.
+ */
+export async function resetTrackedNonce(address: string): Promise<void> {
+  const state = await ensureLoaded();
+  delete state.addresses[address];
+  persistToDisk();
+}
+
+/**
+ * Get the raw state for an address (for diagnostics/health tool).
+ */
+export async function getAddressState(
+  address: string
+): Promise<AddressNonceState | null> {
+  const state = await ensureLoaded();
+  return state.addresses[address] ?? null;
+}
+
+/**
+ * Get the full state file (for diagnostics).
+ */
+export async function getFullState(): Promise<NonceStateFile> {
+  return ensureLoaded();
+}
+
+/**
+ * Force reload state from disk (useful after external process wrote to file).
+ * Merges disk state into memory so external writes (MCP server) are picked up
+ * without losing any in-memory nonce advancements.
+ */
+export async function reloadFromDisk(): Promise<void> {
+  const diskState = await readStateFile();
+  if (_memoryState && Object.keys(_memoryState.addresses).length > 0) {
+    _memoryState = mergeStates(diskState, _memoryState);
+  } else {
+    _memoryState = diskState;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Testing helpers
+// ---------------------------------------------------------------------------
+
+export const _testing = {
+  STALE_NONCE_MS,
+  MAX_PENDING_LOG,
+  MAX_ADDRESSES,
+  get NONCE_STATE_FILE() {
+    return NONCE_STATE_FILE;
+  },
+  /** Override the state file path for test isolation. */
+  setStateFilePath(filePath: string): void {
+    NONCE_STATE_FILE = filePath;
+  },
+  /** Reset state file path to default. */
+  resetStateFilePath(): void {
+    NONCE_STATE_FILE = DEFAULT_NONCE_STATE_FILE;
+  },
+  /** Clear in-memory state without touching disk. */
+  clearMemory(): void {
+    _memoryState = null;
+  },
+  /** Get raw memory state ref for assertions. */
+  getMemoryState(): NonceStateFile | null {
+    return _memoryState;
+  },
+};

--- a/src/lib/utils/x402-protocol.ts
+++ b/src/lib/utils/x402-protocol.ts
@@ -4,6 +4,8 @@
  * No external x402 SDK dependency — all logic is self-contained.
  */
 
+import { randomUUID } from "node:crypto";
+
 // ===== Types =====
 
 /**
@@ -97,6 +99,55 @@ export interface SettlementResponseV2 {
   transaction: string;
   /** Network identifier in CAIP-2 format */
   network: NetworkV2;
+  /** Payment status: "pending" means tx accepted into mempool (treat as success) */
+  paymentStatus?: "confirmed" | "pending" | "failed";
+}
+
+// ===== Conflict Error Types (per landing-page#522) =====
+
+/**
+ * Error codes returned by the relay in 409 responses.
+ * @see https://github.com/aibtcdev/landing-page/issues/522
+ */
+export type ConflictErrorCode =
+  | "SENDER_NONCE_DUPLICATE"
+  | "SENDER_NONCE_STALE"
+  | "SENDER_NONCE_GAP"
+  | "NONCE_CONFLICT";
+
+/** Structured 409 conflict error response from the relay. */
+export interface ConflictErrorResponse {
+  code: ConflictErrorCode;
+  message?: string;
+  retryable?: boolean;
+  retryAfter?: number;
+}
+
+// ===== Payment Identifier Extension =====
+
+/** Extension for relay-side dedup of payment attempts. */
+export interface PaymentIdentifierExtension {
+  [key: string]: unknown;
+  "payment-identifier": {
+    info: { id: string };
+  };
+}
+
+/** Generate a unique payment identifier for relay dedup. */
+export function generatePaymentId(): string {
+  const hex = randomUUID().replace(/-/g, "");
+  return `pay_${hex}`;
+}
+
+/** Build the payment-identifier extension object for PaymentPayloadV2. */
+export function buildPaymentIdentifierExtension(
+  id: string
+): PaymentIdentifierExtension {
+  return {
+    "payment-identifier": {
+      info: { id },
+    },
+  };
 }
 
 // ===== Constants =====

--- a/src/lib/utils/x402-retry.ts
+++ b/src/lib/utils/x402-retry.ts
@@ -1,0 +1,559 @@
+/**
+ * x402 Inbox Retry Logic
+ *
+ * Handles nonce conflicts, relay errors, and payment retry for send-inbox-message.
+ * Ported from aibtc-mcp-server inbox.tools.ts (PR #415) to address the nonce
+ * handling improvements described in landing-page#522.
+ *
+ * @see https://github.com/aibtcdev/landing-page/issues/522
+ * @see https://github.com/aibtcdev/aibtc-mcp-server/issues/413
+ */
+
+import {
+  makeContractCall,
+  uintCV,
+  principalCV,
+  noneCV,
+  someCV,
+  bufferCV,
+} from "@stacks/transactions";
+import {
+  encodePaymentPayload,
+  decodePaymentResponse,
+  generatePaymentId,
+  buildPaymentIdentifierExtension,
+  X402_HEADERS,
+  type PaymentRequiredV2,
+  type PaymentRequirementsV2,
+} from "./x402-protocol.js";
+import {
+  extractTxidFromPaymentSignature,
+  pollTransactionConfirmation,
+} from "./x402-recovery.js";
+import { getHiroApi } from "../services/hiro-api.js";
+import {
+  getTrackedNonce,
+  recordNonceUsed,
+  reconcileWithChain,
+} from "../services/nonce-tracker.js";
+import { type Network, getStacksNetwork, getExplorerTxUrl } from "../config/networks.js";
+import { getContracts, parseContractId } from "../config/contracts.js";
+import { createFungiblePostCondition } from "../transactions/post-conditions.js";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface RetryInfo {
+  retryable: boolean;
+  /** Delay in ms before next retry. Honors relay's retryAfter when present. */
+  delayMs: number;
+  /** Whether the error is a relay-side nonce conflict (safe to reuse same tx). */
+  relaySideConflict: boolean;
+}
+
+export interface InboxSubmitResult {
+  success: boolean;
+  status: number;
+  responseData: Record<string, unknown>;
+  settlementTxid?: string;
+  paymentSignature?: string;
+  recovered?: boolean;
+}
+
+export interface InboxRetryOptions {
+  inboxUrl: string;
+  body: Record<string, unknown>;
+  paymentRequired: PaymentRequiredV2;
+  accept: PaymentRequirementsV2;
+  account: { address: string; privateKey: string };
+  network: Network;
+  contentHash?: string;
+  maxAttempts?: number;
+}
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+/** Default delay when no retryAfter hint is provided. */
+const DEFAULT_RETRY_DELAY_MS = 2_000;
+/** Cap retryAfter to avoid blocking too long (seconds). */
+const MAX_RETRY_AFTER_CAP_S = 60;
+/** Inbox API base URL. */
+const INBOX_BASE = "https://aibtc.com/api/inbox";
+
+// ============================================================================
+// Retry Classifier
+// ============================================================================
+
+/**
+ * Classify a response as retryable and extract retry timing.
+ *
+ * Handles the error codes from landing-page#522:
+ * - SENDER_NONCE_DUPLICATE: wait 30s, retry same tx
+ * - SENDER_NONCE_STALE: re-fetch nonce, re-sign
+ * - SENDER_NONCE_GAP: re-fetch nonce, re-sign
+ * - NONCE_CONFLICT: relay-side, retry after Retry-After header
+ * - 502/503: relay transient errors
+ */
+export function classifyRetryableError(
+  status: number,
+  body: unknown,
+  retryAfterHeader?: string | null
+): RetryInfo {
+  const NOT_RETRYABLE: RetryInfo = { retryable: false, delayMs: 0, relaySideConflict: false };
+
+  // Duplicate-message 409 from the inbox API must NOT be retried —
+  // the message was already delivered and retrying would re-pay.
+  if (status === 409) {
+    const bodyStr = typeof body === "string" ? body : JSON.stringify(body);
+    if (/already exists|duplicate/i.test(bodyStr)) {
+      return NOT_RETRYABLE;
+    }
+  }
+
+  // Parse retryAfter from body or HTTP header
+  let retryAfterMs = DEFAULT_RETRY_DELAY_MS;
+  if (typeof body === "object" && body !== null) {
+    const b = body as Record<string, unknown>;
+    const rawRetryAfter = typeof b["retryAfter"] === "number" ? b["retryAfter"] : 0;
+    if (rawRetryAfter > 0) {
+      retryAfterMs = Math.min(rawRetryAfter, MAX_RETRY_AFTER_CAP_S) * 1000;
+    }
+  }
+  // HTTP Retry-After header (seconds) takes precedence if body didn't have one
+  if (retryAfterHeader && retryAfterMs === DEFAULT_RETRY_DELAY_MS) {
+    const headerSeconds = parseInt(retryAfterHeader, 10);
+    if (!isNaN(headerSeconds) && headerSeconds > 0) {
+      retryAfterMs = Math.min(headerSeconds, MAX_RETRY_AFTER_CAP_S) * 1000;
+    }
+  }
+
+  if (typeof body === "object" && body !== null) {
+    const b = body as Record<string, unknown>;
+
+    // New 409 codes from landing-page#522
+    if (status === 409) {
+      const code = b["code"] as string | undefined;
+
+      // SENDER_NONCE_DUPLICATE: payment already in-flight, wait and retry same tx
+      if (code === "SENDER_NONCE_DUPLICATE") {
+        return { retryable: true, delayMs: 30_000, relaySideConflict: true };
+      }
+
+      // SENDER_NONCE_STALE: nonce already confirmed, need fresh nonce + re-sign
+      if (code === "SENDER_NONCE_STALE") {
+        return { retryable: true, delayMs: 0, relaySideConflict: false };
+      }
+
+      // SENDER_NONCE_GAP: nonce skips ahead, need fresh nonce + re-sign
+      if (code === "SENDER_NONCE_GAP") {
+        return { retryable: true, delayMs: 0, relaySideConflict: false };
+      }
+
+      // NONCE_CONFLICT: sponsor nonce collision, safe to resubmit same tx
+      if (code === "NONCE_CONFLICT") {
+        return { retryable: true, delayMs: retryAfterMs, relaySideConflict: true };
+      }
+    }
+
+    // Relay returns retryable: true for SETTLEMENT_BROADCAST_FAILED
+    if (b["retryable"] === true) {
+      return { retryable: true, delayMs: retryAfterMs, relaySideConflict: false };
+    }
+  }
+
+  // Sender-side nonce conflict from the Stacks node (not relay) — needs fresh tx.
+  if (typeof body === "string") {
+    if (body.includes("ConflictingNonceInMempool") || body.includes("BadNonce")) {
+      return { retryable: true, delayMs: DEFAULT_RETRY_DELAY_MS, relaySideConflict: false };
+    }
+  }
+
+  // 502/503 relay errors
+  if (status === 502) {
+    return { retryable: true, delayMs: 10_000, relaySideConflict: false };
+  }
+  if (status === 503) {
+    return { retryable: true, delayMs: 60_000, relaySideConflict: false };
+  }
+
+  return NOT_RETRYABLE;
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+export function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Compute the next safe nonce for a sender address.
+ * Checks shared nonce tracker first (no network), then reconciles with chain.
+ */
+async function getNextNonce(address: string, network: Network): Promise<number> {
+  // 1. Check shared tracker (fast, no network)
+  const localNext = await getTrackedNonce(address);
+
+  // 2. Fetch chain state for reconciliation
+  const hiroApi = getHiroApi(network);
+  const accountInfo = await hiroApi.getAccountInfo(address);
+  const confirmedNonce = accountInfo.nonce;
+
+  let highestMempoolNonce = -1;
+  try {
+    const mempool = await hiroApi.getMempoolTransactions({
+      sender_address: address,
+      limit: 50,
+    });
+    for (const tx of mempool.results) {
+      if (tx.nonce > highestMempoolNonce) {
+        highestMempoolNonce = tx.nonce;
+      }
+    }
+  } catch {
+    // Non-fatal: fall back to confirmed nonce only
+  }
+
+  const chainNext = Math.max(confirmedNonce, highestMempoolNonce + 1);
+
+  // 3. Reconcile tracker with chain state
+  await reconcileWithChain(address, chainNext);
+
+  // 4. Return max(chain, local) — same logic as MCP server
+  return Math.max(chainNext, localNext ?? 0);
+}
+
+/**
+ * Record that we used a nonce so subsequent calls use a higher value.
+ */
+async function advanceNonceCache(address: string, usedNonce: number, txid = ""): Promise<void> {
+  await recordNonceUsed(address, usedNonce, txid);
+}
+
+/**
+ * Build a sponsored sBTC transfer transaction (signed, not broadcast).
+ * Explicit nonce avoids ConflictingNonceInMempool.
+ */
+async function buildSponsoredSbtcTransfer(
+  senderKey: string,
+  senderAddress: string,
+  recipient: string,
+  amount: bigint,
+  nonce: bigint,
+  network: Network,
+  memo?: string
+): Promise<string> {
+  const contracts = getContracts(network);
+  const { address: contractAddress, name: contractName } = parseContractId(
+    contracts.SBTC_TOKEN
+  );
+  const networkName = getStacksNetwork(network);
+
+  const postCondition = createFungiblePostCondition(
+    senderAddress,
+    contracts.SBTC_TOKEN,
+    "sbtc-token",
+    "eq",
+    amount
+  );
+
+  // Encode memo as (optional (buff 34)): some(buff) if provided, none() otherwise.
+  const memoArg = memo
+    ? someCV(bufferCV(Buffer.from(memo).slice(0, 34)))
+    : noneCV();
+
+  const transaction = await makeContractCall({
+    contractAddress,
+    contractName,
+    functionName: "transfer",
+    functionArgs: [
+      uintCV(amount),
+      principalCV(senderAddress),
+      principalCV(recipient),
+      memoArg,
+    ],
+    senderKey,
+    network: networkName,
+    postConditions: [postCondition],
+    sponsored: true,
+    fee: 0n,
+    nonce,
+  });
+
+  // serialize() returns hex string (no 0x prefix) in @stacks/transactions v7+
+  return "0x" + transaction.serialize();
+}
+
+/**
+ * POST a message to the inbox using a confirmed txid as payment proof.
+ * Used for auto-recovery after settlement failure when payment confirmed on-chain.
+ */
+async function submitWithPaymentTxid(
+  recipientBtcAddress: string,
+  recipientStxAddress: string,
+  content: string,
+  txid: string
+): Promise<{ ok: boolean; status: number; body: string }> {
+  const url = `${INBOX_BASE}/${recipientBtcAddress}`;
+  const res = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      toBtcAddress: recipientBtcAddress,
+      toStxAddress: recipientStxAddress,
+      content,
+      paymentTxid: txid,
+    }),
+  });
+  const body = await res.text();
+  const ok = res.status === 200 || res.status === 201 || res.status === 409;
+  return { ok, status: res.status, body };
+}
+
+// ============================================================================
+// Main Retry Loop
+// ============================================================================
+
+/**
+ * Execute an inbox message send with full retry logic.
+ *
+ * Handles:
+ * - 201 with paymentStatus: "pending" as success
+ * - 409 SENDER_NONCE_DUPLICATE: wait 30s, retry same signed tx
+ * - 409 SENDER_NONCE_STALE/GAP: re-fetch nonce, re-sign, resubmit
+ * - 409 NONCE_CONFLICT: retry after Retry-After header
+ * - 502/503: retry with backoff (10s/60s)
+ * - Auto-recovery: polls relay txids after max retries
+ *
+ * @see https://github.com/aibtcdev/landing-page/issues/522
+ */
+export async function executeInboxWithRetry(
+  options: InboxRetryOptions
+): Promise<InboxSubmitResult> {
+  const {
+    inboxUrl,
+    body,
+    paymentRequired,
+    accept,
+    account,
+    network,
+    contentHash,
+    maxAttempts = 3,
+  } = options;
+
+  const amount = BigInt(accept.amount);
+
+  let lastError = "";
+  let lastPaymentSignature: string | null = null;
+
+  // Track relay txids across failed attempts for auto-recovery.
+  const seenRelayTxids = new Set<string>();
+
+  // Cache first attempt's tx + paymentId for reuse on relay-side conflicts.
+  let cachedTxHex: string | null = null;
+  let cachedPaymentId: string | null = null;
+  let cachedNonce: number | null = null;
+  let nextRetryDelayMs = 0;
+
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    if (attempt > 0 && nextRetryDelayMs > 0) {
+      console.error(
+        `[x402-retry] Retry attempt ${attempt}/${maxAttempts - 1} after ${nextRetryDelayMs}ms`
+      );
+      await sleep(nextRetryDelayMs);
+    }
+
+    // Build or reuse transaction
+    let nonce: number;
+    let txHex: string;
+    let paymentId: string;
+
+    if (cachedTxHex && cachedPaymentId && cachedNonce !== null) {
+      // Relay-side conflict: resubmit the same tx for dedup
+      nonce = cachedNonce;
+      txHex = cachedTxHex;
+      paymentId = cachedPaymentId;
+      console.error(
+        `[x402-retry] Reusing cached tx (nonce=${nonce}) for relay-side dedup`
+      );
+    } else {
+      // Fresh tx: sender-side conflict or first attempt
+      nonce = await getNextNonce(account.address, network);
+      txHex = await buildSponsoredSbtcTransfer(
+        account.privateKey,
+        account.address,
+        accept.payTo,
+        amount,
+        BigInt(nonce),
+        network,
+        contentHash
+      );
+      paymentId = generatePaymentId();
+
+      // Cache for potential reuse on relay-side conflicts
+      cachedTxHex = txHex;
+      cachedPaymentId = paymentId;
+      cachedNonce = nonce;
+    }
+
+    // Encode PaymentPayloadV2 with payment-identifier extension
+    const paymentSignature = encodePaymentPayload({
+      x402Version: 2,
+      resource: paymentRequired.resource,
+      accepted: accept,
+      payload: { transaction: txHex },
+      extensions: buildPaymentIdentifierExtension(paymentId),
+    });
+    lastPaymentSignature = paymentSignature;
+
+    // Send with payment header
+    const finalRes = await fetch(inboxUrl, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        [X402_HEADERS.PAYMENT_SIGNATURE]: paymentSignature,
+      },
+      body: JSON.stringify(body),
+    });
+
+    const responseData = await finalRes.text();
+    let parsed: Record<string, unknown>;
+    try {
+      parsed = JSON.parse(responseData);
+    } catch {
+      parsed = { raw: responseData };
+    }
+
+    // Success: 200/201 (paymentStatus "pending" counts as success per landing-page#522)
+    if (finalRes.status === 201 || finalRes.status === 200) {
+      const settlement = decodePaymentResponse(
+        finalRes.headers.get(X402_HEADERS.PAYMENT_RESPONSE)
+      );
+      const txid = settlement?.transaction;
+
+      // Advance shared nonce tracker on success
+      await advanceNonceCache(account.address, nonce, txid ?? "");
+
+      return {
+        success: true,
+        status: finalRes.status,
+        responseData: parsed,
+        settlementTxid: txid ?? undefined,
+        paymentSignature,
+      };
+    }
+
+    // Extract relay txid from payment-response header (forwarded even on failure)
+    const failedTxid = decodePaymentResponse(
+      finalRes.headers.get(X402_HEADERS.PAYMENT_RESPONSE)
+    )?.transaction;
+    if (failedTxid && seenRelayTxids.has(failedTxid)) {
+      console.error(
+        `[x402-retry] Stale dedup: relay returned previously-seen txid ${failedTxid} on attempt ${attempt + 1}`
+      );
+    } else if (failedTxid) {
+      seenRelayTxids.add(failedTxid);
+    }
+
+    // Classify the error and extract retry timing
+    const retryAfterHeader = finalRes.headers.get("retry-after");
+    const retry = classifyRetryableError(finalRes.status, parsed, retryAfterHeader);
+
+    if (retry.retryable && attempt < maxAttempts - 1) {
+      console.error(
+        `[x402-retry] Retryable error on attempt ${attempt + 1}: status=${finalRes.status} relaySide=${retry.relaySideConflict} delayMs=${retry.delayMs} body=${responseData}`
+      );
+
+      nextRetryDelayMs = retry.delayMs;
+
+      if (retry.relaySideConflict) {
+        // Keep cached tx/paymentId — relay will dedup on resubmit
+      } else {
+        // Sender-side conflict: need a fresh tx with new nonce
+        cachedTxHex = null;
+        cachedPaymentId = null;
+        cachedNonce = null;
+        // Advance nonce cache so the next attempt uses a strictly higher nonce
+        await advanceNonceCache(account.address, nonce);
+      }
+
+      lastError = `${finalRes.status}: ${responseData}`;
+      continue;
+    }
+
+    // Non-retryable or last attempt — build error with txid recovery info
+    const txid = lastPaymentSignature
+      ? extractTxidFromPaymentSignature(lastPaymentSignature)
+      : null;
+
+    const errorBase = `Message delivery failed (${finalRes.status}): ${responseData}`;
+    if (txid && !retry.retryable) {
+      const confirmation = await pollTransactionConfirmation(txid, network);
+      throw new Error(
+        `${errorBase}\n\nPayment transaction was submitted but settlement failed. ` +
+        `Transaction recovery info:\n  txid: ${confirmation.txid}\n  status: ${confirmation.status}\n  explorer: ${confirmation.explorer}`
+      );
+    }
+
+    lastError = `${finalRes.status}: ${responseData}`;
+  }
+
+  // Retries exhausted -- check if any relay txid confirmed on-chain and
+  // resubmit with the confirmed txid as payment proof (auto-recovery).
+  if (seenRelayTxids.size > 0) {
+    const recipientBtcAddress = body["toBtcAddress"] as string;
+    const recipientStxAddress = body["toStxAddress"] as string;
+    const content = body["content"] as string;
+
+    console.error(
+      `[x402-retry] Checking on-chain status of ${seenRelayTxids.size} seen txid(s) before giving up.`
+    );
+    for (const seenTxid of seenRelayTxids) {
+      try {
+        const confirmation = await pollTransactionConfirmation(seenTxid, network, 5_000);
+        if (confirmation.status !== "success" && confirmation.status !== "confirmed") {
+          continue;
+        }
+        console.error(
+          `[x402-retry] Auto-recovery: txid ${seenTxid} confirmed on-chain. Resubmitting.`
+        );
+        const result = await submitWithPaymentTxid(
+          recipientBtcAddress, recipientStxAddress, content, seenTxid
+        );
+        if (result.ok) {
+          let parsed: Record<string, unknown>;
+          try {
+            parsed = JSON.parse(result.body);
+          } catch {
+            parsed = { raw: result.body };
+          }
+          return {
+            success: true,
+            status: result.status,
+            responseData: parsed,
+            settlementTxid: seenTxid,
+            recovered: true,
+          };
+        }
+        console.error(
+          `[x402-retry] Auto-recovery resubmission failed for txid ${seenTxid}: ${result.status} ${result.body}`
+        );
+      } catch {
+        // Non-fatal: move on to the next txid
+      }
+    }
+  }
+
+  // Include all seen txids in the error for diagnostics
+  const txidSummary = seenRelayTxids.size > 0
+    ? `\n\nSeen relay txids (all failed or pending):\n${[...seenRelayTxids].map((id) => `  ${id}`).join("\n")}`
+    : "";
+
+  throw new Error(
+    `Message delivery failed after ${maxAttempts} attempts. Last error: ${lastError}${txidSummary}`
+  );
+}

--- a/x402/x402.ts
+++ b/x402/x402.ts
@@ -434,33 +434,18 @@ program
           );
         }
 
-        // Parse payment requirements from 402 response
+        // Step 2: Parse payment requirements from 402 response
         const paymentHeader = initialRes.headers.get("payment-required");
         if (!paymentHeader) {
           throw new Error("402 response missing payment-required header");
         }
 
-        // Import x402 protocol utilities
-        const {
-          decodePaymentRequired,
-          encodePaymentPayload,
-          X402_HEADERS,
-        } = await import("../src/lib/utils/x402-protocol.js");
-        const {
-          makeContractCall,
-          uintCV,
-          principalCV,
-          noneCV,
-        } = await import("@stacks/transactions");
-        const {
-          getContracts,
-          parseContractId,
-        } = await import("../src/lib/config/contracts.js");
-        const { getStacksNetwork } = await import("../src/lib/config/networks.js");
-        const { createFungiblePostCondition } = await import(
-          "../src/lib/transactions/post-conditions.js"
+        const { decodePaymentRequired } = await import(
+          "../src/lib/utils/x402-protocol.js"
         );
-        const { getHiroApi } = await import("../src/lib/services/hiro-api.js");
+        const { getExplorerTxUrl } = await import(
+          "../src/lib/config/networks.js"
+        );
 
         const paymentRequired = decodePaymentRequired(paymentHeader);
         if (
@@ -471,99 +456,51 @@ program
           throw new Error("No accepted payment methods in 402 response");
         }
         const accept = paymentRequired.accepts[0];
-        const amount = BigInt(accept.amount);
 
-        // Build sponsored sBTC transfer
-        const contracts = getContracts(NETWORK);
-        const { address: contractAddress, name: contractName } =
-          parseContractId(contracts.SBTC_TOKEN);
-        const networkName = getStacksNetwork(NETWORK);
+        // Step 3: Compute SHA-256 content hash for on-chain delivery receipt
+        const contentBytes = new TextEncoder().encode(opts.content);
+        const hashBuffer = await crypto.subtle.digest("SHA-256", contentBytes);
+        const contentHash = Buffer.from(new Uint8Array(hashBuffer)).toString("hex");
 
-        const postCondition = createFungiblePostCondition(
-          account.address,
-          contracts.SBTC_TOKEN,
-          "sbtc-token",
-          "eq",
-          amount
+        // Step 4: Execute with retry logic (handles nonce conflicts, 409s, 502/503)
+        const { executeInboxWithRetry } = await import(
+          "../src/lib/utils/x402-retry.js"
         );
 
-        // Get current nonce
-        const hiro = getHiroApi(NETWORK);
-        const accountInfo = await hiro.getAccountInfo(account.address);
-        const nonce = BigInt(accountInfo.nonce);
-
-        const transaction = await makeContractCall({
-          contractAddress,
-          contractName,
-          functionName: "transfer",
-          functionArgs: [
-            uintCV(amount),
-            principalCV(account.address),
-            principalCV(accept.payTo),
-            noneCV(),
-          ],
-          senderKey: account.privateKey,
-          network: networkName,
-          postConditions: [postCondition],
-          sponsored: true,
-          fee: 0n,
-          nonce,
-        });
-
-        const txHex = "0x" + transaction.serialize();
-
-        // Encode payment payload
-        const paymentSignature = encodePaymentPayload({
-          x402Version: 2,
-          resource: paymentRequired.resource,
-          accepted: accept,
-          payload: { transaction: txHex },
-        });
-
-        // Send with payment header
-        const finalRes = await fetch(inboxUrl, {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            [X402_HEADERS.PAYMENT_SIGNATURE]: paymentSignature,
+        const result = await executeInboxWithRetry({
+          inboxUrl,
+          body,
+          paymentRequired,
+          accept,
+          account: {
+            address: account.address,
+            privateKey: account.privateKey,
           },
-          body: JSON.stringify(body),
+          network: NETWORK,
+          contentHash,
         });
 
-        const responseText = await finalRes.text();
-        let responseData: unknown;
-        try {
-          responseData = JSON.parse(responseText);
-        } catch {
-          responseData = { raw: responseText };
-        }
-
-        if (finalRes.status === 201 || finalRes.status === 200) {
-          const settlementHeader = finalRes.headers.get(X402_HEADERS.PAYMENT_RESPONSE);
-          const { decodePaymentResponse } = await import("../src/lib/utils/x402-protocol.js");
-          const settlement = decodePaymentResponse(settlementHeader);
-          const txid = settlement?.transaction;
-
-          printJson({
-            success: true,
-            message: "Message delivered",
-            recipient: {
-              btcAddress: opts.recipientBtcAddress,
-              stxAddress: opts.recipientStxAddress,
+        // Step 5: Format and print result
+        printJson({
+          success: true,
+          message: result.recovered
+            ? "Message delivered (auto-recovered)"
+            : "Message delivered",
+          recipient: {
+            btcAddress: opts.recipientBtcAddress,
+            stxAddress: opts.recipientStxAddress,
+          },
+          contentLength: opts.content.length,
+          contentHash,
+          inbox: result.responseData,
+          ...(result.settlementTxid && {
+            payment: {
+              txid: result.settlementTxid,
+              amount: accept.amount + " sats sBTC",
+              explorer: getExplorerTxUrl(result.settlementTxid, NETWORK),
             },
-            contentLength: opts.content.length,
-            inbox: responseData,
-            ...(txid && {
-              payment: {
-                txid,
-                amount: accept.amount + " sats sBTC",
-              },
-            }),
-          });
-          return;
-        }
-
-        throw new Error(`Message delivery failed (${finalRes.status}): ${responseText}`);
+          }),
+        });
       } catch (error) {
         handleError(error);
       }


### PR DESCRIPTION
## Summary

- **Port SharedNonceTracker** from aibtc-mcp-server (PR #415) — file-backed at `~/.aibtc/nonce-state.json` with 90s stale window, merge-on-read for cross-process sharing with MCP server
- **Add retry loop for send-inbox-message** handling all 409 nonce conflict codes per landing-page#522:
  - `SENDER_NONCE_DUPLICATE` → wait 30s, retry same signed tx
  - `SENDER_NONCE_STALE` / `SENDER_NONCE_GAP` → re-fetch nonce, re-sign, resubmit
  - `NONCE_CONFLICT` → retry after Retry-After header
  - 502/503 → backoff (10s/60s)
- **Treat 201 `paymentStatus: "pending"` as success** (payment broadcast, confirms next block)
- **Auto-recovery**: polls relay txids after max retries and resubmits with confirmed txid as proof
- **Payment-identifier extension** for relay-side dedup of payment attempts

## Files Changed

| File | Change |
|------|--------|
| `src/lib/services/nonce-tracker.ts` | **NEW** — SharedNonceTracker port from MCP server |
| `src/lib/utils/x402-retry.ts` | **NEW** — retry loop, error classifier, tx builder |
| `src/lib/services/hiro-api.ts` | Add `NonceInfo` type + `getNonceInfo()` for extended nonce endpoint |
| `src/lib/utils/x402-protocol.ts` | Add `ConflictErrorCode`, `paymentStatus`, payment-identifier extension |
| `x402/x402.ts` | Refactor `send-inbox-message` to use `executeInboxWithRetry()` |

## Test plan

- [x] `bun run typecheck` passes
- [ ] Manual test: send inbox message on mainnet, verify retry on simulated 409
- [ ] Verify `~/.aibtc/nonce-state.json` is written after send
- [ ] Verify MCP server picks up nonce state written by CLI skills

Closes #240
Ref: aibtcdev/landing-page#522
Ref: aibtcdev/aibtc-mcp-server#415

🤖 Generated with [Claude Code](https://claude.com/claude-code)