### PR TITLE
fix(relay-diagnostic): add pool state checks and align thresholds with settings

### DIFF
--- a/nonce-manager/AGENT.md
+++ b/nonce-manager/AGENT.md
@@ -1,7 +1,7 @@
 ---
 name: nonce-manager-agent
 skill: nonce-manager
-description: Cross-process Stacks nonce oracle agent guidance for acquiring, releasing, and repairing nonce state safely.
+description: Cross-process Stacks nonce oracle — prevents client-side nonce collisions by serializing nonce acquisition and release across concurrent skills.
 ---
 
 # Nonce Manager — Agent Briefing

--- a/relay-diagnostic/relay-diagnostic.ts
+++ b/relay-diagnostic/relay-diagnostic.ts
@@ -77,7 +77,7 @@ async function getNonceInfo(
 ): Promise<HiroNonceInfo> {
   const baseUrl = getApiBaseUrl(network);
   const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), 30000);
+  const timeout = setTimeout(() => controller.abort(), 10000);
   try {
     const res = await fetch(
       `${baseUrl}/extended/v1/address/${address}/nonces`,
@@ -102,8 +102,17 @@ async function checkRelayHealth(
 
   try {
     const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), 30000);
-    let healthData: { status?: string; version?: string };
+    const timeout = setTimeout(() => controller.abort(), 10000);
+    let healthData: {
+      status?: string;
+      version?: string;
+      nonce?: {
+        circuitBreakerOpen?: boolean;
+        poolStatus?: string;
+        effectiveCapacity?: number;
+        conflictsDetected?: number;
+      };
+    };
     try {
       const healthRes = await fetch(`${relayUrl}/health`, {
         method: "GET",
@@ -119,6 +128,12 @@ async function checkRelayHealth(
       healthData = (await healthRes.json()) as {
         status?: string;
         version?: string;
+        nonce?: {
+          circuitBreakerOpen?: boolean;
+          poolStatus?: string;
+          effectiveCapacity?: number;
+          conflictsDetected?: number;
+        };
       };
     } finally {
       clearTimeout(timeout);
@@ -128,6 +143,22 @@ async function checkRelayHealth(
 
     if (healthData.status !== "ok") {
       issues.push(`Relay status: ${healthData.status ?? "unknown"}`);
+    }
+
+    if (healthData.nonce) {
+      const noncePool = healthData.nonce;
+      if (noncePool.circuitBreakerOpen === true) {
+        issues.push("Relay circuit breaker is open — new sponsored transactions will be rejected");
+      }
+      if (noncePool.poolStatus !== undefined && noncePool.poolStatus !== "healthy") {
+        issues.push(`Relay nonce pool status: ${noncePool.poolStatus}`);
+      }
+      if (noncePool.effectiveCapacity !== undefined && noncePool.effectiveCapacity < 5) {
+        issues.push(`Relay nonce pool capacity critically low: ${noncePool.effectiveCapacity} available`);
+      }
+      if (noncePool.conflictsDetected !== undefined && noncePool.conflictsDetected > 10) {
+        issues.push(`Relay nonce conflicts detected: ${noncePool.conflictsDetected}`);
+      }
     }
 
     const sponsorAddress = SPONSOR_ADDRESSES[network];
@@ -162,7 +193,7 @@ async function checkRelayHealth(
       issues.push(
         `Mempool desync detected: sponsor nonce ${lastExecuted} (executed) vs ${lastMempool} (mempool), gap of ${desyncGap}`
       );
-    } else if (nonceInfo.detected_mempool_nonces.length > 10) {
+    } else if (nonceInfo.detected_mempool_nonces.length > 5) {
       issues.push(
         `Sponsor has ${nonceInfo.detected_mempool_nonces.length} transactions stuck in mempool`
       );
@@ -312,7 +343,7 @@ async function attemptRbf(
   if (txids && txids.length > 0) body.txids = txids;
 
   const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), 30000);
+  const timeout = setTimeout(() => controller.abort(), 10000);
 
   try {
     const res = await fetch(`${relayUrl}/recovery/rbf`, {
@@ -367,7 +398,7 @@ async function attemptFillGaps(
   if (nonces && nonces.length > 0) body.nonces = nonces;
 
   const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), 30000);
+  const timeout = setTimeout(() => controller.abort(), 10000);
 
   try {
     const res = await fetch(`${relayUrl}/recovery/fill-gaps`, {

--- a/settings/settings.ts
+++ b/settings/settings.ts
@@ -307,7 +307,7 @@ program
   .option(
     "--relay-url <url>",
     "Base URL of the sponsor relay",
-    "https://sponsor.aibtc.dev"
+    "https://x402-relay.aibtc.com"
   )
   .option(
     "--sponsor-address <address>",
@@ -394,6 +394,18 @@ program
               `Mempool congestion: ${nonceData.detected_mempool_nonces.length} pending sponsor transactions. ` +
                 "New sponsored transactions may be slow to confirm."
             );
+          }
+          if (
+            nonceData.last_mempool_tx_nonce !== null &&
+            nonceData.last_executed_tx_nonce !== null
+          ) {
+            const desyncGap =
+              nonceData.last_mempool_tx_nonce - nonceData.last_executed_tx_nonce;
+            if (desyncGap > 5) {
+              issues.push(
+                `Mempool desync detected: sponsor nonce ${nonceData.last_executed_tx_nonce} (executed) vs ${nonceData.last_mempool_tx_nonce} (mempool), gap of ${desyncGap}`
+              );
+            }
           }
         } else {
           issues.push(


### PR DESCRIPTION
## Summary

Closes #262

Three fixes to `relay-diagnostic.ts` and `settings.ts`:

- **Pool state fields consumed**: `checkRelayHealth()` in `relay-diagnostic.ts` now reads `nonce.circuitBreakerOpen`, `nonce.poolStatus`, `nonce.effectiveCapacity`, and `nonce.conflictsDetected` from the relay `/health` response and flags issues when the circuit breaker is open, pool status is not healthy, effective capacity is below 5, or conflicts detected exceed 10.

- **Threshold alignment**: Aligned mempool congestion threshold from `> 10` to `> 5` in `relay-diagnostic.ts` to match `settings.ts`. Aligned all `fetch` timeouts in `relay-diagnostic.ts` from 30s to 10s to match `settings.ts`. Added mempool desync gap check (gap `> 5`) to `settings.ts` `check-relay-health` to match `relay-diagnostic.ts`.

- **Default relay URL**: Updated default `--relay-url` in `settings.ts` from `https://sponsor.aibtc.dev` to `https://x402-relay.aibtc.com`, consistent with `relay-diagnostic.ts` and `sponsor.ts`.

## Test plan

- [ ] `bun run typecheck` passes (verified locally)
- [ ] `bun run relay-diagnostic/relay-diagnostic.ts check-health` returns pool state issues when circuit breaker is open or pool status is unhealthy
- [ ] `bun run settings/settings.ts check-relay-health` now hits `https://x402-relay.aibtc.com` by default and reports mempool desync when gap > 5

🤖 Generated with [Claude Code](https://claude.com/claude-code)