### PR TITLE
feat(aibtc-news): add x402 payment flow to file-signal subcommand

### DIFF
--- a/aibtc-news/aibtc-news.ts
+++ b/aibtc-news/aibtc-news.ts
@@ -359,7 +359,126 @@ program
         if (tags.length > 0) body.tags = tags;
         if (disclosure !== undefined) body.disclosure = disclosure;
 
-        const data = await apiPost("/signals", body, headers);
+        // Step 1: POST with auth headers — may return 200 (free) or 402 (x402 payment required)
+        const signalsUrl = `${NEWS_API_BASE}/signals`;
+        const initialRes = await fetch(signalsUrl, {
+          method: "POST",
+          headers,
+          body: JSON.stringify(body),
+        });
+
+        if (initialRes.status !== 402) {
+          const text = await initialRes.text();
+          let data: unknown;
+          try { data = JSON.parse(text); } catch { data = { raw: text }; }
+          if (!initialRes.ok) {
+            throw new Error(`API error ${initialRes.status} from POST /signals: ${text}`);
+          }
+          printJson({
+            success: true,
+            network: NETWORK,
+            message: "Signal filed successfully",
+            beatSlug: opts.beatId,
+            headline: opts.headline,
+            contentLength: opts.content.length,
+            sourcesCount: sources.length,
+            tagsCount: tags.length,
+            disclosureIncluded: disclosure !== undefined,
+            response: data,
+          });
+          return;
+        }
+
+        // Step 2: Handle x402 payment challenge
+        const paymentHeader = initialRes.headers.get("payment-required");
+        if (!paymentHeader) {
+          throw new Error("402 response missing payment-required header");
+        }
+
+        const {
+          decodePaymentRequired,
+          encodePaymentPayload,
+          X402_HEADERS,
+        } = await import("../src/lib/utils/x402-protocol.js");
+        const {
+          makeContractCall,
+          uintCV,
+          principalCV,
+          noneCV,
+        } = await import("@stacks/transactions");
+        const { getContracts, parseContractId } = await import("../src/lib/config/contracts.js");
+        const { getStacksNetwork } = await import("../src/lib/config/networks.js");
+        const { createFungiblePostCondition } = await import("../src/lib/transactions/post-conditions.js");
+        const { getHiroApi } = await import("../src/lib/services/hiro-api.js");
+        const { getAccount } = await import("../src/lib/services/wallet-manager.js");
+
+        const paymentRequired = decodePaymentRequired(paymentHeader);
+        if (!paymentRequired?.accepts?.length) {
+          throw new Error("No accepted payment methods in 402 response");
+        }
+        const accept = paymentRequired.accepts[0];
+        const amount = BigInt(accept.amount);
+
+        // Step 3: Build sponsored sBTC transfer transaction
+        const account = await getAccount();
+        const contracts = getContracts(NETWORK);
+        const { address: contractAddress, name: contractName } = parseContractId(contracts.SBTC_TOKEN);
+        const networkName = getStacksNetwork(NETWORK);
+        const postCondition = createFungiblePostCondition(
+          account.address,
+          contracts.SBTC_TOKEN,
+          "sbtc-token",
+          "eq",
+          amount
+        );
+        const hiro = getHiroApi(NETWORK);
+        const accountInfo = await hiro.getAccountInfo(account.address);
+        const nonce = BigInt(accountInfo.nonce);
+
+        const transaction = await makeContractCall({
+          contractAddress,
+          contractName,
+          functionName: "transfer",
+          functionArgs: [uintCV(amount), principalCV(account.address), principalCV(accept.payTo), noneCV()],
+          senderKey: account.privateKey,
+          network: networkName,
+          postConditions: [postCondition],
+          sponsored: true,
+          fee: 0n,
+          nonce,
+        });
+
+        const txHex = "0x" + transaction.serialize();
+
+        // Step 4: Encode payment payload and retry
+        const paymentSignature = encodePaymentPayload({
+          x402Version: 2,
+          resource: paymentRequired.resource,
+          accepted: accept,
+          payload: { transaction: txHex },
+        });
+
+        const finalRes = await fetch(signalsUrl, {
+          method: "POST",
+          headers: {
+            ...headers,
+            [X402_HEADERS.PAYMENT_SIGNATURE]: paymentSignature,
+          },
+          body: JSON.stringify(body),
+        });
+
+        const responseText = await finalRes.text();
+        let responseData: unknown;
+        try { responseData = JSON.parse(responseText); } catch { responseData = { raw: responseText }; }
+
+        if (!finalRes.ok) {
+          throw new Error(`Signal delivery failed after payment (${finalRes.status}): ${responseText}`);
+        }
+
+        const settlementHeader = finalRes.headers.get(X402_HEADERS.PAYMENT_RESPONSE);
+        const { decodePaymentResponse } = await import("../src/lib/utils/x402-protocol.js");
+        const settlement = decodePaymentResponse(settlementHeader);
+        const txid = settlement?.transaction;
 
         printJson({
           success: true,
@@ -371,7 +490,8 @@ program
           sourcesCount: sources.length,
           tagsCount: tags.length,
           disclosureIncluded: disclosure !== undefined,
-          response: data,
+          response: responseData,
+          ...(txid && { payment: { txid, amount: accept.amount + " sats sBTC" } }),
         });
       } catch (error) {
         handleError(error);

--- a/aibtc-news/aibtc-news.ts
+++ b/aibtc-news/aibtc-news.ts
@@ -449,6 +449,7 @@ program
         });
 
         const txHex = "0x" + transaction.serialize();
+        const paymentTxid = transaction.txid();
 
         // Step 4: Encode payment payload and retry
         const paymentSignature = encodePaymentPayload({
@@ -472,13 +473,13 @@ program
         try { responseData = JSON.parse(responseText); } catch { responseData = { raw: responseText }; }
 
         if (!finalRes.ok) {
-          throw new Error(`Signal delivery failed after payment (${finalRes.status}): ${responseText}`);
+          throw new Error(`Signal delivery failed after payment (${finalRes.status}): ${responseText} (paymentTxid=${paymentTxid})`);
         }
 
         const settlementHeader = finalRes.headers.get(X402_HEADERS.PAYMENT_RESPONSE);
         const { decodePaymentResponse } = await import("../src/lib/utils/x402-protocol.js");
-        const settlement = decodePaymentResponse(settlementHeader);
-        const txid = settlement?.transaction;
+        const settlement = settlementHeader ? decodePaymentResponse(settlementHeader) : null;
+        const txid = settlement?.transaction ?? paymentTxid;
 
         printJson({
           success: true,

--- a/skills.json
+++ b/skills.json
@@ -1,6 +1,6 @@
 {
   "version": "0.40.0",
-  "generated": "2026-04-29T23:45:36.845Z",
+  "generated": "2026-04-30T00:36:15.566Z",
   "skills": [
     {
       "name": "agent-lookup",


### PR DESCRIPTION
## Summary

Adapts the existing `inbox send` x402 payment pattern to handle HTTP 402 challenges from `POST /api/signals` on aibtc.news.

- POST with auth headers first (free period passthrough — 200 returns immediately)
- On 402: parse `payment-required` header, build sponsored sBTC transfer, encode payment payload, retry with `payment-signature` header
- Surfaces `payment.txid` and `payment.amount` in the JSON output when a payment was made
- Backwards compatible — works with and without the server-side gate

Closes #254.

## Test plan
- [ ] `bun run typecheck` passes (verified ✅)
- [ ] `file-signal` succeeds when server returns 200 (no payment gate active)
- [ ] `file-signal` completes payment flow when server returns 402

🤖 Generated with [Claude Code](https://claude.com/claude-code) by 369SunRay (Amber Otter)