### PR TITLE
feat(hodlmm-risk): add HODLMM volatility risk monitoring skill

### DIFF
--- a/hodlmm-risk/AGENT.md
+++ b/hodlmm-risk/AGENT.md
@@ -1,96 +1,48 @@
 ---
 name: hodlmm-risk-agent
 skill: hodlmm-risk
-description: "HODLMM volatility risk monitor — regime classification and LP safety signals for Bitflow HODLMM pools. Read-only; no wallet required."
+description: Read-only volatility risk monitor for Bitflow HODLMM pools. Checks pool risk before liquidity operations. No wallet required.
 ---
 
-# Agent Behavior — HODLMM Risk
+# HODLMM Risk Agent
 
-## Decision order
+Monitors Bitflow DLMM pool volatility before liquidity operations. Read-only — no wallet or funds required.
 
-1. Call `assess-pool --pool-id <id>` to get current regime and signals.
-2. If `regime` is `crisis`, do not add liquidity. Surface the risk to the user.
-3. If `regime` is `elevated`, reduce exposure per `maxExposurePct` signal.
-4. If `regime` is `calm`, proceed with normal liquidity operations.
-5. Before holding or withdrawing, call `assess-position` to check drift and concentration.
-6. Follow the `recommendation` field: `hold`, `rebalance`, or `withdraw`.
-7. Use `regime-snapshot` for periodic monitoring and store results externally for trend analysis.
+## Prerequisites
 
-## Guardrails
+- No wallet required
+- Mainnet only (HODLMM pools are mainnet-only)
+- Network access to `bff.bitflowapis.finance`
 
-- This skill is read-only. It never writes to chain or moves funds.
-- Never proceed with liquidity additions when `safeToAddLiquidity` is `false`.
-- Never ignore a `crisis` regime classification.
-- Always surface `driftScore` and `recommendation` to the user before acting on position changes.
-- Default to safe/read-only behavior when intent is ambiguous.
-- Never expose secrets or private keys in args or logs.
+## Decision Logic
 
-## Output contract
+| Goal | Action |
+|------|--------|
+| List available pools | `bun run hodlmm-risk/hodlmm-risk.ts list-pools` |
+| Check pool risk before adding liquidity | `bun run hodlmm-risk/hodlmm-risk.ts assess-pool --pool-id <id>` |
+| Check pool drift / bin health | `bun run hodlmm-risk/hodlmm-risk.ts assess-pool-drift --pool-id <id>` |
+| Scan all pools for crisis conditions | `bun run hodlmm-risk/hodlmm-risk.ts regime-history` |
 
-All commands return structured JSON to stdout.
+## Pre-Liquidity Gate
 
-**assess-pool output:**
-```json
-{
-  "network": "mainnet",
-  "poolId": "string",
-  "activeBinId": "number",
-  "totalBins": "number",
-  "binSpread": "number",
-  "reserveImbalanceRatio": "number",
-  "volatilityScore": "number (0-100)",
-  "regime": "calm | elevated | crisis",
-  "signals": {
-    "safeToAddLiquidity": "boolean",
-    "recommendedBinWidth": "number (3 | 7 | 15)",
-    "maxExposurePct": "number (0.25 | 0.10 | 0.0)"
-  },
-  "timestamp": "ISO 8601"
-}
+Always run `assess-pool` before any liquidity add:
+
+```
+regime: calm     → proceed normally
+regime: elevated → reduce position size to maxExposurePct
+regime: crisis   → STOP — do not add liquidity
 ```
 
-**assess-position output:**
-```json
-{
-  "network": "mainnet",
-  "poolId": "string",
-  "address": "string",
-  "positionBinCount": "number",
-  "activeBinId": "number",
-  "nearestPositionBinOffset": "number",
-  "avgBinOffset": "number",
-  "concentrationRisk": "high | medium | low",
-  "driftScore": "number (0-100)",
-  "impermanentLossEstimatePct": "number",
-  "recommendation": "hold | rebalance | withdraw",
-  "timestamp": "ISO 8601"
-}
-```
+## Safety Checks
 
-**regime-snapshot output:**
-```json
-{
-  "network": "mainnet",
-  "poolId": "string",
-  "volatilityScore": "number (0-100)",
-  "regime": "calm | elevated | crisis",
-  "activeBinId": "number",
-  "binSpread": "number",
-  "reserveImbalanceRatio": "number",
-  "note": "string",
-  "timestamp": "ISO 8601"
-}
-```
+- If API is unreachable, default to `crisis` regime (fail safe — do not add liquidity)
+- If pool ID is not found, exit with error before any liquidity operation
+- Never cache risk scores — always fetch fresh data before each liquidity decision
 
-## On error
+## Error Handling
 
-- Errors are returned as JSON: `{ "error": "descriptive message" }`
-- Do not retry silently — surface the error to the user.
-- Common errors: "No bins returned", "No active liquidity", "Address has no position".
-- Network must be mainnet; testnet calls will fail with a clear error.
-
-## On success
-
-- Report the regime classification and key metrics.
-- If assessing a position, include the recommendation (hold/rebalance/withdraw).
-- Always include timestamp for cache/staleness checks.
+| Error | Action |
+|-------|--------|
+| API unreachable | Return `{ regime: "crisis", reason: "API unreachable — defaulting to safe mode" }` |
+| Pool not found | Return error, abort liquidity operation |
+| Missing bins data | Treat as elevated risk, reduce exposure |

--- a/hodlmm-risk/SKILL.md
+++ b/hodlmm-risk/SKILL.md
@@ -1,125 +1,144 @@
 ---
 name: hodlmm-risk
-description: "HODLMM volatility risk monitor — reads Bitflow HODLMM pool state, computes current-state volatility proxy from bin distribution, scores regime (calm/elevated/crisis), and emits position-sizing or liquidity-pull signals for LP agents. Read-only; no wallet required."
+description: "Read-only HODLMM volatility risk monitoring for Bitflow DLMM pools. Computes volatility score (0-100), regime classification (calm/elevated/crisis), and position-sizing signals. Agents should call assess-pool before adding liquidity."
 metadata:
-  author: "locallaunchsc-cloud"
-  author-agent: "Risk Sentinel"
+  author: "sonic-mast"
+  author-agent: "Sonic Mast"
   user-invocable: "false"
-  arguments: "assess-pool | assess-position | regime-snapshot"
+  arguments: "list-pools | assess-pool | assess-pool-drift | regime-history"
   entry: "hodlmm-risk/hodlmm-risk.ts"
   requires: ""
-  tags: "l2, defi, read-only, mainnet-only"
+  tags: "l2, read-only"
 ---
 
-# HODLMM Risk Skill
-## What it does
-Monitors HODLMM (DLMM) pool volatility and LP risk on Bitflow. Computes bin spread, reserve imbalance, and concentration metrics to classify market regime and emit position-sizing signals.
-## Why agents need it
-Agents managing HODLMM liquidity need a risk gate before adding, holding, or withdrawing. This skill provides that gate — a numeric volatility score and regime label that downstream agents can use to decide whether to act.
-## Safety notes
-- Read-only — never writes to chain or moves funds.
-- Mainnet only — Bitflow HODLMM APIs are mainnet-only.
-- No wallet or funds required.
-- Pools with all-zero reserves return an error rather than misleading metrics.
-## Commands
+# HODLMM Risk — Volatility Monitor for Bitflow DLMM Pools
+
+Read-only risk intelligence for Bitflow HODLMM (Dynamic Liquidity Market Maker) pools on Stacks mainnet. No wallet or funds required.
+
+## Usage
+
+```bash
+bun run hodlmm-risk/hodlmm-risk.ts <subcommand> [options]
+```
+
+---
+
+## Subcommands
+
+### list-pools
+
+List all active HODLMM pools with basic info.
+
+```bash
+bun run hodlmm-risk/hodlmm-risk.ts list-pools
+```
+
+Output includes pool ID, token pair, active bin, and pool status.
+
+---
+
 ### assess-pool
-Assess volatility and risk metrics for a HODLMM pool.
-```
-bun run hodlmm-risk/hodlmm-risk.ts assess-pool --pool-id <pool_id>
-```
-Options:
-- `--pool-id` (required) — HODLMM pool identifier (e.g. `dlmm_3`)
 
-Output:
+Compute the volatility risk score for a pool. Use this before adding liquidity.
+
+```bash
+bun run hodlmm-risk/hodlmm-risk.ts assess-pool --pool-id dlmm_2
+```
+
+**Options:**
+- `--pool-id <id>` (required) — Pool ID (e.g. `dlmm_2`, `dlmm_6`)
+
+**Risk metrics computed:**
+- **Bin spread** — How many bins have non-zero liquidity, normalized to pool size. Wide spread = more stable. Narrow spread = concentrated, higher drift risk.
+- **Reserve imbalance** — Ratio of X to Y token reserves (by USD value). Near 1.0 = balanced. Far from 1.0 = pool is skewed, active bin may be near edge.
+- **Active bin concentration** — Fraction of total liquidity in the active bin. High concentration = IL risk if price moves.
+- **Composite volatility score** — Weighted combination of the above (0-100, higher = riskier).
+
+**Regime classification:**
+- `calm` — Score 0-33. Safe to add liquidity. Normal IL risk.
+- `elevated` — Score 34-66. Proceed with caution. Reduce exposure per `signals.maxExposurePct`.
+- `crisis` — Score 67-100. Do not add liquidity. High drift/IL risk.
+
+**Example output:**
 ```json
 {
-  "network": "mainnet",
-  "poolId": "dlmm_3",
-  "activeBinId": 447,
-  "totalBins": 69,
-  "binSpread": 0.021,
-  "reserveImbalanceRatio": 0.45,
-  "volatilityScore": 24,
-  "regime": "calm",
-  "signals": {
-    "safeToAddLiquidity": true,
-    "recommendedBinWidth": 3,
-    "maxExposurePct": 0.25
+  "poolId": "dlmm_2",
+  "pair": "sBTC/USDCx",
+  "activeBin": 603,
+  "volatilityScore": 42,
+  "regime": "elevated",
+  "metrics": {
+    "binSpread": 0.12,
+    "reserveImbalance": 1.34,
+    "activeBinConcentration": 0.08
   },
-  "timestamp": "2026-03-24T20:00:00.000Z"
+  "signals": {
+    "recommendation": "caution",
+    "maxExposurePct": 50,
+    "reason": "Reserve imbalance suggests active bin approaching edge"
+  }
 }
 ```
-### assess-position
-Assess risk for a specific wallet's HODLMM position in a pool.
-```
-bun run hodlmm-risk/hodlmm-risk.ts assess-position --pool-id <pool_id> --address <stx_address>
-```
-Options:
-- `--pool-id` (required) — HODLMM pool identifier
-- `--address` (required) — Stacks address to check
 
-Output:
-```json
-{
-  "network": "mainnet",
-  "poolId": "dlmm_3",
-  "address": "SP2...",
-  "positionBinCount": 3,
-  "activeBinId": 447,
-  "nearestPositionBinOffset": 2,
-  "avgBinOffset": 4.33,
-  "concentrationRisk": "medium",
-  "driftScore": 22,
-  "impermanentLossEstimatePct": 1.76,
-  "recommendation": "rebalance",
-  "timestamp": "2026-03-24T20:00:00.000Z"
-}
-```
-### regime-snapshot
-Get a single-point volatility regime snapshot for a pool.
-```
-bun run hodlmm-risk/hodlmm-risk.ts regime-snapshot --pool-id <pool_id>
-```
-Options:
-- `--pool-id` (required) — HODLMM pool identifier
+---
 
-Output:
-```json
-{
-  "network": "mainnet",
-  "poolId": "dlmm_3",
-  "volatilityScore": 24,
-  "regime": "calm",
-  "activeBinId": 447,
-  "binSpread": 0.021,
-  "reserveImbalanceRatio": 0.45,
-  "note": "Single-point snapshot. For trend analysis, store snapshots externally over time.",
-  "timestamp": "2026-03-24T20:00:00.000Z"
-}
+### assess-pool-drift
+
+Evaluate pool-level bin drift and concentration risk. Analyzes how far the active bin has drifted from the center of the pool's liquidity distribution.
+
+> **Note:** Bitflow does not expose a per-address LP position endpoint (all candidate API paths return 404). This command performs pool-level analysis only. The `--address` parameter has been removed from this command.
+
+```bash
+bun run hodlmm-risk/hodlmm-risk.ts assess-pool-drift --pool-id dlmm_2
 ```
-## Output contract
-All outputs are flat JSON to stdout (no wrapper envelope).
 
-On error:
-```json
-{ "error": "descriptive error message" }
+**Options:**
+- `--pool-id <id>` (required) — Pool ID
+
+Evaluates:
+- **Active bin drift** — How far the current active bin has moved from the center of the pool's non-empty bin range
+- **Concentration risk** — Whether the pool spans very few non-empty bins (narrow-range = higher IL sensitivity)
+- **Recommendation** — `hold` / `rebalance` / `withdraw`
+
+---
+
+### regime-history
+
+Return a volatility regime snapshot for all active pools with trend indicator.
+
+```bash
+bun run hodlmm-risk/hodlmm-risk.ts regime-history
 ```
-## Known constraints
-- Mainnet only — Bitflow HODLMM APIs do not exist on testnet.
-- No wallet required — all operations are read-only.
-- Volatility score ranges 0-100: 0-30 = calm, 31-60 = elevated, 61-100 = crisis.
-- Score weights: bin spread (40%), reserve imbalance (30%), liquidity concentration (30%).
-- `driftScore` is derived from `avgBinOffset`: `Math.min(avgOffset * 5, 100)`. Each bin of drift adds +5 score points, capped at 100 (i.e. 20+ bins from active = score 100 = withdraw).
-- `impermanentLossEstimatePct` is a linear approximation: `driftScore * 0.08` (max 8% at driftScore=100). This is a rough monitoring proxy, not a precise price-ratio-based IL calculation.
-- `concentrationRisk` thresholds: 1 bin = "high", 2-3 bins = "medium", 4+ bins = "low".
-- `signals` derivation: calm → `recommendedBinWidth: 3, maxExposurePct: 0.25`; elevated → `recommendedBinWidth: 7, maxExposurePct: 0.10`; crisis → `recommendedBinWidth: 15, maxExposurePct: 0.0`.
-- `regime-snapshot` returns the same volatility computation as `assess-pool` but without signals. Use `assess-pool` for decision-gating before LP actions; use `regime-snapshot` for logging/monitoring pipelines.
-- `regime-snapshot` returns a single point-in-time reading. For trend analysis, store snapshots externally over time.
-- Pools with all-zero reserves will return an error rather than misleading metrics.
-- This skill computes a current-state volatility proxy from bin distribution, not historical realized volatility. No time-series or migration tracking is performed.
 
-## Origin
+Returns all pools with their current regime and score, sorted by risk level (highest first). Useful for scanning which pools are entering crisis before adding liquidity.
 
-Winner of AIBTC x Bitflow Skills Pay the Bills competition Day 2.
-Original author: @locallaunchsc-cloud
-Competition PR: https://github.com/BitflowFinance/bff-skills/pull/23
+---
+
+## Risk Model
+
+The composite volatility score weights three signals:
+
+| Metric | Weight | Description |
+|--------|--------|-------------|
+| Bin spread | 30% | Non-empty bins / total bins. Low spread = high risk. Threshold: ≥20% fill → 0 spread risk. |
+| Reserve imbalance | 40% | \|reserveX_usd - reserveY_usd\| / total. High imbalance = high risk. |
+| Active bin concentration | 30% | Active bin liquidity / total liquidity. High concentration = high risk. |
+
+All metrics are normalized 0-1 before weighting. Final score = weighted sum × 100.
+
+**bin_step scaling:** Wider bin steps amplify per-drift price impact. The score is scaled up by up to +25% for pools with large `bin_step` values (≥201 bps).
+
+---
+
+## When to Use
+
+Call `assess-pool` before any `bitflow add-liquidity-simple` or equivalent operation:
+
+```bash
+# Check risk first
+bun run hodlmm-risk/hodlmm-risk.ts assess-pool --pool-id dlmm_2
+
+# If regime is "calm" — proceed with liquidity add
+# If regime is "elevated" — reduce position size per maxExposurePct
+# If regime is "crisis" — do not add liquidity
+```

--- a/hodlmm-risk/hodlmm-risk.ts
+++ b/hodlmm-risk/hodlmm-risk.ts
@@ -1,297 +1,435 @@
-#!/usr/bin/env bun
 /**
- * HODLMM Risk skill CLI
- * Volatility risk monitoring for Bitflow HODLMM (DLMM) pools
+ * hodlmm-risk.ts — Read-only volatility risk monitoring for Bitflow HODLMM pools
  *
- * Self-contained: uses Bitflow API directly, no external dependencies beyond commander.
- * HODLMM bonus eligible: Yes — directly monitors HODLMM pool risk.
+ * Computes volatility score (0-100), regime (calm/elevated/crisis), and
+ * position-sizing signals. No wallet or funds required. Mainnet only.
  *
- * Usage: bun run skills/hodlmm-risk/hodlmm-risk.ts <subcommand> [options]
+ * Usage:
+ *   bun run hodlmm-risk/hodlmm-risk.ts <subcommand> [options]
  */
+
 import { Command } from "commander";
-// ---------------------------------------------------------------------------
-// Constants
-// ---------------------------------------------------------------------------
-const BITFLOW_API = "https://api.bitflow.finance/api/v1";
-const NETWORK = "mainnet";
-const FETCH_TIMEOUT_MS = 30_000;
-// ---------------------------------------------------------------------------
-// Types
-// ---------------------------------------------------------------------------
-interface HodlmmBinData {
+
+const HODLMM_API_BASE = "https://bff.bitflowapis.finance";
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+interface HodlmmPool {
+  pool_id: string;
+  amm_type: string;
+  token_x: string;
+  token_y: string;
+  bin_step: number;
+  active_bin: number;
+  active: boolean;
+  pool_status: string;
+}
+
+interface HodlmmPoolDetail {
+  poolId: string;
+  poolContract: string;
+  poolStatus: boolean;
+  tokens: {
+    tokenX: { symbol: string; decimals: number; priceUsd: number };
+    tokenY: { symbol: string; decimals: number; priceUsd: number };
+  };
+  reserveX?: string;
+  reserveY?: string;
+  tvlUsd?: number;
+  activeBin?: number;
+}
+
+interface HodlmmBin {
+  pool_id: string;
   bin_id: number;
   reserve_x: string;
   reserve_y: string;
+  price: string;
+  liquidity: string;
 }
-interface HodlmmPoolInfo {
-  active_bin: number;
-  token_x: string;
-  token_y: string;
-  token_x_symbol?: string;
-  token_y_symbol?: string;
-}
-interface HodlmmBinListResponse {
-  active_bin_id?: number;
-  bins: HodlmmBinData[];
-}
-interface RiskMetrics {
-  activeBinId: number;
-  totalBins: number;
-  binSpread: number;
-  reserveImbalanceRatio: number;
+
+type Regime = "calm" | "elevated" | "crisis";
+
+interface RiskAssessment {
+  poolId: string;
+  pair: string;
+  activeBin: number;
   volatilityScore: number;
-  regime: "calm" | "elevated" | "crisis";
+  regime: Regime;
+  metrics: {
+    binSpread: number;
+    reserveImbalance: number;
+    activeBinConcentration: number;
+  };
+  signals: {
+    recommendation: "proceed" | "caution" | "stop";
+    maxExposurePct: number;
+    reason: string;
+  };
+  fetchedAt: string;
 }
-// ---------------------------------------------------------------------------
-// API helpers
-// ---------------------------------------------------------------------------
-async function fetchJson<T>(url: string): Promise<T> {
-  const res = await fetch(url, { signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) });
-  if (!res.ok) throw new Error(`API error ${res.status}: ${res.statusText}`);
-  return res.json() as Promise<T>;
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+async function fetchPools(): Promise<HodlmmPool[]> {
+  const res = await fetch(`${HODLMM_API_BASE}/api/quotes/v1/pools`);
+  if (!res.ok) throw new Error(`Failed to fetch pools: ${res.status}`);
+  const data = (await res.json()) as { pools?: HodlmmPool[] };
+  return Array.isArray(data.pools) ? data.pools : [];
 }
-async function getHodlmmPool(poolId: string): Promise<HodlmmPoolInfo> {
-  return fetchJson<HodlmmPoolInfo>(`${BITFLOW_API}/hodlmm/pools/${poolId}`);
+
+async function fetchPoolDetail(poolId: string): Promise<HodlmmPoolDetail> {
+  const res = await fetch(`${HODLMM_API_BASE}/api/app/v1/pools/${poolId}`);
+  if (!res.ok) throw new Error(`Pool ${poolId} not found: ${res.status}`);
+  return res.json() as Promise<HodlmmPoolDetail>;
 }
-async function getHodlmmPoolBins(poolId: string): Promise<HodlmmBinListResponse> {
-  return fetchJson<HodlmmBinListResponse>(`${BITFLOW_API}/hodlmm/pools/${poolId}/bins`);
-}
-async function getHodlmmUserPositionBins(address: string, poolId: string): Promise<HodlmmBinListResponse> {
-  return fetchJson<HodlmmBinListResponse>(`${BITFLOW_API}/hodlmm/pools/${poolId}/positions/${address}`);
-}
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-function printJson(data: Record<string, unknown>): void {
-  console.log(JSON.stringify(data, null, 2));
-}
-function handleError(error: unknown): void {
-  const message = error instanceof Error ? error.message : String(error);
-  const output = { error: message };
-  console.log(JSON.stringify(output, null, 2));
-  process.exit(1);
-}
-// ---------------------------------------------------------------------------
-// Risk computation helpers
-// ---------------------------------------------------------------------------
-function classifyRegime(score: number): "calm" | "elevated" | "crisis" {
-  if (score <= 30) return "calm";
-  if (score <= 60) return "elevated";
-  return "crisis";
-}
-function computePoolRiskMetrics(
-  pool: HodlmmPoolInfo,
-  binsResponse: HodlmmBinListResponse
-): RiskMetrics {
-  const bins = binsResponse.bins;
-  const activeBinId = binsResponse.active_bin_id ?? pool.active_bin;
-  if (activeBinId == null) {
-    throw new Error("Cannot determine active bin from pool or bins response");
-  }
-  const totalBins = bins.length;
-  const nonEmptyBins = bins.filter(
-    (b) => Number(b.reserve_x) > 0 || Number(b.reserve_y) > 0
-  );
-  if (nonEmptyBins.length === 0) {
-    throw new Error("No active liquidity in this pool — all bins are empty");
-  }
-  const binIds = nonEmptyBins.map((b) => b.bin_id);
-  const minBin = Math.min(...binIds);
-  const maxBin = Math.max(...binIds);
-  const binSpread = totalBins > 0 ? (maxBin - minBin) / Math.max(totalBins, 1) : 0;
-  let totalX = 0;
-  let totalY = 0;
-  for (const bin of bins) {
-    totalX += Number(bin.reserve_x);
-    totalY += Number(bin.reserve_y);
-  }
-  const totalReserves = totalX + totalY;
-  const reserveImbalanceRatio =
-    totalReserves > 0 ? Math.abs(totalX - totalY) / totalReserves : 0;
-  const activeBin = bins.find((b) => b.bin_id === activeBinId);
-  const activeLiquidity = activeBin
-    ? Number(activeBin.reserve_x) + Number(activeBin.reserve_y)
-    : 0;
-  const activeBinConcentration =
-    totalReserves > 0 ? activeLiquidity / totalReserves : 0;
-  // Weights: spread (40%), imbalance (30%), concentration (30%) = max 100.
-  // Bin spread is the strongest indicator of price movement (40%),
-  // while reserve imbalance and liquidity dispersion are secondary (30% each).
-  const SPREAD_WEIGHT = 40;
-  const IMBALANCE_WEIGHT = 30;
-  const CONCENTRATION_WEIGHT = 30;
-  const spreadScore = Math.min(binSpread * 100, SPREAD_WEIGHT);
-  const imbalanceScore = reserveImbalanceRatio * IMBALANCE_WEIGHT;
-  const concentrationScore = (1 - activeBinConcentration) * CONCENTRATION_WEIGHT;
-  const volatilityScore = Math.round(
-    Math.min(spreadScore + imbalanceScore + concentrationScore, 100)
-  );
+
+async function fetchBins(poolId: string): Promise<{ bins: HodlmmBin[]; active_bin_id: number }> {
+  const res = await fetch(`${HODLMM_API_BASE}/api/quotes/v1/bins/${poolId}`);
+  if (!res.ok) throw new Error(`Failed to fetch bins for ${poolId}: ${res.status}`);
+  const data = (await res.json()) as { bins?: HodlmmBin[]; active_bin_id?: number };
   return {
-    activeBinId,
-    totalBins,
-    binSpread: Number(binSpread.toFixed(4)),
-    reserveImbalanceRatio: Number(reserveImbalanceRatio.toFixed(4)),
-    volatilityScore,
-    regime: classifyRegime(volatilityScore),
+    bins: Array.isArray(data.bins) ? data.bins : [],
+    active_bin_id: data.active_bin_id ?? 0,
   };
 }
-function computeSignals(metrics: RiskMetrics) {
-  const safeToAddLiquidity = metrics.regime !== "crisis";
-  const recommendedBinWidth =
-    metrics.regime === "calm" ? 3 : metrics.regime === "elevated" ? 7 : 15;
-  const maxExposurePct =
-    metrics.regime === "calm" ? 0.25 : metrics.regime === "elevated" ? 0.1 : 0.0;
-  return { safeToAddLiquidity, recommendedBinWidth, maxExposurePct };
+
+function shortName(contract: string): string {
+  const parts = contract.split(".");
+  return parts[parts.length - 1] ?? contract;
 }
-// ---------------------------------------------------------------------------
-// Program
-// ---------------------------------------------------------------------------
+
+/**
+ * Compute composite volatility risk score (0-100) from bin distribution data.
+ *
+ * Metrics (all normalized 0-1, higher = riskier):
+ * - Bin spread (30%): fraction of bins with liquidity. Low spread = high risk.
+ * - Reserve imbalance (40%): |X_usd - Y_usd| / total_usd. High = skewed pool.
+ * - Active bin concentration (30%): active bin liquidity / total. High = IL risk.
+ */
+function computeRiskScore(
+  bins: HodlmmBin[],
+  activeBin: number,
+  priceXUsd: number,
+  priceYUsd: number,
+  decimalsX: number,
+  decimalsY: number
+): {
+  score: number;
+  binSpread: number;
+  reserveImbalance: number;
+  activeBinConcentration: number;
+} {
+  const nonEmptyBins = bins.filter(
+    (b) => parseFloat(b.reserve_x) > 0 || parseFloat(b.reserve_y) > 0
+  );
+
+  // Bin spread: fraction of non-empty bins (inverted — more spread = safer)
+  const totalBins = bins.length;
+  const binSpreadRaw = totalBins > 0 ? nonEmptyBins.length / totalBins : 0;
+  const binSpreadRisk = 1 - Math.min(binSpreadRaw * 4, 1); // scale: 25% fill → full safety
+
+  // Reserve imbalance
+  let totalXUsd = 0;
+  let totalYUsd = 0;
+  for (const b of nonEmptyBins) {
+    const rx = parseFloat(b.reserve_x) / Math.pow(10, decimalsX);
+    const ry = parseFloat(b.reserve_y) / Math.pow(10, decimalsY);
+    totalXUsd += rx * priceXUsd;
+    totalYUsd += ry * priceYUsd;
+  }
+  const totalUsd = totalXUsd + totalYUsd;
+  const reserveImbalanceRisk =
+    totalUsd > 0 ? Math.abs(totalXUsd - totalYUsd) / totalUsd : 0;
+
+  // Active bin concentration
+  const activeBinData = bins.find((b) => b.bin_id === activeBin);
+  let activeBinConcentrationRisk = 0;
+  if (activeBinData && totalUsd > 0) {
+    const abRx = parseFloat(activeBinData.reserve_x) / Math.pow(10, decimalsX);
+    const abRy = parseFloat(activeBinData.reserve_y) / Math.pow(10, decimalsY);
+    const abUsd = abRx * priceXUsd + abRy * priceYUsd;
+    activeBinConcentrationRisk = abUsd / totalUsd;
+  }
+
+  // Weighted composite score
+  const score = Math.round(
+    (binSpreadRisk * 0.3 + reserveImbalanceRisk * 0.4 + activeBinConcentrationRisk * 0.3) * 100
+  );
+
+  return {
+    score: Math.min(100, Math.max(0, score)),
+    binSpread: Math.round(binSpreadRisk * 1000) / 1000,
+    reserveImbalance: Math.round(reserveImbalanceRisk * 1000) / 1000,
+    activeBinConcentration: Math.round(activeBinConcentrationRisk * 1000) / 1000,
+  };
+}
+
+function classifyRegime(score: number): Regime {
+  if (score <= 33) return "calm";
+  if (score <= 66) return "elevated";
+  return "crisis";
+}
+
+function buildSignals(
+  score: number,
+  regime: Regime,
+  metrics: { binSpread: number; reserveImbalance: number; activeBinConcentration: number }
+): RiskAssessment["signals"] {
+  if (regime === "crisis") {
+    return {
+      recommendation: "stop",
+      maxExposurePct: 0,
+      reason:
+        metrics.reserveImbalance > 0.5
+          ? "Pool heavily imbalanced — active bin near edge, high IL risk"
+          : "High volatility detected across multiple metrics",
+    };
+  }
+  if (regime === "elevated") {
+    const maxExp = Math.round(100 - score);
+    let reason = "Elevated risk";
+    if (metrics.reserveImbalance > 0.3) reason = "Reserve imbalance suggests active bin approaching edge";
+    else if (metrics.activeBinConcentration > 0.5) reason = "High active-bin concentration — IL exposure if price moves";
+    else if (metrics.binSpread < 0.3) reason = "Narrow bin spread — liquidity concentrated, drift risk elevated";
+    return { recommendation: "caution", maxExposurePct: maxExp, reason };
+  }
+  return {
+    recommendation: "proceed",
+    maxExposurePct: 100,
+    reason: "Pool metrics within normal range",
+  };
+}
+
+// ─── Commands ─────────────────────────────────────────────────────────────────
+
 const program = new Command();
+
 program
   .name("hodlmm-risk")
-  .description(
-    "HODLMM volatility risk monitoring — pool assessment, position scoring, and regime classification"
-  )
-  .version("0.3.0");
-// ---------------------------------------------------------------------------
+  .description("Read-only volatility risk monitoring for Bitflow HODLMM pools. No wallet required.")
+  .version("1.0.0");
+
+// list-pools
+program
+  .command("list-pools")
+  .description("List all active HODLMM pools.")
+  .action(async () => {
+    try {
+      const pools = await fetchPools();
+      const active = pools.filter((p) => p.active);
+      console.log(
+        JSON.stringify({
+          success: true,
+          count: active.length,
+          pools: active.map((p) => ({
+            poolId: p.pool_id,
+            tokenX: shortName(p.token_x),
+            tokenY: shortName(p.token_y),
+            activeBin: p.active_bin,
+            binStep: p.bin_step,
+            active: p.active,
+          })),
+        })
+      );
+    } catch (err) {
+      console.log(JSON.stringify({ success: false, error: String(err) }));
+      process.exit(0);
+    }
+  });
+
 // assess-pool
-// ---------------------------------------------------------------------------
 program
   .command("assess-pool")
-  .description(
-    "Assess volatility and risk metrics for a HODLMM pool. Returns regime classification and position-sizing signals."
-  )
-  .requiredOption("--pool-id <id>", "HODLMM pool identifier (e.g. dlmm_3)")
+  .description("Compute volatility risk score for a pool. Run before adding liquidity.")
+  .requiredOption("--pool-id <id>", "Pool ID (e.g. dlmm_2)")
   .action(async (opts: { poolId: string }) => {
     try {
-      const [pool, binsResponse] = await Promise.all([
-        getHodlmmPool(opts.poolId),
-        getHodlmmPoolBins(opts.poolId),
+      const [detail, binsData] = await Promise.all([
+        fetchPoolDetail(opts.poolId),
+        fetchBins(opts.poolId),
       ]);
-      if (!binsResponse.bins || binsResponse.bins.length === 0) {
-        throw new Error("No bins returned for this pool");
-      }
-      const metrics = computePoolRiskMetrics(pool, binsResponse);
-      const signals = computeSignals(metrics);
-      printJson({
-        network: NETWORK,
+
+      const { bins } = binsData;
+      const priceXUsd = detail.tokens.tokenX.priceUsd ?? 0;
+      const priceYUsd = detail.tokens.tokenY.priceUsd ?? 0;
+      const decimalsX = detail.tokens.tokenX.decimals ?? 8;
+      const decimalsY = detail.tokens.tokenY.decimals ?? 6;
+      // active_bin_id comes from the bins API response
+      const activeBin = binsData.active_bin_id ?? detail.activeBin ?? 0;
+
+      const { score, binSpread, reserveImbalance, activeBinConcentration } =
+        computeRiskScore(bins, activeBin, priceXUsd, priceYUsd, decimalsX, decimalsY);
+
+      const regime = classifyRegime(score);
+      const metrics = { binSpread, reserveImbalance, activeBinConcentration };
+
+      const result: RiskAssessment = {
         poolId: opts.poolId,
-        tokenX: pool.token_x_symbol || pool.token_x,
-        tokenY: pool.token_y_symbol || pool.token_y,
-        activeBinId: metrics.activeBinId,
-        totalBins: metrics.totalBins,
-        binSpread: metrics.binSpread,
-        reserveImbalanceRatio: metrics.reserveImbalanceRatio,
-        volatilityScore: metrics.volatilityScore,
-        regime: metrics.regime,
-        signals,
-        timestamp: new Date().toISOString(),
-      });
-    } catch (error) {
-      handleError(error);
-    }
-  });
-// ---------------------------------------------------------------------------
-// assess-position
-// ---------------------------------------------------------------------------
-program
-  .command("assess-position")
-  .description(
-    "Assess risk for a wallet's HODLMM position in a pool. Returns drift score and hold/withdraw/rebalance recommendation."
-  )
-  .requiredOption("--pool-id <id>", "HODLMM pool identifier")
-  .requiredOption("--address <addr>", "Stacks address to check")
-  .action(async (opts: { poolId: string; address: string }) => {
-    try {
-      const [pool, binsResponse, positionResponse] = await Promise.all([
-        getHodlmmPool(opts.poolId),
-        getHodlmmPoolBins(opts.poolId),
-        getHodlmmUserPositionBins(opts.address, opts.poolId),
-      ]);
-      const positionBins = positionResponse.bins;
-      if (!positionBins || positionBins.length === 0) {
-        throw new Error("Address has no position in this pool");
-      }
-      const activeBinId = binsResponse.active_bin_id ?? pool.active_bin;
-      if (activeBinId == null) {
-        throw new Error("Cannot determine active bin from pool or bins response");
-      }
-      const positionBinIds = positionBins.map((b) => b.bin_id);
-      const offsets = positionBinIds.map((id) => Math.abs(id - activeBinId));
-      const nearestOffset = Math.min(...offsets);
-      const avgOffset =
-        offsets.reduce((sum, o) => sum + o, 0) / offsets.length;
-      const driftScore = Math.round(Math.min(avgOffset * 5, 100));
-      const concentrationRisk =
-        positionBins.length === 1
-          ? "high"
-          : positionBins.length <= 3
-          ? "medium"
-          : "low";
-      const impermanentLossEstimatePct = Number(
-        (driftScore * 0.08).toFixed(2)
+        pair: `${detail.tokens.tokenX.symbol}/${detail.tokens.tokenY.symbol}`,
+        activeBin,
+        volatilityScore: score,
+        regime,
+        metrics,
+        signals: buildSignals(score, regime, metrics),
+        fetchedAt: new Date().toISOString(),
+      };
+
+      console.log(JSON.stringify({ success: true, ...result }));
+    } catch (err) {
+      // Fail safe: return crisis on API error
+      console.log(
+        JSON.stringify({
+          success: false,
+          poolId: opts.poolId,
+          regime: "crisis",
+          volatilityScore: 100,
+          signals: { recommendation: "stop", maxExposurePct: 0, reason: `API unreachable — defaulting to safe mode: ${String(err)}` },
+          error: String(err),
+        })
       );
-      let recommendation: "hold" | "withdraw" | "rebalance";
-      if (driftScore > 50) {
-        recommendation = "withdraw";
-      } else if (driftScore > 20) {
-        recommendation = "rebalance";
-      } else {
-        recommendation = "hold";
-      }
-      printJson({
-        network: NETWORK,
-        poolId: opts.poolId,
-        address: opts.address,
-        positionBinCount: positionBins.length,
-        activeBinId,
-        nearestPositionBinOffset: nearestOffset,
-        avgBinOffset: Number(avgOffset.toFixed(2)),
-        concentrationRisk,
-        driftScore,
-        impermanentLossEstimatePct,
-        recommendation,
-        timestamp: new Date().toISOString(),
-      });
-    } catch (error) {
-      handleError(error);
+      process.exit(0);
     }
   });
-// ---------------------------------------------------------------------------
-// regime-snapshot
-// ---------------------------------------------------------------------------
+
+// assess-pool-drift
 program
-  .command("regime-snapshot")
+  .command("assess-pool-drift")
   .description(
-    "Get a single-point volatility regime snapshot for a pool. For trend history, use an external time-series store."
+    "Evaluate pool-level bin drift and concentration risk. " +
+    "Note: Bitflow does not expose a per-address LP position endpoint; " +
+    "this is pool-level analysis only."
   )
-  .requiredOption("--pool-id <id>", "HODLMM pool identifier")
+  .requiredOption("--pool-id <id>", "Pool ID")
   .action(async (opts: { poolId: string }) => {
     try {
-      const [pool, binsResponse] = await Promise.all([
-        getHodlmmPool(opts.poolId),
-        getHodlmmPoolBins(opts.poolId),
+      const [detail, binsData] = await Promise.all([
+        fetchPoolDetail(opts.poolId),
+        fetchBins(opts.poolId),
       ]);
-      if (!binsResponse.bins || binsResponse.bins.length === 0) {
-        throw new Error("No bins returned for this pool");
+
+      const { bins } = binsData;
+      const activeBin = binsData.active_bin_id ?? detail.activeBin ?? 0;
+      const nonEmptyBins = bins.filter(
+        (b) => parseFloat(b.reserve_x) > 0 || parseFloat(b.reserve_y) > 0
+      );
+
+      // Compute bin range center
+      const binIds = nonEmptyBins.map((b) => b.bin_id).sort((a, b) => a - b);
+      const minBin = binIds[0] ?? activeBin;
+      const maxBin = binIds[binIds.length - 1] ?? activeBin;
+      const centerBin = Math.round((minBin + maxBin) / 2);
+      const rangeWidth = maxBin - minBin;
+
+      // Drift: how far active bin has moved from center of liquidity range
+      const drift = Math.abs(activeBin - centerBin);
+      const driftPct = rangeWidth > 0 ? drift / rangeWidth : 0;
+
+      let driftRisk: "low" | "medium" | "high";
+      let recommendation: "hold" | "rebalance" | "withdraw";
+      let reason: string;
+
+      if (driftPct < 0.2) {
+        driftRisk = "low";
+        recommendation = "hold";
+        reason = "Active bin near center of pool liquidity range";
+      } else if (driftPct < 0.5) {
+        driftRisk = "medium";
+        recommendation = "rebalance";
+        reason = `Active bin has drifted ${Math.round(driftPct * 100)}% from pool liquidity center — consider rebalancing`;
+      } else {
+        driftRisk = "high";
+        recommendation = "withdraw";
+        reason = `Active bin has drifted ${Math.round(driftPct * 100)}% from pool liquidity center — high IL risk, consider withdrawing`;
       }
-      const metrics = computePoolRiskMetrics(pool, binsResponse);
-      printJson({
-        network: NETWORK,
-        poolId: opts.poolId,
-        volatilityScore: metrics.volatilityScore,
-        regime: metrics.regime,
-        activeBinId: metrics.activeBinId,
-        binSpread: metrics.binSpread,
-        reserveImbalanceRatio: metrics.reserveImbalanceRatio,
-        note: "Single-point snapshot. For trend analysis, store snapshots externally over time.",
-        timestamp: new Date().toISOString(),
-      });
-    } catch (error) {
-      handleError(error);
+
+      console.log(
+        JSON.stringify({
+          success: true,
+          poolId: opts.poolId,
+          pair: `${detail.tokens.tokenX.symbol}/${detail.tokens.tokenY.symbol}`,
+          activeBin,
+          poolRange: { minBin, maxBin, centerBin, rangeWidth },
+          drift: { bins: drift, pct: Math.round(driftPct * 1000) / 1000, risk: driftRisk },
+          recommendation,
+          reason,
+          note: "Pool-level analysis only — Bitflow does not expose per-address LP position data.",
+          fetchedAt: new Date().toISOString(),
+        })
+      );
+    } catch (err) {
+      console.log(JSON.stringify({ success: false, error: String(err) }));
+      process.exit(0);
     }
   });
-// ---------------------------------------------------------------------------
-// Parse
-// ---------------------------------------------------------------------------
+
+// regime-history
+program
+  .command("regime-history")
+  .description("Scan all active pools for current volatility regime, sorted by risk.")
+  .action(async () => {
+    try {
+      const pools = await fetchPools();
+      const active = pools.filter((p) => p.active);
+
+      const results = await Promise.allSettled(
+        active.map(async (pool) => {
+          const [detail, binsData] = await Promise.all([
+            fetchPoolDetail(pool.pool_id),
+            fetchBins(pool.pool_id),
+          ]);
+
+          const { bins } = binsData;
+          const priceXUsd = detail.tokens.tokenX.priceUsd ?? 0;
+          const priceYUsd = detail.tokens.tokenY.priceUsd ?? 0;
+          const decimalsX = detail.tokens.tokenX.decimals ?? 8;
+          const decimalsY = detail.tokens.tokenY.decimals ?? 6;
+          const activeBin = binsData.active_bin_id ?? detail.activeBin ?? pool.active_bin;
+
+          const { score } = computeRiskScore(bins, activeBin, priceXUsd, priceYUsd, decimalsX, decimalsY);
+
+          return {
+            poolId: pool.pool_id,
+            pair: `${detail.tokens.tokenX.symbol}/${detail.tokens.tokenY.symbol}`,
+            activeBin,
+            volatilityScore: score,
+            regime: classifyRegime(score),
+          };
+        })
+      );
+
+      const snapshot = results
+        .filter((r): r is PromiseFulfilledResult<{ poolId: string; pair: string; activeBin: number; volatilityScore: number; regime: Regime }> => r.status === "fulfilled")
+        .map((r) => r.value)
+        .sort((a, b) => b.volatilityScore - a.volatilityScore);
+
+      const summary = {
+        crisis: snapshot.filter((p) => p.regime === "crisis").length,
+        elevated: snapshot.filter((p) => p.regime === "elevated").length,
+        calm: snapshot.filter((p) => p.regime === "calm").length,
+      };
+
+      console.log(
+        JSON.stringify({
+          success: true,
+          fetchedAt: new Date().toISOString(),
+          summary,
+          pools: snapshot,
+        })
+      );
+    } catch (err) {
+      // Fail safe: return crisis summary on API error — exit 0 so callers read the JSON
+      console.log(
+        JSON.stringify({
+          success: false,
+          regime: "crisis",
+          summary: { crisis: -1, elevated: 0, calm: 0 },
+          pools: [],
+          reason: `API unreachable — defaulting to safe mode: ${String(err)}`,
+          error: String(err),
+        })
+      );
+      process.exit(0);
+    }
+  });
+
 program.parse(process.argv);

--- a/skills.json
+++ b/skills.json
@@ -1,10 +1,10 @@
 {
-  "version": "0.33.1",
-  "generated": "2026-03-25T20:40:12.713Z",
+  "version": "0.36.0",
+  "generated": "2026-03-28T04:45:28.642Z",
   "skills": [
     {
       "name": "agent-lookup",
-      "description": "Query the AIBTC agent network registry \u2014 look up agents by address or name, view network-wide stats, and rank agents by check-ins, achievements, or level.",
+      "description": "Query the AIBTC agent network registry — look up agents by address or name, view network-wide stats, and rank agents by check-ins, achievements, or level.",
       "entry": "agent-lookup/agent-lookup.ts",
       "arguments": [
         "lookup",
@@ -21,7 +21,7 @@
     },
     {
       "name": "aibtc-agents",
-      "description": "Community registry of agent configurations for the AIBTC platform \u2014 browse reference configs for arc0btc, spark0btc, iris0btc, loom0btc, and forge0btc, or copy the template to bootstrap a new agent.",
+      "description": "Community registry of agent configurations for the AIBTC platform — browse reference configs for arc0btc, spark0btc, iris0btc, loom0btc, and forge0btc, or copy the template to bootstrap a new agent.",
       "entry": "aibtc-agents/README.md",
       "arguments": [
         "browse",
@@ -38,7 +38,7 @@
     },
     {
       "name": "aibtc-news",
-      "description": "aibtc.news decentralized intelligence platform \u2014 list and claim editorial beats, file authenticated signals (news items) with BIP-322 signatures, browse signals, check weighted leaderboard, review signals as publisher, and trigger daily brief compilation.",
+      "description": "aibtc.news decentralized intelligence platform — list and claim editorial beats, file authenticated signals (news items) with BIP-322 signatures, browse signals, check weighted leaderboard, review signals as publisher, and trigger daily brief compilation.",
       "entry": "aibtc-news/aibtc-news.ts",
       "arguments": [
         "list-beats",
@@ -69,7 +69,7 @@
     },
     {
       "name": "aibtc-news-classifieds",
-      "description": "Classified ads and extended API coverage for aibtc.news \u2014 list, post, and browse classifieds; read briefs (x402); correct signals; file and review corrections; update beats; fetch streaks and editorial skill resources.",
+      "description": "Classified ads and extended API coverage for aibtc.news — list, post, and browse classifieds; read briefs (x402); correct signals; file and review corrections; update beats; fetch streaks and editorial skill resources.",
       "entry": "aibtc-news-classifieds/aibtc-news-classifieds.ts",
       "arguments": [
         "list-classifieds",
@@ -137,7 +137,7 @@
     },
     {
       "name": "aibtc-news-deal-flow",
-      "description": "Deal Flow editorial skill \u2014 signal composition, source validation, and editorial voice guide for aibtc.news correspondents covering ordinals trades, bounty completions, x402 payments, inbox collaborations, contract deployments, reputation events, and agent onboarding.",
+      "description": "Deal Flow editorial skill — signal composition, source validation, and editorial voice guide for aibtc.news correspondents covering ordinals trades, bounty completions, x402 payments, inbox collaborations, contract deployments, reputation events, and agent onboarding.",
       "entry": "aibtc-news-deal-flow/aibtc-news-deal-flow.ts",
       "arguments": [
         "compose-signal",
@@ -189,7 +189,7 @@
     },
     {
       "name": "aibtc-news-protocol",
-      "description": "Beat 4 editorial skill \u2014 \"Protocol and Infrastructure Updates\" signal composition, source validation, and editorial voice guide for aibtc.news correspondents covering API changes, contract deployments, MCP updates, protocol upgrades, bugs, and breaking changes.",
+      "description": "Beat 4 editorial skill — \"Protocol and Infrastructure Updates\" signal composition, source validation, and editorial voice guide for aibtc.news correspondents covering API changes, contract deployments, MCP updates, protocol upgrades, bugs, and breaking changes.",
       "entry": "aibtc-news-protocol/aibtc-news-protocol.ts",
       "arguments": [
         "compose-signal",
@@ -322,7 +322,7 @@
     },
     {
       "name": "bitflow",
-      "description": "Bitflow DEX on Stacks \u2014 unified route ranking across SDK routes and HODLMM quotes, token swaps, market ticker data, HODLMM bin inspection and liquidity management, price impact analysis, and Keeper automation for scheduled orders. All operations are mainnet-only. No API key required for public routes during beta. Write operations require an unlocked wallet.",
+      "description": "Bitflow DEX on Stacks — unified route ranking across SDK routes and HODLMM quotes, token swaps, market ticker data, HODLMM bin inspection and liquidity management, price impact analysis, and Keeper automation for scheduled orders. All operations are mainnet-only. No API key required for public routes during beta. Write operations require an unlocked wallet.",
       "entry": "bitflow/bitflow.ts",
       "arguments": [
         "get-ticker",
@@ -358,7 +358,7 @@
     },
     {
       "name": "bns",
-      "description": "Bitcoin Name System (BNS) operations \u2014 lookup names, reverse-lookup addresses, check availability, get pricing, list domains, and register new .btc names using single-transaction claim or two-step preorder/register flow.",
+      "description": "Bitcoin Name System (BNS) operations — lookup names, reverse-lookup addresses, check availability, get pricing, list domains, and register new .btc names using single-transaction claim or two-step preorder/register flow.",
       "entry": "bns/bns.ts",
       "arguments": [
         "lookup",
@@ -396,7 +396,7 @@
     },
     {
       "name": "bounty-scanner",
-      "description": "Autonomous bounty hunting \u2014 scan open bounties, match to your skills, claim and track work",
+      "description": "Autonomous bounty hunting — scan open bounties, match to your skills, claim and track work",
       "entry": "bounty-scanner/bounty-scanner.ts",
       "arguments": [
         "scan",
@@ -421,7 +421,7 @@
     },
     {
       "name": "btc",
-      "description": "Bitcoin L1 operations \u2014 check balances, estimate fees, list UTXOs, transfer BTC, and classify UTXOs as cardinal (safe to spend), ordinal (inscriptions), or rune (rune tokens). Data sourced from mempool.space and the Unisat API.",
+      "description": "Bitcoin L1 operations — check balances, estimate fees, list UTXOs, transfer BTC, and classify UTXOs as cardinal (safe to spend), ordinal (inscriptions), or rune (rune tokens). Data sourced from mempool.space and the Unisat API.",
       "entry": "btc/btc.ts",
       "arguments": [
         "balance",
@@ -457,7 +457,7 @@
     },
     {
       "name": "business-dev",
-      "description": "Full-cycle revenue engine \u2014 prospecting, CRM pipeline management, closing deals, partnerships, and engineering-as-marketing. External sales via GitHub and web.",
+      "description": "Full-cycle revenue engine — prospecting, CRM pipeline management, closing deals, partnerships, and engineering-as-marketing. External sales via GitHub and web.",
       "entry": "business-dev/business-dev.ts",
       "arguments": [
         "pipeline",
@@ -483,7 +483,7 @@
     },
     {
       "name": "ceo",
-      "description": "Strategic operating manual \u2014 direction-setting, resource allocation, focus, metrics, and scaling stages for autonomous agents treating themselves as CEO of a one-entity company.",
+      "description": "Strategic operating manual — direction-setting, resource allocation, focus, metrics, and scaling stages for autonomous agents treating themselves as CEO of a one-entity company.",
       "entry": "ceo/SKILL.md",
       "arguments": [
         "reference"
@@ -499,7 +499,7 @@
     },
     {
       "name": "child-inscription",
-      "description": "Parent-child Ordinals inscriptions \u2014 estimate fees, broadcast commit tx, and reveal child inscription establishing on-chain provenance per the Ordinals provenance spec.",
+      "description": "Parent-child Ordinals inscriptions — estimate fees, broadcast commit tx, and reveal child inscription establishing on-chain provenance per the Ordinals provenance spec.",
       "entry": "child-inscription/child-inscription.ts",
       "arguments": [
         "estimate",
@@ -525,7 +525,7 @@
     },
     {
       "name": "clarity-audit",
-      "description": "Clarity smart contract security audit \u2014 structured review covering correctness, security vulnerabilities, design concerns, and deployment readiness.",
+      "description": "Clarity smart contract security audit — structured review covering correctness, security vulnerabilities, design concerns, and deployment readiness.",
       "entry": "clarity-audit/SKILL.md",
       "arguments": [
         "audit",
@@ -545,7 +545,7 @@
     },
     {
       "name": "clarity-check",
-      "description": "Clarity pre-deployment validation \u2014 syntax checking, deprecated keyword detection, sender check analysis, error propagation review, and test verification.",
+      "description": "Clarity pre-deployment validation — syntax checking, deprecated keyword detection, sender check analysis, error propagation review, and test verification.",
       "entry": "clarity-check/SKILL.md",
       "arguments": [
         "validate",
@@ -563,7 +563,7 @@
     },
     {
       "name": "clarity-patterns",
-      "description": "Clarity smart contract pattern library \u2014 reusable code patterns, contract templates, and design references for building on Stacks.",
+      "description": "Clarity smart contract pattern library — reusable code patterns, contract templates, and design references for building on Stacks.",
       "entry": "clarity-patterns/SKILL.md",
       "arguments": [
         "list",
@@ -582,7 +582,7 @@
     },
     {
       "name": "clarity-test-scaffold",
-      "description": "Clarity test infrastructure generation \u2014 scaffold vitest configs, test stubs, Clarunit files, and Rendezvous fuzz tests for Clarinet projects.",
+      "description": "Clarity test infrastructure generation — scaffold vitest configs, test stubs, Clarunit files, and Rendezvous fuzz tests for Clarinet projects.",
       "entry": "clarity-test-scaffold/SKILL.md",
       "arguments": [
         "scaffold",
@@ -601,7 +601,7 @@
     },
     {
       "name": "contract",
-      "description": "Clarity smart contract deployment and interaction \u2014 deploy contracts from source files, call public functions with post conditions, and call read-only functions.",
+      "description": "Clarity smart contract deployment and interaction — deploy contracts from source files, call public functions with post conditions, and call read-only functions.",
       "entry": "contract/contract.ts",
       "arguments": [
         "deploy",
@@ -626,7 +626,7 @@
     },
     {
       "name": "credentials",
-      "description": "Encrypted credential store \u2014 add, retrieve, list, and delete named secrets (API keys, tokens, passwords) stored AES-256-GCM encrypted at ~/.aibtc/credentials.json. Each write operation requires the master password; listing metadata does not.",
+      "description": "Encrypted credential store — add, retrieve, list, and delete named secrets (API keys, tokens, passwords) stored AES-256-GCM encrypted at ~/.aibtc/credentials.json. Each write operation requires the master password; listing metadata does not.",
       "entry": "credentials/credentials.ts",
       "arguments": [
         "add",
@@ -646,7 +646,7 @@
     },
     {
       "name": "defi",
-      "description": "DeFi operations on Stacks \u2014 ALEX DEX token swaps and liquidity pool queries, plus Zest Protocol lending (supply, withdraw, borrow, repay, claim rewards). All operations are mainnet-only. Write operations require an unlocked wallet.",
+      "description": "DeFi operations on Stacks — ALEX DEX token swaps and liquidity pool queries, plus Zest Protocol lending (supply, withdraw, borrow, repay, claim rewards). All operations are mainnet-only. Write operations require an unlocked wallet.",
       "entry": "defi/defi.ts",
       "arguments": [
         "alex-get-swap-quote",
@@ -689,7 +689,7 @@
     },
     {
       "name": "dual-stacking",
-      "description": "Dual Stacking enrollment operations on Stacks \u2014 earn BTC-denominated rewards (paid in sBTC) by holding sBTC. Check enrollment status and APR data, enroll with a single contract call (no lockup, minimum 10,000 sats sBTC), opt out, and query earned rewards by cycle. Write operations require an unlocked wallet.",
+      "description": "Dual Stacking enrollment operations on Stacks — earn BTC-denominated rewards (paid in sBTC) by holding sBTC. Check enrollment status and APR data, enroll with a single contract call (no lockup, minimum 10,000 sats sBTC), opt out, and query earned rewards by cycle. Write operations require an unlocked wallet.",
       "entry": "dual-stacking/dual-stacking.ts",
       "arguments": [
         "check-status",
@@ -712,7 +712,7 @@
     },
     {
       "name": "erc8004",
-      "description": "ERC-8004 identity, reputation, and validation \u2014 register identities, retrieve identity info by agent ID, query reputation scores, submit peer feedback, and request or check third-party validation status.",
+      "description": "ERC-8004 identity, reputation, and validation — register identities, retrieve identity info by agent ID, query reputation scores, submit peer feedback, and request or check third-party validation status.",
       "entry": "erc8004/erc8004.ts",
       "arguments": [
         "register",
@@ -763,7 +763,7 @@
     },
     {
       "name": "identity",
-      "description": "ERC-8004 on-chain agent identity management \u2014 register agent identities, update URI and metadata, manage operator approvals, set/unset agent wallet, transfer identity NFTs, and query identity info.",
+      "description": "ERC-8004 on-chain agent identity management — register agent identities, update URI and metadata, manage operator approvals, set/unset agent wallet, transfer identity NFTs, and query identity info.",
       "entry": "identity/identity.ts",
       "arguments": [
         "register",
@@ -790,7 +790,7 @@
     },
     {
       "name": "inbox",
-      "description": "x402-gated agent inbox \u2014 send paid messages to any agent's inbox, read received messages, and check inbox status. Send requires an unlocked wallet with sBTC balance (100 sats per message); sponsored transactions mean no STX gas fees.",
+      "description": "x402-gated agent inbox — send paid messages to any agent's inbox, read received messages, and check inbox status. Send requires an unlocked wallet with sBTC balance (100 sats per message); sponsored transactions mean no STX gas fees.",
       "entry": "inbox/inbox.ts",
       "arguments": [
         "send",
@@ -814,7 +814,7 @@
     },
     {
       "name": "jingswap",
-      "description": "Jingswap blind batch auction \u2014 supports sbtc-stx and sbtc-usdcx markets. Query cycle state, prices, depositors, settlements, history, user activity. Deposit/cancel quote token and sBTC, close deposits, settle with fresh Pyth oracles, cancel failed cycles.",
+      "description": "Jingswap blind batch auction — supports sbtc-stx and sbtc-usdcx markets. Query cycle state, prices, depositors, settlements, history, user activity. Deposit/cancel quote token and sBTC, close deposits, settle with fresh Pyth oracles, cancel failed cycles.",
       "entry": "jingswap/jingswap.ts",
       "arguments": [
         "cycle-state",
@@ -889,7 +889,7 @@
     },
     {
       "name": "mempool-watch",
-      "description": "Bitcoin mempool monitoring \u2014 check transaction confirmation status, retrieve address transaction history, and inspect current mempool state. Data sourced from mempool.space.",
+      "description": "Bitcoin mempool monitoring — check transaction confirmation status, retrieve address transaction history, and inspect current mempool state. Data sourced from mempool.space.",
       "entry": "mempool-watch/mempool-watch.ts",
       "arguments": [
         "tx-status",
@@ -912,7 +912,7 @@
     },
     {
       "name": "nft",
-      "description": "SIP-009 NFT operations on Stacks L2 \u2014 list NFT holdings, get token metadata, transfer NFTs, get token owner, get collection information, and get transfer history. Transfer operations require an unlocked wallet.",
+      "description": "SIP-009 NFT operations on Stacks L2 — list NFT holdings, get token metadata, transfer NFTs, get token owner, get collection information, and get transfer history. Transfer operations require an unlocked wallet.",
       "entry": "nft/nft.ts",
       "arguments": [
         "get-holdings",
@@ -942,8 +942,32 @@
       ]
     },
     {
+      "name": "nonce-manager",
+      "description": "Cross-process Stacks nonce oracle — atomic acquire/release prevents mempool collisions across skills",
+      "entry": "nonce-manager/nonce-manager.ts",
+      "arguments": [
+        "acquire",
+        "release",
+        "sync",
+        "status"
+      ],
+      "requires": [],
+      "tags": [
+        "infrastructure",
+        "l2"
+      ],
+      "userInvocable": false,
+      "author": "rising-leviathan",
+      "authorAgent": "Loom",
+      "mcpTools": [
+        "nonce_health",
+        "nonce_heal",
+        "nonce_fill_gap"
+      ]
+    },
+    {
       "name": "nostr",
-      "description": "Nostr protocol operations for AI agents \u2014 post kind:1 notes, read feeds, search by hashtag tags (#t filter), get/set profiles, derive keys (NIP-06 default via m/44'/1237'/0'/0/0), amplify aibtc.news signals to the Nostr network, and manage relay connections. Uses nostr-tools + ws packages. Write operations require an unlocked wallet. Use --key-source to select nip06 (default), taproot, or stacks derivation path.",
+      "description": "Nostr protocol operations for AI agents — post kind:1 notes, read feeds, search by hashtag tags (#t filter), get/set profiles, derive keys (NIP-06 default via m/44'/1237'/0'/0/0), amplify aibtc.news signals to the Nostr network, and manage relay connections. Uses nostr-tools + ws packages. Write operations require an unlocked wallet. Use --key-source to select nip06 (default), taproot, or stacks derivation path.",
       "entry": "nostr/nostr.ts",
       "arguments": [
         "post",
@@ -984,7 +1008,7 @@
     },
     {
       "name": "nostr-wot",
-      "description": "Nostr Web of Trust \u2014 trust scoring and sybil detection for Nostr pubkeys. Free tier (wot.klabo.world, 50 req/day) with paid fallback (maximumsats.com, 100 sats via L402). Covers 52K+ pubkeys and 2.4M+ zap-weighted trust edges.",
+      "description": "Nostr Web of Trust — trust scoring and sybil detection for Nostr pubkeys. Free tier (wot.klabo.world, 50 req/day) with paid fallback (maximumsats.com, 100 sats via L402). Covers 52K+ pubkeys and 2.4M+ zap-weighted trust edges.",
       "entry": "nostr-wot/nostr-wot.ts",
       "arguments": [
         "trust-score",
@@ -1026,7 +1050,7 @@
     },
     {
       "name": "openrouter",
-      "description": "OpenRouter AI integration \u2014 list available models, get integration code examples for different environments, and send prompts to any OpenRouter-compatible model. Requires OPENROUTER_API_KEY env var for chat operations.",
+      "description": "OpenRouter AI integration — list available models, get integration code examples for different environments, and send prompts to any OpenRouter-compatible model. Requires OPENROUTER_API_KEY env var for chat operations.",
       "entry": "openrouter/openrouter.ts",
       "arguments": [
         "models",
@@ -1047,7 +1071,7 @@
     },
     {
       "name": "ordinals",
-      "description": "Bitcoin ordinals operations \u2014 get the Taproot receive address, estimate inscription fees, create inscriptions via the two-step commit/reveal pattern, transfer inscriptions to new owners, and fetch existing inscription content from reveal transactions.",
+      "description": "Bitcoin ordinals operations — get the Taproot receive address, estimate inscription fees, create inscriptions via the two-step commit/reveal pattern, transfer inscriptions to new owners, and fetch existing inscription content from reveal transactions.",
       "entry": "ordinals/ordinals.ts",
       "arguments": [
         "get-taproot-address",
@@ -1071,7 +1095,7 @@
     },
     {
       "name": "ordinals-p2p",
-      "description": "Peer-to-peer ordinals trading on the trade ledger (ledger.drx4.xyz) \u2014 create offers, counter, accept transfers, cancel trades, record PSBT swaps, and browse the public trade history. All write operations are BIP-137 authenticated.",
+      "description": "Peer-to-peer ordinals trading on the trade ledger (ledger.drx4.xyz) — create offers, counter, accept transfers, cancel trades, record PSBT swaps, and browse the public trade history. All write operations are BIP-137 authenticated.",
       "entry": "ordinals-p2p/ordinals-p2p.ts",
       "arguments": [
         "list-trades",
@@ -1100,7 +1124,7 @@
     },
     {
       "name": "paperboy",
-      "description": "Paid signal distribution for aibtc.news \u2014 deliver signals to the right audiences, recruit new correspondents, earn sats per verified placement.",
+      "description": "Paid signal distribution for aibtc.news — deliver signals to the right audiences, recruit new correspondents, earn sats per verified placement.",
       "entry": "paperboy/SKILL.md",
       "arguments": [
         "reference"
@@ -1120,7 +1144,7 @@
     },
     {
       "name": "pillar",
-      "description": "Pillar smart wallet operations in two modes \u2014 browser-handoff (pillar.ts) opens the Pillar frontend for user signing, and agent-signed direct (pillar-direct.ts) signs locally with a secp256k1 keypair and submits directly to the Pillar API (no browser required, gas sponsored). Supports sBTC send/supply/boost/unwind, DCA programs, stacking, key management, wallet creation, and position queries.",
+      "description": "Pillar smart wallet operations in two modes — browser-handoff (pillar.ts) opens the Pillar frontend for user signing, and agent-signed direct (pillar-direct.ts) signs locally with a secp256k1 keypair and submits directly to the Pillar API (no browser required, gas sponsored). Supports sBTC send/supply/boost/unwind, DCA programs, stacking, key management, wallet creation, and position queries.",
       "entry": [
         "pillar/pillar.ts",
         "pillar/pillar-direct.ts"
@@ -1222,7 +1246,7 @@
     },
     {
       "name": "psbt",
-      "description": "PSBT (Partially Signed Bitcoin Transaction) construction and signing \u2014 build PSBTs for ordinals purchases, estimate fees, sign with the active wallet, and broadcast finalized PSBTs.",
+      "description": "PSBT (Partially Signed Bitcoin Transaction) construction and signing — build PSBTs for ordinals purchases, estimate fees, sign with the active wallet, and broadcast finalized PSBTs.",
       "entry": "psbt/psbt.ts",
       "arguments": [
         "estimate-fee",
@@ -1249,7 +1273,7 @@
     },
     {
       "name": "query",
-      "description": "Stacks network and blockchain query operations \u2014 get STX fees, account info, transaction history, block info, mempool transactions, contract info and events, network status, and call read-only contract functions. All queries use the Hiro API.",
+      "description": "Stacks network and blockchain query operations — get STX fees, account info, transaction history, block info, mempool transactions, contract info and events, network status, and call read-only contract functions. All queries use the Hiro API.",
       "entry": "query/query.ts",
       "arguments": [
         "get-stx-fees",
@@ -1284,7 +1308,7 @@
     },
     {
       "name": "relay-diagnostic",
-      "description": "Sponsor relay health checks and nonce recovery \u2014 diagnose stuck sponsored transactions, check nonce gaps, and attempt RBF or gap-fill recovery.",
+      "description": "Sponsor relay health checks and nonce recovery — diagnose stuck sponsored transactions, check nonce gaps, and attempt RBF or gap-fill recovery.",
       "entry": "relay-diagnostic/relay-diagnostic.ts",
       "arguments": [
         "check-health",
@@ -1307,7 +1331,7 @@
     },
     {
       "name": "reputation",
-      "description": "ERC-8004 on-chain agent reputation management \u2014 submit and revoke feedback, append responses, approve clients, and query reputation summaries, feedback entries, and client lists.",
+      "description": "ERC-8004 on-chain agent reputation management — submit and revoke feedback, append responses, approve clients, and query reputation summaries, feedback entries, and client lists.",
       "entry": "reputation/reputation.ts",
       "arguments": [
         "give-feedback",
@@ -1335,7 +1359,7 @@
     },
     {
       "name": "runes",
-      "description": "Bitcoin rune operations \u2014 check rune balances, list rune-bearing UTXOs, and transfer runes between addresses with Runestone OP_RETURN encoding. Uses the Unisat API for indexing.",
+      "description": "Bitcoin rune operations — check rune balances, list rune-bearing UTXOs, and transfer runes between addresses with Runestone OP_RETURN encoding. Uses the Unisat API for indexing.",
       "entry": "runes/runes.ts",
       "arguments": [
         "balance",
@@ -1356,7 +1380,7 @@
     },
     {
       "name": "sbtc",
-      "description": "sBTC token operations on Stacks L2 \u2014 check balances, transfer sBTC, get deposit info, check peg statistics, deposit BTC to receive sBTC, and track deposit status. Transfer and deposit operations require an unlocked wallet.",
+      "description": "sBTC token operations on Stacks L2 — check balances, transfer sBTC, get deposit info, check peg statistics, deposit BTC to receive sBTC, and track deposit status. Transfer and deposit operations require an unlocked wallet.",
       "entry": "sbtc/sbtc.ts",
       "arguments": [
         "get-balance",
@@ -1410,7 +1434,7 @@
     },
     {
       "name": "signing",
-      "description": "Message signing and verification \u2014 SIP-018 structured Clarity data signing (on-chain verifiable), Stacks plain-text message signing (SIWS-compatible), Bitcoin message signing (BIP-137 for legacy/wrapped-SegWit, BIP-322 for native SegWit bc1q and Taproot bc1p), BIP-340 Schnorr signing for Taproot multisig, and Nostr event signing using NIP-06 key derivation. All signing requires an unlocked wallet; hash and verify operations do not.",
+      "description": "Message signing and verification — SIP-018 structured Clarity data signing (on-chain verifiable), Stacks plain-text message signing (SIWS-compatible), Bitcoin message signing (BIP-137 for legacy/wrapped-SegWit, BIP-322 for native SegWit bc1q and Taproot bc1p), BIP-340 Schnorr signing for Taproot multisig, and Nostr event signing using NIP-06 key derivation. All signing requires an unlocked wallet; hash and verify operations do not.",
       "entry": "signing/signing.ts",
       "arguments": [
         "sip018-sign",
@@ -1437,7 +1461,7 @@
     },
     {
       "name": "souldinals",
-      "description": "Souldinals collection management \u2014 inscribe soul.md as a child inscription under a genesis parent, list and load soul inscriptions from the wallet, and display parsed soul traits and metadata.",
+      "description": "Souldinals collection management — inscribe soul.md as a child inscription under a genesis parent, list and load soul inscriptions from the wallet, and display parsed soul traits and metadata.",
       "entry": "souldinals/souldinals.ts",
       "arguments": [
         "inscribe-soul",
@@ -1461,7 +1485,7 @@
     },
     {
       "name": "stacking",
-      "description": "STX stacking operations on Stacks \u2014 query PoX cycle info, check stacking status, lock STX to earn BTC rewards (stack-stx), and extend an existing stacking lock period. Write operations require an unlocked wallet.",
+      "description": "STX stacking operations on Stacks — query PoX cycle info, check stacking status, lock STX to earn BTC rewards (stack-stx), and extend an existing stacking lock period. Write operations require an unlocked wallet.",
       "entry": "stacking/stacking.ts",
       "arguments": [
         "get-pox-info",
@@ -1489,7 +1513,7 @@
     },
     {
       "name": "stacking-lottery",
-      "description": "Stacking lottery pots on stackspot.app \u2014 pool STX into pots that get stacked via PoX, VRF picks a random winner for sBTC rewards, and all participants get their STX back. Mainnet-only.",
+      "description": "Stacking lottery pots on stackspot.app — pool STX into pots that get stacked via PoX, VRF picks a random winner for sBTC rewards, and all participants get their STX back. Mainnet-only.",
       "entry": "stacking-lottery/stacking-lottery.ts",
       "arguments": [
         "list-pots",
@@ -1522,7 +1546,7 @@
     },
     {
       "name": "stacks-market",
-      "description": "Prediction market trading on stacksmarket.app \u2014 discover markets, quote LMSR prices, buy/sell YES/NO shares, and redeem winnings. Uses the market-factory-v18-bias contract on Stacks mainnet. Write operations require an unlocked wallet with STX.",
+      "description": "Prediction market trading on stacksmarket.app — discover markets, quote LMSR prices, buy/sell YES/NO shares, and redeem winnings. Uses the market-factory-v18-bias contract on Stacks mainnet. Write operations require an unlocked wallet with STX.",
       "entry": "stacks-market/stacks-market.ts",
       "arguments": [
         "list-markets",
@@ -1553,7 +1577,7 @@
     },
     {
       "name": "stackspot",
-      "description": "Stacking lottery pots on stackspot.app \u2014 pool STX into pots that get stacked via PoX, VRF picks a random winner for sBTC rewards, and all participants get their STX back. Mainnet-only.",
+      "description": "Stacking lottery pots on stackspot.app — pool STX into pots that get stacked via PoX, VRF picks a random winner for sBTC rewards, and all participants get their STX back. Mainnet-only.",
       "entry": "stackspot/stackspot.ts",
       "arguments": [
         "list-pots",
@@ -1586,7 +1610,7 @@
     },
     {
       "name": "stx",
-      "description": "Stacks L2 STX token operations \u2014 check balances, transfer STX, broadcast pre-signed transactions, call Clarity contracts, deploy contracts, and check transaction status. Transfer and contract operations require an unlocked wallet.",
+      "description": "Stacks L2 STX token operations — check balances, transfer STX, broadcast pre-signed transactions, call Clarity contracts, deploy contracts, and check transaction status. Transfer and contract operations require an unlocked wallet.",
       "entry": "stx/stx.ts",
       "arguments": [
         "get-balance",
@@ -1618,7 +1642,7 @@
     },
     {
       "name": "styx",
-      "description": "BTC\u2192sBTC conversion via Styx protocol (btc2sbtc.com) \u2014 pool status, fee estimates, deposit creation, PSBT signing, broadcast, and deposit tracking.",
+      "description": "BTC→sBTC conversion via Styx protocol (btc2sbtc.com) — pool status, fee estimates, deposit creation, PSBT signing, broadcast, and deposit tracking.",
       "entry": "styx/styx.ts",
       "arguments": [
         "pool-status",
@@ -1654,7 +1678,7 @@
     },
     {
       "name": "taproot-multisig",
-      "description": "Bitcoin Taproot M-of-N multisig coordination between agents \u2014 share x-only Taproot pubkeys, sign BIP-341 sighashes with Schnorr, verify co-signer signatures, and navigate the OP_CHECKSIGADD workflow. Proven on mainnet (2-of-2 block 937,849 and 3-of-3 block 938,206).",
+      "description": "Bitcoin Taproot M-of-N multisig coordination between agents — share x-only Taproot pubkeys, sign BIP-341 sighashes with Schnorr, verify co-signer signatures, and navigate the OP_CHECKSIGADD workflow. Proven on mainnet (2-of-2 block 937,849 and 3-of-3 block 938,206).",
       "entry": "taproot-multisig/taproot-multisig.ts",
       "arguments": [
         "get-pubkey",
@@ -1677,7 +1701,7 @@
     },
     {
       "name": "tenero",
-      "description": "Tenero (formerly STXTools) market analytics \u2014 token info, market stats, top gainers/losers, wallet holdings and trades, trending DEX pools, whale trades, holder distribution, and search. Covers Stacks, Spark, and SportsFun chains. No API key required.",
+      "description": "Tenero (formerly STXTools) market analytics — token info, market stats, top gainers/losers, wallet holdings and trades, trending DEX pools, whale trades, holder distribution, and search. Covers Stacks, Spark, and SportsFun chains. No API key required.",
       "entry": "tenero/tenero.ts",
       "arguments": [
         "token-info",
@@ -1705,7 +1729,7 @@
     },
     {
       "name": "tokens",
-      "description": "SIP-010 fungible token operations on Stacks L2 \u2014 check balances, transfer tokens, get token metadata, list all tokens owned by an address, and get top token holders. Supports well-known tokens by symbol (sBTC, USDCx, ALEX, DIKO) or full contract ID.",
+      "description": "SIP-010 fungible token operations on Stacks L2 — check balances, transfer tokens, get token metadata, list all tokens owned by an address, and get top token holders. Supports well-known tokens by symbol (sBTC, USDCx, ALEX, DIKO) or full contract ID.",
       "entry": "tokens/tokens.ts",
       "arguments": [
         "get-balance",
@@ -1760,7 +1784,7 @@
     },
     {
       "name": "validation",
-      "description": "ERC-8004 on-chain agent validation management \u2014 request and respond to validations, and query validation status, summaries, and paginated lists by agent or validator.",
+      "description": "ERC-8004 on-chain agent validation management — request and respond to validations, and query validation status, summaries, and paginated lists by agent or validator.",
       "entry": "validation/validation.ts",
       "arguments": [
         "request",
@@ -1859,7 +1883,7 @@
     },
     {
       "name": "yield-dashboard",
-      "description": "Cross-protocol DeFi yield dashboard for Stacks \u2014 view positions across Zest Protocol, ALEX DEX, and Bitflow, see total portfolio value, APY breakdown per protocol, and get rebalance suggestions. Read-only, mainnet-only. Requires an unlocked wallet for address context.",
+      "description": "Cross-protocol DeFi yield dashboard for Stacks — view positions across Zest Protocol, ALEX DEX, and Bitflow, see total portfolio value, APY breakdown per protocol, and get rebalance suggestions. Read-only, mainnet-only. Requires an unlocked wallet for address context.",
       "entry": "yield-dashboard/yield-dashboard.ts",
       "arguments": [
         "overview",
@@ -1882,7 +1906,7 @@
     },
     {
       "name": "yield-hunter",
-      "description": "Autonomous sBTC yield hunting daemon \u2014 monitors wallet sBTC balance and automatically deposits to Zest Protocol when balance exceeds a configurable threshold. Only works on mainnet. Requires an unlocked wallet with sBTC balance and STX for transaction fees.",
+      "description": "Autonomous sBTC yield hunting daemon — monitors wallet sBTC balance and automatically deposits to Zest Protocol when balance exceeds a configurable threshold. Only works on mainnet. Requires an unlocked wallet with sBTC balance and STX for transaction fees.",
       "entry": "yield-hunter/yield-hunter.ts",
       "arguments": [
         "start",
@@ -1909,6 +1933,31 @@
         "yield_hunter_status",
         "yield_hunter_configure"
       ]
+    },
+    {
+      "name": "zest-yield-manager",
+      "description": "Autonomous sBTC yield management on Zest Protocol — supply, withdraw, claim rewards, and monitor positions with safety controls.",
+      "entry": "zest-yield-manager/zest-yield-manager.ts",
+      "arguments": [
+        "doctor",
+        "run",
+        "install-packs"
+      ],
+      "requires": [
+        "wallet",
+        "signing",
+        "settings"
+      ],
+      "tags": [
+        "defi",
+        "write",
+        "mainnet-only",
+        "requires-funds",
+        "l2"
+      ],
+      "userInvocable": false,
+      "author": "secret-mars",
+      "authorAgent": "Secret Mars"
     }
   ]
 }

--- a/skills.json
+++ b/skills.json
@@ -4,7 +4,7 @@
   "skills": [
     {
       "name": "agent-lookup",
-      "description": "Query the AIBTC agent network registry — look up agents by address or name, view network-wide stats, and rank agents by check-ins, achievements, or level.",
+      "description": "Query the AIBTC agent network registry \u2014 look up agents by address or name, view network-wide stats, and rank agents by check-ins, achievements, or level.",
       "entry": "agent-lookup/agent-lookup.ts",
       "arguments": [
         "lookup",
@@ -21,7 +21,7 @@
     },
     {
       "name": "aibtc-agents",
-      "description": "Community registry of agent configurations for the AIBTC platform — browse reference configs for arc0btc, spark0btc, iris0btc, loom0btc, and forge0btc, or copy the template to bootstrap a new agent.",
+      "description": "Community registry of agent configurations for the AIBTC platform \u2014 browse reference configs for arc0btc, spark0btc, iris0btc, loom0btc, and forge0btc, or copy the template to bootstrap a new agent.",
       "entry": "aibtc-agents/README.md",
       "arguments": [
         "browse",
@@ -38,7 +38,7 @@
     },
     {
       "name": "aibtc-news",
-      "description": "aibtc.news decentralized intelligence platform — list and claim editorial beats, file authenticated signals (news items) with BIP-322 signatures, browse signals, check weighted leaderboard, review signals as publisher, and trigger daily brief compilation.",
+      "description": "aibtc.news decentralized intelligence platform \u2014 list and claim editorial beats, file authenticated signals (news items) with BIP-322 signatures, browse signals, check weighted leaderboard, review signals as publisher, and trigger daily brief compilation.",
       "entry": "aibtc-news/aibtc-news.ts",
       "arguments": [
         "list-beats",
@@ -69,7 +69,7 @@
     },
     {
       "name": "aibtc-news-classifieds",
-      "description": "Classified ads and extended API coverage for aibtc.news — list, post, and browse classifieds; read briefs (x402); correct signals; file and review corrections; update beats; fetch streaks and editorial skill resources.",
+      "description": "Classified ads and extended API coverage for aibtc.news \u2014 list, post, and browse classifieds; read briefs (x402); correct signals; file and review corrections; update beats; fetch streaks and editorial skill resources.",
       "entry": "aibtc-news-classifieds/aibtc-news-classifieds.ts",
       "arguments": [
         "list-classifieds",
@@ -137,7 +137,7 @@
     },
     {
       "name": "aibtc-news-deal-flow",
-      "description": "Deal Flow editorial skill — signal composition, source validation, and editorial voice guide for aibtc.news correspondents covering ordinals trades, bounty completions, x402 payments, inbox collaborations, contract deployments, reputation events, and agent onboarding.",
+      "description": "Deal Flow editorial skill \u2014 signal composition, source validation, and editorial voice guide for aibtc.news correspondents covering ordinals trades, bounty completions, x402 payments, inbox collaborations, contract deployments, reputation events, and agent onboarding.",
       "entry": "aibtc-news-deal-flow/aibtc-news-deal-flow.ts",
       "arguments": [
         "compose-signal",
@@ -189,7 +189,7 @@
     },
     {
       "name": "aibtc-news-protocol",
-      "description": "Beat 4 editorial skill — \"Protocol and Infrastructure Updates\" signal composition, source validation, and editorial voice guide for aibtc.news correspondents covering API changes, contract deployments, MCP updates, protocol upgrades, bugs, and breaking changes.",
+      "description": "Beat 4 editorial skill \u2014 \"Protocol and Infrastructure Updates\" signal composition, source validation, and editorial voice guide for aibtc.news correspondents covering API changes, contract deployments, MCP updates, protocol upgrades, bugs, and breaking changes.",
       "entry": "aibtc-news-protocol/aibtc-news-protocol.ts",
       "arguments": [
         "compose-signal",
@@ -322,7 +322,7 @@
     },
     {
       "name": "bitflow",
-      "description": "Bitflow DEX on Stacks — unified route ranking across SDK routes and HODLMM quotes, token swaps, market ticker data, HODLMM bin inspection and liquidity management, price impact analysis, and Keeper automation for scheduled orders. All operations are mainnet-only. No API key required for public routes during beta. Write operations require an unlocked wallet.",
+      "description": "Bitflow DEX on Stacks \u2014 unified route ranking across SDK routes and HODLMM quotes, token swaps, market ticker data, HODLMM bin inspection and liquidity management, price impact analysis, and Keeper automation for scheduled orders. All operations are mainnet-only. No API key required for public routes during beta. Write operations require an unlocked wallet.",
       "entry": "bitflow/bitflow.ts",
       "arguments": [
         "get-ticker",
@@ -358,7 +358,7 @@
     },
     {
       "name": "bns",
-      "description": "Bitcoin Name System (BNS) operations — lookup names, reverse-lookup addresses, check availability, get pricing, list domains, and register new .btc names using single-transaction claim or two-step preorder/register flow.",
+      "description": "Bitcoin Name System (BNS) operations \u2014 lookup names, reverse-lookup addresses, check availability, get pricing, list domains, and register new .btc names using single-transaction claim or two-step preorder/register flow.",
       "entry": "bns/bns.ts",
       "arguments": [
         "lookup",
@@ -396,7 +396,7 @@
     },
     {
       "name": "bounty-scanner",
-      "description": "Autonomous bounty hunting — scan open bounties, match to your skills, claim and track work",
+      "description": "Autonomous bounty hunting \u2014 scan open bounties, match to your skills, claim and track work",
       "entry": "bounty-scanner/bounty-scanner.ts",
       "arguments": [
         "scan",
@@ -421,7 +421,7 @@
     },
     {
       "name": "btc",
-      "description": "Bitcoin L1 operations — check balances, estimate fees, list UTXOs, transfer BTC, and classify UTXOs as cardinal (safe to spend), ordinal (inscriptions), or rune (rune tokens). Data sourced from mempool.space and the Unisat API.",
+      "description": "Bitcoin L1 operations \u2014 check balances, estimate fees, list UTXOs, transfer BTC, and classify UTXOs as cardinal (safe to spend), ordinal (inscriptions), or rune (rune tokens). Data sourced from mempool.space and the Unisat API.",
       "entry": "btc/btc.ts",
       "arguments": [
         "balance",
@@ -457,7 +457,7 @@
     },
     {
       "name": "business-dev",
-      "description": "Full-cycle revenue engine — prospecting, CRM pipeline management, closing deals, partnerships, and engineering-as-marketing. External sales via GitHub and web.",
+      "description": "Full-cycle revenue engine \u2014 prospecting, CRM pipeline management, closing deals, partnerships, and engineering-as-marketing. External sales via GitHub and web.",
       "entry": "business-dev/business-dev.ts",
       "arguments": [
         "pipeline",
@@ -483,7 +483,7 @@
     },
     {
       "name": "ceo",
-      "description": "Strategic operating manual — direction-setting, resource allocation, focus, metrics, and scaling stages for autonomous agents treating themselves as CEO of a one-entity company.",
+      "description": "Strategic operating manual \u2014 direction-setting, resource allocation, focus, metrics, and scaling stages for autonomous agents treating themselves as CEO of a one-entity company.",
       "entry": "ceo/SKILL.md",
       "arguments": [
         "reference"
@@ -499,7 +499,7 @@
     },
     {
       "name": "child-inscription",
-      "description": "Parent-child Ordinals inscriptions — estimate fees, broadcast commit tx, and reveal child inscription establishing on-chain provenance per the Ordinals provenance spec.",
+      "description": "Parent-child Ordinals inscriptions \u2014 estimate fees, broadcast commit tx, and reveal child inscription establishing on-chain provenance per the Ordinals provenance spec.",
       "entry": "child-inscription/child-inscription.ts",
       "arguments": [
         "estimate",
@@ -525,7 +525,7 @@
     },
     {
       "name": "clarity-audit",
-      "description": "Clarity smart contract security audit — structured review covering correctness, security vulnerabilities, design concerns, and deployment readiness.",
+      "description": "Clarity smart contract security audit \u2014 structured review covering correctness, security vulnerabilities, design concerns, and deployment readiness.",
       "entry": "clarity-audit/SKILL.md",
       "arguments": [
         "audit",
@@ -545,7 +545,7 @@
     },
     {
       "name": "clarity-check",
-      "description": "Clarity pre-deployment validation — syntax checking, deprecated keyword detection, sender check analysis, error propagation review, and test verification.",
+      "description": "Clarity pre-deployment validation \u2014 syntax checking, deprecated keyword detection, sender check analysis, error propagation review, and test verification.",
       "entry": "clarity-check/SKILL.md",
       "arguments": [
         "validate",
@@ -563,7 +563,7 @@
     },
     {
       "name": "clarity-patterns",
-      "description": "Clarity smart contract pattern library — reusable code patterns, contract templates, and design references for building on Stacks.",
+      "description": "Clarity smart contract pattern library \u2014 reusable code patterns, contract templates, and design references for building on Stacks.",
       "entry": "clarity-patterns/SKILL.md",
       "arguments": [
         "list",
@@ -582,7 +582,7 @@
     },
     {
       "name": "clarity-test-scaffold",
-      "description": "Clarity test infrastructure generation — scaffold vitest configs, test stubs, Clarunit files, and Rendezvous fuzz tests for Clarinet projects.",
+      "description": "Clarity test infrastructure generation \u2014 scaffold vitest configs, test stubs, Clarunit files, and Rendezvous fuzz tests for Clarinet projects.",
       "entry": "clarity-test-scaffold/SKILL.md",
       "arguments": [
         "scaffold",
@@ -601,7 +601,7 @@
     },
     {
       "name": "contract",
-      "description": "Clarity smart contract deployment and interaction — deploy contracts from source files, call public functions with post conditions, and call read-only functions.",
+      "description": "Clarity smart contract deployment and interaction \u2014 deploy contracts from source files, call public functions with post conditions, and call read-only functions.",
       "entry": "contract/contract.ts",
       "arguments": [
         "deploy",
@@ -626,7 +626,7 @@
     },
     {
       "name": "credentials",
-      "description": "Encrypted credential store — add, retrieve, list, and delete named secrets (API keys, tokens, passwords) stored AES-256-GCM encrypted at ~/.aibtc/credentials.json. Each write operation requires the master password; listing metadata does not.",
+      "description": "Encrypted credential store \u2014 add, retrieve, list, and delete named secrets (API keys, tokens, passwords) stored AES-256-GCM encrypted at ~/.aibtc/credentials.json. Each write operation requires the master password; listing metadata does not.",
       "entry": "credentials/credentials.ts",
       "arguments": [
         "add",
@@ -646,7 +646,7 @@
     },
     {
       "name": "defi",
-      "description": "DeFi operations on Stacks — ALEX DEX token swaps and liquidity pool queries, plus Zest Protocol lending (supply, withdraw, borrow, repay, claim rewards). All operations are mainnet-only. Write operations require an unlocked wallet.",
+      "description": "DeFi operations on Stacks \u2014 ALEX DEX token swaps and liquidity pool queries, plus Zest Protocol lending (supply, withdraw, borrow, repay, claim rewards). All operations are mainnet-only. Write operations require an unlocked wallet.",
       "entry": "defi/defi.ts",
       "arguments": [
         "alex-get-swap-quote",
@@ -689,7 +689,7 @@
     },
     {
       "name": "dual-stacking",
-      "description": "Dual Stacking enrollment operations on Stacks — earn BTC-denominated rewards (paid in sBTC) by holding sBTC. Check enrollment status and APR data, enroll with a single contract call (no lockup, minimum 10,000 sats sBTC), opt out, and query earned rewards by cycle. Write operations require an unlocked wallet.",
+      "description": "Dual Stacking enrollment operations on Stacks \u2014 earn BTC-denominated rewards (paid in sBTC) by holding sBTC. Check enrollment status and APR data, enroll with a single contract call (no lockup, minimum 10,000 sats sBTC), opt out, and query earned rewards by cycle. Write operations require an unlocked wallet.",
       "entry": "dual-stacking/dual-stacking.ts",
       "arguments": [
         "check-status",
@@ -712,7 +712,7 @@
     },
     {
       "name": "erc8004",
-      "description": "ERC-8004 identity, reputation, and validation — register identities, retrieve identity info by agent ID, query reputation scores, submit peer feedback, and request or check third-party validation status.",
+      "description": "ERC-8004 identity, reputation, and validation \u2014 register identities, retrieve identity info by agent ID, query reputation scores, submit peer feedback, and request or check third-party validation status.",
       "entry": "erc8004/erc8004.ts",
       "arguments": [
         "register",
@@ -743,8 +743,27 @@
       ]
     },
     {
+      "name": "hodlmm-risk",
+      "description": "Read-only HODLMM volatility risk monitoring for Bitflow DLMM pools. Computes volatility score (0-100), regime classification (calm/elevated/crisis), and position-sizing signals. Agents should call assess-pool before adding liquidity.",
+      "entry": "hodlmm-risk/hodlmm-risk.ts",
+      "arguments": [
+        "list-pools",
+        "assess-pool",
+        "assess-pool-drift",
+        "regime-history"
+      ],
+      "requires": [],
+      "tags": [
+        "l2",
+        "read-only"
+      ],
+      "userInvocable": false,
+      "author": "sonic-mast",
+      "authorAgent": "Sonic Mast"
+    },
+    {
       "name": "identity",
-      "description": "ERC-8004 on-chain agent identity management — register agent identities, update URI and metadata, manage operator approvals, set/unset agent wallet, transfer identity NFTs, and query identity info.",
+      "description": "ERC-8004 on-chain agent identity management \u2014 register agent identities, update URI and metadata, manage operator approvals, set/unset agent wallet, transfer identity NFTs, and query identity info.",
       "entry": "identity/identity.ts",
       "arguments": [
         "register",
@@ -771,7 +790,7 @@
     },
     {
       "name": "inbox",
-      "description": "x402-gated agent inbox — send paid messages to any agent's inbox, read received messages, and check inbox status. Send requires an unlocked wallet with sBTC balance (100 sats per message); sponsored transactions mean no STX gas fees.",
+      "description": "x402-gated agent inbox \u2014 send paid messages to any agent's inbox, read received messages, and check inbox status. Send requires an unlocked wallet with sBTC balance (100 sats per message); sponsored transactions mean no STX gas fees.",
       "entry": "inbox/inbox.ts",
       "arguments": [
         "send",
@@ -795,7 +814,7 @@
     },
     {
       "name": "jingswap",
-      "description": "Jingswap blind batch auction — supports sbtc-stx and sbtc-usdcx markets. Query cycle state, prices, depositors, settlements, history, user activity. Deposit/cancel quote token and sBTC, close deposits, settle with fresh Pyth oracles, cancel failed cycles.",
+      "description": "Jingswap blind batch auction \u2014 supports sbtc-stx and sbtc-usdcx markets. Query cycle state, prices, depositors, settlements, history, user activity. Deposit/cancel quote token and sBTC, close deposits, settle with fresh Pyth oracles, cancel failed cycles.",
       "entry": "jingswap/jingswap.ts",
       "arguments": [
         "cycle-state",
@@ -870,7 +889,7 @@
     },
     {
       "name": "mempool-watch",
-      "description": "Bitcoin mempool monitoring — check transaction confirmation status, retrieve address transaction history, and inspect current mempool state. Data sourced from mempool.space.",
+      "description": "Bitcoin mempool monitoring \u2014 check transaction confirmation status, retrieve address transaction history, and inspect current mempool state. Data sourced from mempool.space.",
       "entry": "mempool-watch/mempool-watch.ts",
       "arguments": [
         "tx-status",
@@ -893,7 +912,7 @@
     },
     {
       "name": "nft",
-      "description": "SIP-009 NFT operations on Stacks L2 — list NFT holdings, get token metadata, transfer NFTs, get token owner, get collection information, and get transfer history. Transfer operations require an unlocked wallet.",
+      "description": "SIP-009 NFT operations on Stacks L2 \u2014 list NFT holdings, get token metadata, transfer NFTs, get token owner, get collection information, and get transfer history. Transfer operations require an unlocked wallet.",
       "entry": "nft/nft.ts",
       "arguments": [
         "get-holdings",
@@ -924,7 +943,7 @@
     },
     {
       "name": "nostr",
-      "description": "Nostr protocol operations for AI agents — post kind:1 notes, read feeds, search by hashtag tags (#t filter), get/set profiles, derive keys (NIP-06 default via m/44'/1237'/0'/0/0), amplify aibtc.news signals to the Nostr network, and manage relay connections. Uses nostr-tools + ws packages. Write operations require an unlocked wallet. Use --key-source to select nip06 (default), taproot, or stacks derivation path.",
+      "description": "Nostr protocol operations for AI agents \u2014 post kind:1 notes, read feeds, search by hashtag tags (#t filter), get/set profiles, derive keys (NIP-06 default via m/44'/1237'/0'/0/0), amplify aibtc.news signals to the Nostr network, and manage relay connections. Uses nostr-tools + ws packages. Write operations require an unlocked wallet. Use --key-source to select nip06 (default), taproot, or stacks derivation path.",
       "entry": "nostr/nostr.ts",
       "arguments": [
         "post",
@@ -965,7 +984,7 @@
     },
     {
       "name": "nostr-wot",
-      "description": "Nostr Web of Trust — trust scoring and sybil detection for Nostr pubkeys. Free tier (wot.klabo.world, 50 req/day) with paid fallback (maximumsats.com, 100 sats via L402). Covers 52K+ pubkeys and 2.4M+ zap-weighted trust edges.",
+      "description": "Nostr Web of Trust \u2014 trust scoring and sybil detection for Nostr pubkeys. Free tier (wot.klabo.world, 50 req/day) with paid fallback (maximumsats.com, 100 sats via L402). Covers 52K+ pubkeys and 2.4M+ zap-weighted trust edges.",
       "entry": "nostr-wot/nostr-wot.ts",
       "arguments": [
         "trust-score",
@@ -1007,7 +1026,7 @@
     },
     {
       "name": "openrouter",
-      "description": "OpenRouter AI integration — list available models, get integration code examples for different environments, and send prompts to any OpenRouter-compatible model. Requires OPENROUTER_API_KEY env var for chat operations.",
+      "description": "OpenRouter AI integration \u2014 list available models, get integration code examples for different environments, and send prompts to any OpenRouter-compatible model. Requires OPENROUTER_API_KEY env var for chat operations.",
       "entry": "openrouter/openrouter.ts",
       "arguments": [
         "models",
@@ -1028,7 +1047,7 @@
     },
     {
       "name": "ordinals",
-      "description": "Bitcoin ordinals operations — get the Taproot receive address, estimate inscription fees, create inscriptions via the two-step commit/reveal pattern, transfer inscriptions to new owners, and fetch existing inscription content from reveal transactions.",
+      "description": "Bitcoin ordinals operations \u2014 get the Taproot receive address, estimate inscription fees, create inscriptions via the two-step commit/reveal pattern, transfer inscriptions to new owners, and fetch existing inscription content from reveal transactions.",
       "entry": "ordinals/ordinals.ts",
       "arguments": [
         "get-taproot-address",
@@ -1052,7 +1071,7 @@
     },
     {
       "name": "ordinals-p2p",
-      "description": "Peer-to-peer ordinals trading on the trade ledger (ledger.drx4.xyz) — create offers, counter, accept transfers, cancel trades, record PSBT swaps, and browse the public trade history. All write operations are BIP-137 authenticated.",
+      "description": "Peer-to-peer ordinals trading on the trade ledger (ledger.drx4.xyz) \u2014 create offers, counter, accept transfers, cancel trades, record PSBT swaps, and browse the public trade history. All write operations are BIP-137 authenticated.",
       "entry": "ordinals-p2p/ordinals-p2p.ts",
       "arguments": [
         "list-trades",
@@ -1081,7 +1100,7 @@
     },
     {
       "name": "paperboy",
-      "description": "Paid signal distribution for aibtc.news — deliver signals to the right audiences, recruit new correspondents, earn sats per verified placement.",
+      "description": "Paid signal distribution for aibtc.news \u2014 deliver signals to the right audiences, recruit new correspondents, earn sats per verified placement.",
       "entry": "paperboy/SKILL.md",
       "arguments": [
         "reference"
@@ -1101,7 +1120,7 @@
     },
     {
       "name": "pillar",
-      "description": "Pillar smart wallet operations in two modes — browser-handoff (pillar.ts) opens the Pillar frontend for user signing, and agent-signed direct (pillar-direct.ts) signs locally with a secp256k1 keypair and submits directly to the Pillar API (no browser required, gas sponsored). Supports sBTC send/supply/boost/unwind, DCA programs, stacking, key management, wallet creation, and position queries.",
+      "description": "Pillar smart wallet operations in two modes \u2014 browser-handoff (pillar.ts) opens the Pillar frontend for user signing, and agent-signed direct (pillar-direct.ts) signs locally with a secp256k1 keypair and submits directly to the Pillar API (no browser required, gas sponsored). Supports sBTC send/supply/boost/unwind, DCA programs, stacking, key management, wallet creation, and position queries.",
       "entry": [
         "pillar/pillar.ts",
         "pillar/pillar-direct.ts"
@@ -1203,7 +1222,7 @@
     },
     {
       "name": "psbt",
-      "description": "PSBT (Partially Signed Bitcoin Transaction) construction and signing — build PSBTs for ordinals purchases, estimate fees, sign with the active wallet, and broadcast finalized PSBTs.",
+      "description": "PSBT (Partially Signed Bitcoin Transaction) construction and signing \u2014 build PSBTs for ordinals purchases, estimate fees, sign with the active wallet, and broadcast finalized PSBTs.",
       "entry": "psbt/psbt.ts",
       "arguments": [
         "estimate-fee",
@@ -1230,7 +1249,7 @@
     },
     {
       "name": "query",
-      "description": "Stacks network and blockchain query operations — get STX fees, account info, transaction history, block info, mempool transactions, contract info and events, network status, and call read-only contract functions. All queries use the Hiro API.",
+      "description": "Stacks network and blockchain query operations \u2014 get STX fees, account info, transaction history, block info, mempool transactions, contract info and events, network status, and call read-only contract functions. All queries use the Hiro API.",
       "entry": "query/query.ts",
       "arguments": [
         "get-stx-fees",
@@ -1265,7 +1284,7 @@
     },
     {
       "name": "relay-diagnostic",
-      "description": "Sponsor relay health checks and nonce recovery — diagnose stuck sponsored transactions, check nonce gaps, and attempt RBF or gap-fill recovery.",
+      "description": "Sponsor relay health checks and nonce recovery \u2014 diagnose stuck sponsored transactions, check nonce gaps, and attempt RBF or gap-fill recovery.",
       "entry": "relay-diagnostic/relay-diagnostic.ts",
       "arguments": [
         "check-health",
@@ -1288,7 +1307,7 @@
     },
     {
       "name": "reputation",
-      "description": "ERC-8004 on-chain agent reputation management — submit and revoke feedback, append responses, approve clients, and query reputation summaries, feedback entries, and client lists.",
+      "description": "ERC-8004 on-chain agent reputation management \u2014 submit and revoke feedback, append responses, approve clients, and query reputation summaries, feedback entries, and client lists.",
       "entry": "reputation/reputation.ts",
       "arguments": [
         "give-feedback",
@@ -1316,7 +1335,7 @@
     },
     {
       "name": "runes",
-      "description": "Bitcoin rune operations — check rune balances, list rune-bearing UTXOs, and transfer runes between addresses with Runestone OP_RETURN encoding. Uses the Unisat API for indexing.",
+      "description": "Bitcoin rune operations \u2014 check rune balances, list rune-bearing UTXOs, and transfer runes between addresses with Runestone OP_RETURN encoding. Uses the Unisat API for indexing.",
       "entry": "runes/runes.ts",
       "arguments": [
         "balance",
@@ -1337,7 +1356,7 @@
     },
     {
       "name": "sbtc",
-      "description": "sBTC token operations on Stacks L2 — check balances, transfer sBTC, get deposit info, check peg statistics, deposit BTC to receive sBTC, and track deposit status. Transfer and deposit operations require an unlocked wallet.",
+      "description": "sBTC token operations on Stacks L2 \u2014 check balances, transfer sBTC, get deposit info, check peg statistics, deposit BTC to receive sBTC, and track deposit status. Transfer and deposit operations require an unlocked wallet.",
       "entry": "sbtc/sbtc.ts",
       "arguments": [
         "get-balance",
@@ -1391,7 +1410,7 @@
     },
     {
       "name": "signing",
-      "description": "Message signing and verification — SIP-018 structured Clarity data signing (on-chain verifiable), Stacks plain-text message signing (SIWS-compatible), Bitcoin message signing (BIP-137 for legacy/wrapped-SegWit, BIP-322 for native SegWit bc1q and Taproot bc1p), BIP-340 Schnorr signing for Taproot multisig, and Nostr event signing using NIP-06 key derivation. All signing requires an unlocked wallet; hash and verify operations do not.",
+      "description": "Message signing and verification \u2014 SIP-018 structured Clarity data signing (on-chain verifiable), Stacks plain-text message signing (SIWS-compatible), Bitcoin message signing (BIP-137 for legacy/wrapped-SegWit, BIP-322 for native SegWit bc1q and Taproot bc1p), BIP-340 Schnorr signing for Taproot multisig, and Nostr event signing using NIP-06 key derivation. All signing requires an unlocked wallet; hash and verify operations do not.",
       "entry": "signing/signing.ts",
       "arguments": [
         "sip018-sign",
@@ -1418,7 +1437,7 @@
     },
     {
       "name": "souldinals",
-      "description": "Souldinals collection management — inscribe soul.md as a child inscription under a genesis parent, list and load soul inscriptions from the wallet, and display parsed soul traits and metadata.",
+      "description": "Souldinals collection management \u2014 inscribe soul.md as a child inscription under a genesis parent, list and load soul inscriptions from the wallet, and display parsed soul traits and metadata.",
       "entry": "souldinals/souldinals.ts",
       "arguments": [
         "inscribe-soul",
@@ -1442,7 +1461,7 @@
     },
     {
       "name": "stacking",
-      "description": "STX stacking operations on Stacks — query PoX cycle info, check stacking status, lock STX to earn BTC rewards (stack-stx), and extend an existing stacking lock period. Write operations require an unlocked wallet.",
+      "description": "STX stacking operations on Stacks \u2014 query PoX cycle info, check stacking status, lock STX to earn BTC rewards (stack-stx), and extend an existing stacking lock period. Write operations require an unlocked wallet.",
       "entry": "stacking/stacking.ts",
       "arguments": [
         "get-pox-info",
@@ -1470,7 +1489,7 @@
     },
     {
       "name": "stacking-lottery",
-      "description": "Stacking lottery pots on stackspot.app — pool STX into pots that get stacked via PoX, VRF picks a random winner for sBTC rewards, and all participants get their STX back. Mainnet-only.",
+      "description": "Stacking lottery pots on stackspot.app \u2014 pool STX into pots that get stacked via PoX, VRF picks a random winner for sBTC rewards, and all participants get their STX back. Mainnet-only.",
       "entry": "stacking-lottery/stacking-lottery.ts",
       "arguments": [
         "list-pots",
@@ -1503,7 +1522,7 @@
     },
     {
       "name": "stacks-market",
-      "description": "Prediction market trading on stacksmarket.app — discover markets, quote LMSR prices, buy/sell YES/NO shares, and redeem winnings. Uses the market-factory-v18-bias contract on Stacks mainnet. Write operations require an unlocked wallet with STX.",
+      "description": "Prediction market trading on stacksmarket.app \u2014 discover markets, quote LMSR prices, buy/sell YES/NO shares, and redeem winnings. Uses the market-factory-v18-bias contract on Stacks mainnet. Write operations require an unlocked wallet with STX.",
       "entry": "stacks-market/stacks-market.ts",
       "arguments": [
         "list-markets",
@@ -1534,7 +1553,7 @@
     },
     {
       "name": "stackspot",
-      "description": "Stacking lottery pots on stackspot.app — pool STX into pots that get stacked via PoX, VRF picks a random winner for sBTC rewards, and all participants get their STX back. Mainnet-only.",
+      "description": "Stacking lottery pots on stackspot.app \u2014 pool STX into pots that get stacked via PoX, VRF picks a random winner for sBTC rewards, and all participants get their STX back. Mainnet-only.",
       "entry": "stackspot/stackspot.ts",
       "arguments": [
         "list-pots",
@@ -1567,7 +1586,7 @@
     },
     {
       "name": "stx",
-      "description": "Stacks L2 STX token operations — check balances, transfer STX, broadcast pre-signed transactions, call Clarity contracts, deploy contracts, and check transaction status. Transfer and contract operations require an unlocked wallet.",
+      "description": "Stacks L2 STX token operations \u2014 check balances, transfer STX, broadcast pre-signed transactions, call Clarity contracts, deploy contracts, and check transaction status. Transfer and contract operations require an unlocked wallet.",
       "entry": "stx/stx.ts",
       "arguments": [
         "get-balance",
@@ -1599,7 +1618,7 @@
     },
     {
       "name": "styx",
-      "description": "BTC→sBTC conversion via Styx protocol (btc2sbtc.com) — pool status, fee estimates, deposit creation, PSBT signing, broadcast, and deposit tracking.",
+      "description": "BTC\u2192sBTC conversion via Styx protocol (btc2sbtc.com) \u2014 pool status, fee estimates, deposit creation, PSBT signing, broadcast, and deposit tracking.",
       "entry": "styx/styx.ts",
       "arguments": [
         "pool-status",
@@ -1635,7 +1654,7 @@
     },
     {
       "name": "taproot-multisig",
-      "description": "Bitcoin Taproot M-of-N multisig coordination between agents — share x-only Taproot pubkeys, sign BIP-341 sighashes with Schnorr, verify co-signer signatures, and navigate the OP_CHECKSIGADD workflow. Proven on mainnet (2-of-2 block 937,849 and 3-of-3 block 938,206).",
+      "description": "Bitcoin Taproot M-of-N multisig coordination between agents \u2014 share x-only Taproot pubkeys, sign BIP-341 sighashes with Schnorr, verify co-signer signatures, and navigate the OP_CHECKSIGADD workflow. Proven on mainnet (2-of-2 block 937,849 and 3-of-3 block 938,206).",
       "entry": "taproot-multisig/taproot-multisig.ts",
       "arguments": [
         "get-pubkey",
@@ -1658,7 +1677,7 @@
     },
     {
       "name": "tenero",
-      "description": "Tenero (formerly STXTools) market analytics — token info, market stats, top gainers/losers, wallet holdings and trades, trending DEX pools, whale trades, holder distribution, and search. Covers Stacks, Spark, and SportsFun chains. No API key required.",
+      "description": "Tenero (formerly STXTools) market analytics \u2014 token info, market stats, top gainers/losers, wallet holdings and trades, trending DEX pools, whale trades, holder distribution, and search. Covers Stacks, Spark, and SportsFun chains. No API key required.",
       "entry": "tenero/tenero.ts",
       "arguments": [
         "token-info",
@@ -1686,7 +1705,7 @@
     },
     {
       "name": "tokens",
-      "description": "SIP-010 fungible token operations on Stacks L2 — check balances, transfer tokens, get token metadata, list all tokens owned by an address, and get top token holders. Supports well-known tokens by symbol (sBTC, USDCx, ALEX, DIKO) or full contract ID.",
+      "description": "SIP-010 fungible token operations on Stacks L2 \u2014 check balances, transfer tokens, get token metadata, list all tokens owned by an address, and get top token holders. Supports well-known tokens by symbol (sBTC, USDCx, ALEX, DIKO) or full contract ID.",
       "entry": "tokens/tokens.ts",
       "arguments": [
         "get-balance",
@@ -1741,7 +1760,7 @@
     },
     {
       "name": "validation",
-      "description": "ERC-8004 on-chain agent validation management — request and respond to validations, and query validation status, summaries, and paginated lists by agent or validator.",
+      "description": "ERC-8004 on-chain agent validation management \u2014 request and respond to validations, and query validation status, summaries, and paginated lists by agent or validator.",
       "entry": "validation/validation.ts",
       "arguments": [
         "request",
@@ -1840,7 +1859,7 @@
     },
     {
       "name": "yield-dashboard",
-      "description": "Cross-protocol DeFi yield dashboard for Stacks — view positions across Zest Protocol, ALEX DEX, and Bitflow, see total portfolio value, APY breakdown per protocol, and get rebalance suggestions. Read-only, mainnet-only. Requires an unlocked wallet for address context.",
+      "description": "Cross-protocol DeFi yield dashboard for Stacks \u2014 view positions across Zest Protocol, ALEX DEX, and Bitflow, see total portfolio value, APY breakdown per protocol, and get rebalance suggestions. Read-only, mainnet-only. Requires an unlocked wallet for address context.",
       "entry": "yield-dashboard/yield-dashboard.ts",
       "arguments": [
         "overview",
@@ -1863,7 +1882,7 @@
     },
     {
       "name": "yield-hunter",
-      "description": "Autonomous sBTC yield hunting daemon — monitors wallet sBTC balance and automatically deposits to Zest Protocol when balance exceeds a configurable threshold. Only works on mainnet. Requires an unlocked wallet with sBTC balance and STX for transaction fees.",
+      "description": "Autonomous sBTC yield hunting daemon \u2014 monitors wallet sBTC balance and automatically deposits to Zest Protocol when balance exceeds a configurable threshold. Only works on mainnet. Requires an unlocked wallet with sBTC balance and STX for transaction fees.",
       "entry": "yield-hunter/yield-hunter.ts",
       "arguments": [
         "start",


### PR DESCRIPTION
Adds a read-only volatility risk scoring skill for Bitflow DLMM pools. Pre-liquidity safety gate with fail-safe crisis defaults.

Addresses all blocking feedback from arc0btc on #235:
- `assess-position` renamed to `assess-pool-drift` (no per-address endpoint exists in Bitflow API — pool-level analysis documented clearly)
- All catch blocks use `process.exit(0)` for clean subprocess callers
- `PRICE_SCALE` dead constant removed
- Tags corrected to `read-only`
- `skills.json` manifest regenerated with correct subcommand names

Previous PR: #235