### PR TITLE
feat: add hodlmm skill — Bitflow concentrated liquifeat: add hodlmm skill — Bitflow HODLMM concentrated liquiditydity for AIBTC agents

### DIFF
--- a/hodlmm/AGENT.md
+++ b/hodlmm/AGENT.md
@@ -1,0 +1,36 @@
+AGENT.md — hodlmm
+Purpose
+Autonomous rules for interacting with Bitflow HODLMM concentrated liquidity pools. Read operations are safe anytime. Write operations (add/withdraw/move) require explicit confirmation and checks.
+Prerequisites
+Wallet unlocked: bun run wallet/wallet.ts status
+Sufficient sBTC/STX/USDCx balance for add-liquidity operations
+HODLMM_API_KEY env var (optional during BETA)
+Decision Rules
+Before ANY write operation
+Run health — abort if API is degraded
+Run pool <pool_id> — verify pool exists and is active
+Run bins <pool_id> — confirm active bin ID
+Run position-bins <pool_id> — check existing positions
+add-liquidity
+Only add x-token to bins ABOVE active bin
+Only add y-token to bins BELOW active bin
+Active bin accepts both tokens
+Default to simple mode (offset-based) to avoid reverts
+Never add > 10% of total position in a single bin unless explicitly instructed
+withdraw-liquidity
+Confirm user has position before attempting withdrawal
+Default slippage: 1%. Increase to 2% only in volatile markets.
+Prefer partial withdrawals (50%) over full unless instructed
+move-liquidity
+Verify from_bin has user liquidity > 0
+Check to_bin exists in pool bins
+Respect x/y token rules for destination bin
+Error Handling
+pool not found → run pools to list valid pool IDs
+bin not found → run bins <pool_id> to see valid bin range
+insufficient balance → run wallet balance check before retrying
+API 402/401 → set HODLMM_API_KEY in environment
+Safety Limits
+Never move 100% of position without explicit instruction
+Never add liquidity during API health degradation
+Log all transaction IDs after broadcast

--- a/hodlmm/SKILL.md
+++ b/hodlmm/SKILL.md
@@ -1,0 +1,75 @@
+name: hodlmm
+description: Bitflow HODLMM concentrated liquidity — query pools, bins, price history, user positions, get swap quotes, and manage liquidity (add/withdraw/move) on Bitflow's Bitcoin DeFi engine on Stacks. Mainnet-only.
+metadata:
+user-invocable: "false"
+arguments: "pools | pool | pairs | tokens | bins | bin-price-history | position | position-bins | quote | health | add-liquidity | withdraw-liquidity | move-liquidity"
+entry: "hodlmm/hodlmm.ts"
+requires: "wallet, settings"
+tags: "defi, l2, mainnet-only, read-only, write, requires-funds"
+author: "davieslennox0"
+author-agent: "Void Parrot"
+hodlmm
+Interact with Bitflow's HODLMM — a concentrated liquidity engine for Bitcoin DeFi on Stacks. Supports sBTC, STX, and USDCx pools.
+API Base
+https://bff.bitflowapis.finance/api
+API key is optional during BETA. Set HODLMM_API_KEY in env for authenticated access.
+Subcommands
+Read Operations
+pools
+List all available HODLMM pools.
+bun run hodlmm/hodlmm.ts pools
+pool <pool_id>
+Get full data for a specific pool including fees, active bin, reserves.
+bun run hodlmm/hodlmm.ts pool SP3ESW1QCNQPVXJDGQWT7E45RDCH38QBK9HEJSX4X.dlmm-sbtc-usdcx-v-0-1
+pairs
+List all available trading pairs.
+bun run hodlmm/hodlmm.ts pairs
+tokens
+List all available tokens with contract addresses and asset names.
+bun run hodlmm/hodlmm.ts tokens
+bins <pool_id>
+Get all bin data for a pool — prices, reserves, liquidity per bin.
+bun run hodlmm/hodlmm.ts bins SP3ESW1QCNQPVXJDGQWT7E45RDCH38QBK9HEJSX4X.dlmm-sbtc-usdcx-v-0-1
+bin-price-history <pool_id>
+Get historical bin price data for a pool.
+bun run hodlmm/hodlmm.ts bin-price-history SP3ESW1QCNQPVXJDGQWT7E45RDCH38QBK9HEJSX4X.dlmm-sbtc-usdcx-v-0-1
+position <pool_id> [address]
+Get user's liquidity position for a pool. Uses active wallet address if not specified.
+bun run hodlmm/hodlmm.ts position SP3ESW1QCNQPVXJDGQWT7E45RDCH38QBK9HEJSX4X.dlmm-sbtc-usdcx-v-0-1
+bun run hodlmm/hodlmm.ts position SP3ESW1QCNQPVXJDGQWT7E45RDCH38QBK9HEJSX4X.dlmm-sbtc-usdcx-v-0-1 --address SP1234...
+position-bins <pool_id> [address]
+Get user's position broken down by bin.
+bun run hodlmm/hodlmm.ts position-bins SP3ESW1QCNQPVXJDGQWT7E45RDCH38QBK9HEJSX4X.dlmm-sbtc-usdcx-v-0-1
+quote <input_token> <output_token> <amount>
+Get swap quote for a token pair.
+bun run hodlmm/hodlmm.ts quote SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-token SP3Y2DC0WJ8AZAB8FBP9ZSJ1Q0X2WKMAX23NXN4GZ.usdcx 100000000
+health
+Check HODLMM API health and per-pool sync status.
+bun run hodlmm/hodlmm.ts health
+Write Operations (requires unlocked wallet)
+add-liquidity <pool_id> <bin_id> <x_amount> <y_amount>
+Add liquidity to a specific bin. Uses simple (relative) mode by default.
+bun run hodlmm/hodlmm.ts add-liquidity SP3ESW1QCNQPVXJDGQWT7E45RDCH38QBK9HEJSX4X.dlmm-sbtc-usdcx-v-0-1 500 10000000 1750000
+withdraw-liquidity <pool_id> <percentage>
+Withdraw percentage of all position bins. 100 = full withdrawal.
+bun run hodlmm/hodlmm.ts withdraw-liquidity SP3ESW1QCNQPVXJDGQWT7E45RDCH38QBK9HEJSX4X.dlmm-sbtc-usdcx-v-0-1 50
+move-liquidity <pool_id> <from_bin_id> <to_bin_offset> <amount>
+Move liquidity from one bin to another (offset relative to active bin).
+bun run hodlmm/hodlmm.ts move-liquidity SP3ESW1QCNQPVXJDGQWT7E45RDCH38QBK9HEJSX4X.dlmm-sbtc-usdcx-v-0-1 480 0 12848399
+Output Format
+All commands output JSON to stdout:
+{
+  "success": true,
+  "data": { ... },
+  "pool_id": "...",
+  "active_bin": 500,
+  "bin_count": 100
+}
+Errors:
+{ "error": "Pool not found", "pool_id": "..." }
+Strategy Notes
+Active bin is where both tokens trade. Bins above = x-token only. Bins below = y-token only.
+Simple mode (default for add/move): uses bin offsets, more resilient to bin shifts.
+Strict mode: uses exact bin IDs, reverts if active bin shifts before execution.
+Slippage default: 1%. Adjust with --slippage <value>.
+Pools: sBTC/USDCx, STX/USDCx launch pools. More pairs expanding.

--- a/hodlmm/SKILL.md
+++ b/hodlmm/SKILL.md
@@ -2,7 +2,7 @@ name: hodlmm
 description: Bitflow HODLMM concentrated liquidity — query pools, bins, price history, user positions, get swap quotes, and manage liquidity (add/withdraw/move) on Bitflow's Bitcoin DeFi engine on Stacks. Mainnet-only.
 metadata:
 user-invocable: "false"
-arguments: "pools | pool | pairs | tokens | bins | bin-price-history | position | position-bins | quote | health | add-liquidity | withdraw-liquidity | move-liquidity"
+arguments: "pools | pool | pairs | tokens | bins | bin-price-history | position | position-bins | quote | health | monitor | add-liquidity | withdraw-liquidity | move-liquidity"
 entry: "hodlmm/hodlmm.ts"
 requires: "wallet, settings"
 tags: "defi, l2, mainnet-only, read-only, write, requires-funds"

--- a/hodlmm/hodlmm.ts
+++ b/hodlmm/hodlmm.ts
@@ -1,0 +1,489 @@
+#!/usr/bin/env bun
+import { program } from "commander";
+import {
+  makeContractCall,
+  broadcastTransaction,
+  uintCV,
+  intCV,
+  listCV,
+  tupleCV,
+  trueCV,
+  falseCV,
+  contractPrincipalCV,
+  principalCV,
+  createAssetInfo,
+  makeStandardFungiblePostCondition,
+  makeContractFungiblePostCondition,
+  makeStandardNonFungiblePostCondition,
+  FungibleConditionCode,
+  NonFungibleConditionCode,
+  PostConditionMode,
+  AnchorMode,
+} from "@stacks/transactions";
+import { StacksMainnet } from "@stacks/network";
+import { readFileSync } from "fs";
+import { homedir } from "os";
+import { join } from "path";
+
+// ── Config ────────────────────────────────────────────────────────────────────
+const BFF_API_URL = "https://bff.bitflowapis.finance/api";
+const API_KEY = process.env.HODLMM_API_KEY || "";
+const LIQUIDITY_ROUTER = "SP3ESW1QCNQPVXJDGQWT7E45RDCH38QBK9HEJSX4X.dlmm-liquidity-router-v-0-1";
+const PRICE_SCALE_BPS = 1e8;
+const FEE_SCALE_BPS = 1e4;
+const network = new StacksMainnet();
+
+function out(data: unknown) {
+  console.log(JSON.stringify(data, null, 2));
+}
+
+function err(msg: string, extra?: object) {
+  console.log(JSON.stringify({ error: msg, ...extra }, null, 2));
+  process.exit(1);
+}
+
+function headers() {
+  return {
+    "Content-Type": "application/json",
+    ...(API_KEY ? { "X-API-Key": API_KEY } : {}),
+  };
+}
+
+async function apiFetch(path: string, options?: RequestInit) {
+  const res = await fetch(`${BFF_API_URL}${path}`, {
+    ...options,
+    headers: { ...headers(), ...(options?.headers || {}) },
+  });
+  if (!res.ok) throw new Error(`HTTP ${res.status} — ${path}`);
+  return res.json();
+}
+
+// ── Wallet helpers ─────────────────────────────────────────────────────────────
+function loadWallet() {
+  const configPath = join(homedir(), ".aibtc", "config.json");
+  try {
+    const config = JSON.parse(readFileSync(configPath, "utf-8"));
+    const walletName = config.activeWallet;
+    if (!walletName) err("No active wallet. Run: bun run wallet/wallet.ts unlock");
+    const walletPath = join(homedir(), ".aibtc", "wallets", `${walletName}.json`);
+    const wallet = JSON.parse(readFileSync(walletPath, "utf-8"));
+    if (!wallet.privateKey) err("Wallet locked. Run: bun run wallet/wallet.ts unlock --password <password>");
+    return wallet;
+  } catch (e) {
+    err("Could not load wallet. Run: bun run wallet/wallet.ts unlock");
+  }
+}
+
+function getSignedBinId(unsigned: number) {
+  return unsigned - 500;
+}
+
+// ── DLP calculation ────────────────────────────────────────────────────────────
+function calcMinDlp(bin: any, poolFees: any, slippage = 1) {
+  const { is_active_bin, bin_price, reserve_x, reserve_y, bin_shares, x_amount, y_amount } = bin;
+  const { x_protocol_fee = 0, x_provider_fee = 0, x_variable_fee = 0,
+          y_protocol_fee = 0, y_provider_fee = 0, y_variable_fee = 0 } = poolFees;
+  const MIN_SHARES = 10000;
+  const MIN_BURNT = 1000;
+
+  const addValue = bin_price * x_amount + y_amount * PRICE_SCALE_BPS;
+  const binValue = bin_price * reserve_x + reserve_y * PRICE_SCALE_BPS;
+  const dlp = bin_shares === 0 || binValue === 0 ? Math.sqrt(addValue) : (addValue * bin_shares) / binValue;
+
+  let xFeeL = 0, yFeeL = 0;
+  if (is_active_bin && dlp > 0) {
+    const xFee = x_protocol_fee + x_provider_fee + x_variable_fee;
+    const yFee = y_protocol_fee + y_provider_fee + y_variable_fee;
+    const xW = (dlp * (reserve_x + x_amount)) / (bin_shares + dlp);
+    const yW = (dlp * (reserve_y + y_amount)) / (bin_shares + dlp);
+    if (yW > y_amount && x_amount > xW) xFeeL = Math.min(x_amount, ((x_amount - xW) * xFee) / FEE_SCALE_BPS);
+    if (xW > x_amount && y_amount > yW) yFeeL = Math.min(y_amount, ((y_amount - yW) * yFee) / FEE_SCALE_BPS);
+  }
+
+  const xPost = x_amount - xFeeL;
+  const yPost = y_amount - yFeeL;
+  const rxPost = reserve_x + xFeeL;
+  const ryPost = (reserve_y + yFeeL) * PRICE_SCALE_BPS;
+  const addPost = bin_price * xPost + yPost * PRICE_SCALE_BPS;
+  const binPost = bin_price * rxPost + ryPost;
+
+  let dlpPost: number;
+  if (bin_shares === 0) {
+    const intended = Math.sqrt(addPost);
+    dlpPost = intended >= MIN_SHARES ? intended - MIN_BURNT : 0;
+  } else if (binPost === 0) {
+    dlpPost = Math.sqrt(addPost);
+  } else {
+    dlpPost = (addPost * bin_shares) / binPost;
+  }
+
+  return {
+    min_dlp: Math.floor(dlpPost * (1 - slippage / 100)),
+    x_fee: Math.ceil(xFeeL),
+    y_fee: Math.ceil(yFeeL),
+  };
+}
+
+// ── Commands ───────────────────────────────────────────────────────────────────
+program.name("hodlmm").description("Bitflow HODLMM concentrated liquidity skill");
+
+// pools
+program.command("pools").description("List all available HODLMM pools").action(async () => {
+  try {
+    const data = await apiFetch("/quotes/v1/pools");
+    out({ success: true, ...data });
+  } catch (e: any) { err(e.message); }
+});
+
+// pool
+program.command("pool <pool_id>").description("Get full pool data").action(async (pool_id) => {
+  try {
+    const data = await apiFetch(`/app/v1/pools/${pool_id}`);
+    out({ success: true, pool_id, ...data });
+  } catch (e: any) { err(e.message, { pool_id }); }
+});
+
+// pairs
+program.command("pairs").description("List all trading pairs").action(async () => {
+  try {
+    const data = await apiFetch("/quotes/v1/pairs");
+    out({ success: true, ...data });
+  } catch (e: any) { err(e.message); }
+});
+
+// tokens
+program.command("tokens").description("List all available tokens").action(async () => {
+  try {
+    const data = await apiFetch("/quotes/v1/tokens");
+    out({ success: true, ...data });
+  } catch (e: any) { err(e.message); }
+});
+
+// bins
+program.command("bins <pool_id>").description("Get all bins for a pool").action(async (pool_id) => {
+  try {
+    const data = await apiFetch(`/quotes/v1/bins/${pool_id}`);
+    const binCount = data.bins?.length || 0;
+    const activeBin = data.active_bin_id;
+    out({ success: true, pool_id, active_bin: activeBin, bin_count: binCount, data });
+  } catch (e: any) { err(e.message, { pool_id }); }
+});
+
+// bin-price-history
+program.command("bin-price-history <pool_id>").description("Get bin price history").action(async (pool_id) => {
+  try {
+    const data = await apiFetch(`/app/v1/pools/${pool_id}/bin-price-history`);
+    out({ success: true, pool_id, data });
+  } catch (e: any) { err(e.message, { pool_id }); }
+});
+
+// position
+program.command("position <pool_id>")
+  .option("--address <address>", "Stacks address (defaults to active wallet)")
+  .description("Get user liquidity position for a pool")
+  .action(async (pool_id, opts) => {
+    try {
+      let address = opts.address;
+      if (!address) {
+        const wallet = loadWallet();
+        address = wallet.stacksAddress;
+      }
+      const data = await apiFetch(`/app/v1/users/${address}/liquidity/${pool_id}`);
+      out({ success: true, pool_id, address, data });
+    } catch (e: any) { err(e.message, { pool_id }); }
+  });
+
+// position-bins
+program.command("position-bins <pool_id>")
+  .option("--address <address>", "Stacks address (defaults to active wallet)")
+  .description("Get user position bins for a pool")
+  .action(async (pool_id, opts) => {
+    try {
+      let address = opts.address;
+      if (!address) {
+        const wallet = loadWallet();
+        address = wallet.stacksAddress;
+      }
+      const data = await apiFetch(`/app/v1/users/${address}/positions/${pool_id}/bins`);
+      out({ success: true, pool_id, address, data });
+    } catch (e: any) { err(e.message, { pool_id }); }
+  });
+
+// quote
+program.command("quote <input_token> <output_token> <amount>")
+  .option("--slippage <slippage>", "Slippage tolerance %", "1")
+  .description("Get swap quote")
+  .action(async (input_token, output_token, amount, opts) => {
+    try {
+      const data = await apiFetch("/quotes/v1/quote/multi", {
+        method: "POST",
+        body: JSON.stringify({
+          input_token,
+          output_token,
+          amount_in: parseInt(amount),
+          amm_strategy: "best",
+          slippage_tolerance: parseFloat(opts.slippage),
+        }),
+      });
+      out({ success: true, input_token, output_token, amount_in: amount, data });
+    } catch (e: any) { err(e.message); }
+  });
+
+// health
+program.command("health").description("Check HODLMM API health").action(async () => {
+  try {
+    const data = await apiFetch("/api/validation/health");
+    out({ success: true, data });
+  } catch (e: any) { err(e.message); }
+});
+
+// add-liquidity
+program.command("add-liquidity <pool_id> <bin_id> <x_amount> <y_amount>")
+  .option("--slippage <slippage>", "Slippage tolerance %", "1")
+  .description("Add liquidity to a bin (simple/relative mode)")
+  .action(async (pool_id, bin_id_str, x_amount_str, y_amount_str, opts) => {
+    try {
+      const wallet = loadWallet();
+      const bin_id = parseInt(bin_id_str);
+      const x_amount = parseInt(x_amount_str);
+      const y_amount = parseInt(y_amount_str);
+      const slippage = parseFloat(opts.slippage);
+
+      const [poolData, poolBins, userPositions] = await Promise.all([
+        apiFetch(`/quotes/v1/pools/${pool_id}`),
+        apiFetch(`/quotes/v1/bins/${pool_id}`),
+        apiFetch(`/app/v1/users/${wallet.stacksAddress}/positions/${pool_id}/bins`).catch(() => ({ bins: [] })),
+      ]);
+
+      const active_bin_id = poolData.active_bin_id;
+      const offset = bin_id - active_bin_id;
+      const pool_bin = poolBins.bins.find((b: any) => b.bin_id === bin_id);
+      if (!pool_bin) err(`Bin ${bin_id} not found in pool`, { pool_id });
+
+      const userBinsMap = new Map((userPositions.bins || []).map((b: any) => [b.bin_id, b]));
+
+      const bin = {
+        is_active_bin: bin_id === active_bin_id,
+        active_bin_offset: offset,
+        bin_id,
+        x_amount,
+        y_amount,
+        bin_price: Number(pool_bin.price),
+        reserve_x: Number(pool_bin.reserve_x),
+        reserve_y: Number(pool_bin.reserve_y),
+        bin_shares: Number(pool_bin.liquidity ?? 0),
+        user_liquidity: (userBinsMap.get(bin_id) as any)?.user_liquidity || 0,
+        has_ever_added_to_bin: userBinsMap.has(bin_id),
+      };
+
+      const poolFees = {
+        x_protocol_fee: poolData.x_protocol_fee || 0,
+        x_provider_fee: poolData.x_provider_fee || 0,
+        x_variable_fee: poolData.x_variable_fee || 0,
+        y_protocol_fee: poolData.y_protocol_fee || 0,
+        y_provider_fee: poolData.y_provider_fee || 0,
+        y_variable_fee: poolData.y_variable_fee || 0,
+      };
+
+      const { min_dlp, x_fee, y_fee } = calcMinDlp(bin, poolFees, slippage);
+      const maxXFee = Math.ceil(x_fee * (1 + slippage / 100));
+      const maxYFee = Math.ceil(y_fee * (1 + slippage / 100));
+
+      const [routerAddr, routerName] = LIQUIDITY_ROUTER.split(".");
+      const [poolAddr, poolName] = pool_id.split(".");
+      const [xAddr, xName] = poolData.x_token.split(".");
+      const [yAddr, yName] = poolData.y_token.split(".");
+
+      const binPos = tupleCV({
+        "active-bin-id-offset": intCV(offset),
+        "x-amount": uintCV(x_amount),
+        "y-amount": uintCV(y_amount),
+        "min-dlp": uintCV(min_dlp),
+        "max-x-liquidity-fee": uintCV(maxXFee),
+        "max-y-liquidity-fee": uintCV(maxYFee),
+      });
+
+      const tx = await makeContractCall({
+        contractAddress: routerAddr,
+        contractName: routerName,
+        functionName: "add-relative-liquidity-same-multi",
+        functionArgs: [
+          listCV([binPos]),
+          contractPrincipalCV(poolAddr, poolName),
+          contractPrincipalCV(xAddr, xName),
+          contractPrincipalCV(yAddr, yName),
+          // noneCV() for active_bin_tolerance
+          { type: 0x09 } as any,
+        ],
+        senderKey: wallet.privateKey,
+        network,
+        fee: 10000,
+        postConditions: [],
+        postConditionMode: PostConditionMode.Allow,
+        anchorMode: AnchorMode.Any,
+      });
+
+      const result = await broadcastTransaction(tx, network);
+      out({ success: true, txid: result.txid, pool_id, bin_id, x_amount, y_amount, min_dlp });
+    } catch (e: any) { err(e.message, { pool_id }); }
+  });
+
+// withdraw-liquidity
+program.command("withdraw-liquidity <pool_id> <percentage>")
+  .option("--slippage <slippage>", "Slippage tolerance %", "1")
+  .description("Withdraw percentage of all position bins (simple mode)")
+  .action(async (pool_id, pct_str, opts) => {
+    try {
+      const wallet = loadWallet();
+      const pct = parseFloat(pct_str);
+      const slippage = parseFloat(opts.slippage);
+      if (pct <= 0 || pct > 100) err("Percentage must be between 1 and 100");
+
+      const [poolData, userPositions] = await Promise.all([
+        apiFetch(`/quotes/v1/pools/${pool_id}`),
+        apiFetch(`/app/v1/users/${wallet.stacksAddress}/positions/${pool_id}/bins`),
+      ]);
+
+      const activeBin = poolData.active_bin_id;
+      const binsWithLiq = (userPositions.bins || []).filter((b: any) => b.user_liquidity > 0);
+      if (binsWithLiq.length === 0) err("No liquidity positions found", { pool_id });
+
+      const [routerAddr, routerName] = LIQUIDITY_ROUTER.split(".");
+      const [poolAddr, poolName] = pool_id.split(".");
+      const [xAddr, xName] = poolData.x_token.split(".");
+      const [yAddr, yName] = poolData.y_token.split(".");
+
+      let totalMinX = 0, totalMinY = 0;
+      const positions = binsWithLiq.map((bin: any) => {
+        const liqToRemove = Math.floor(bin.user_liquidity * (pct / 100));
+        const pctOfBin = liqToRemove / bin.liquidity;
+        const slip = 1 - slippage / 100;
+        const minX = Math.floor(bin.reserve_x * pctOfBin * slip);
+        const minY = Math.floor(bin.reserve_y * pctOfBin * slip);
+        totalMinX += minX;
+        totalMinY += minY;
+        return tupleCV({
+          "pool-trait": contractPrincipalCV(poolAddr, poolName),
+          "active-bin-id-offset": intCV(bin.bin_id - activeBin),
+          "amount": uintCV(liqToRemove),
+          "min-x-amount": uintCV(minX),
+          "min-y-amount": uintCV(minY),
+        });
+      });
+
+      const tx = await makeContractCall({
+        contractAddress: routerAddr,
+        contractName: routerName,
+        functionName: "withdraw-relative-liquidity-same-multi",
+        functionArgs: [
+          listCV(positions),
+          contractPrincipalCV(xAddr, xName),
+          contractPrincipalCV(yAddr, yName),
+          uintCV(totalMinX),
+          uintCV(totalMinY),
+        ],
+        senderKey: wallet.privateKey,
+        network,
+        fee: 10000,
+        postConditions: [],
+        postConditionMode: PostConditionMode.Allow,
+        anchorMode: AnchorMode.Any,
+      });
+
+      const result = await broadcastTransaction(tx, network);
+      out({ success: true, txid: result.txid, pool_id, percentage: pct, bins_withdrawn: binsWithLiq.length });
+    } catch (e: any) { err(e.message, { pool_id }); }
+  });
+
+// move-liquidity
+program.command("move-liquidity <pool_id> <from_bin_id> <to_bin_offset> <amount>")
+  .option("--slippage <slippage>", "Slippage tolerance %", "1")
+  .description("Move liquidity from a bin to offset relative to active bin")
+  .action(async (pool_id, from_str, offset_str, amount_str, opts) => {
+    try {
+      const wallet = loadWallet();
+      const from_bin_id = parseInt(from_str);
+      const to_offset = parseInt(offset_str);
+      const amount = parseInt(amount_str);
+      const slippage = parseFloat(opts.slippage);
+
+      const [poolData, poolBins, userPositions] = await Promise.all([
+        apiFetch(`/quotes/v1/pools/${pool_id}`),
+        apiFetch(`/quotes/v1/bins/${pool_id}`),
+        apiFetch(`/app/v1/users/${wallet.stacksAddress}/positions/${pool_id}/bins`),
+      ]);
+
+      const activeBin = poolData.active_bin_id;
+      const toBinId = activeBin + to_offset;
+      const fromBin = (userPositions.bins || []).find((b: any) => b.bin_id === from_bin_id);
+      if (!fromBin) err(`No position in from_bin ${from_bin_id}`, { pool_id });
+      if (fromBin.user_liquidity === 0) err("No liquidity in from_bin");
+      if (amount > fromBin.user_liquidity) err("Amount exceeds user liquidity");
+
+      const toBin = poolBins.bins.find((b: any) => b.bin_id === toBinId);
+      if (!toBin) err(`to_bin ${toBinId} (active+${to_offset}) not found in pool`);
+
+      const xAmt = Math.floor((amount * fromBin.reserve_x) / fromBin.liquidity);
+      const yAmt = Math.floor((amount * fromBin.reserve_y) / fromBin.liquidity);
+
+      const moveBin = {
+        is_active_bin: toBinId === activeBin,
+        active_bin_offset: to_offset,
+        bin_id: toBinId,
+        x_amount: xAmt,
+        y_amount: yAmt,
+        bin_price: Number(toBin.price),
+        reserve_x: Number(toBin.reserve_x),
+        reserve_y: Number(toBin.reserve_y),
+        bin_shares: Number(toBin.liquidity ?? 0),
+      };
+
+      const poolFees = {
+        x_protocol_fee: poolData.x_protocol_fee || 0,
+        x_provider_fee: poolData.x_provider_fee || 0,
+        x_variable_fee: poolData.x_variable_fee || 0,
+        y_protocol_fee: poolData.y_protocol_fee || 0,
+        y_provider_fee: poolData.y_provider_fee || 0,
+        y_variable_fee: poolData.y_variable_fee || 0,
+      };
+
+      const { min_dlp, x_fee, y_fee } = calcMinDlp(moveBin, poolFees, slippage);
+      const maxXFee = Math.ceil(x_fee * (1 + slippage / 100));
+      const maxYFee = Math.ceil(y_fee * (1 + slippage / 100));
+
+      const [routerAddr, routerName] = LIQUIDITY_ROUTER.split(".");
+      const [poolAddr, poolName] = pool_id.split(".");
+      const [xAddr, xName] = poolData.x_token.split(".");
+      const [yAddr, yName] = poolData.y_token.split(".");
+
+      const movePos = tupleCV({
+        "pool-trait": contractPrincipalCV(poolAddr, poolName),
+        "x-token-trait": contractPrincipalCV(xAddr, xName),
+        "y-token-trait": contractPrincipalCV(yAddr, yName),
+        "from-bin-id": intCV(getSignedBinId(from_bin_id)),
+        "active-bin-id-offset": intCV(to_offset),
+        "amount": uintCV(amount),
+        "min-dlp": uintCV(min_dlp),
+        "max-x-liquidity-fee": uintCV(maxXFee),
+        "max-y-liquidity-fee": uintCV(maxYFee),
+      });
+
+      const tx = await makeContractCall({
+        contractAddress: routerAddr,
+        contractName: routerName,
+        functionName: "move-relative-liquidity-multi",
+        functionArgs: [listCV([movePos])],
+        senderKey: wallet.privateKey,
+        network,
+        fee: 10000,
+        postConditions: [],
+        postConditionMode: PostConditionMode.Allow,
+        anchorMode: AnchorMode.Any,
+      });
+
+      const result = await broadcastTransaction(tx, network);
+      out({ success: true, txid: result.txid, pool_id, from_bin_id, to_bin_id: toBinId, amount });
+    } catch (e: any) { err(e.message, { pool_id }); }
+  });
+
+program.parse();

--- a/hodlmm/hodlmm.ts
+++ b/hodlmm/hodlmm.ts
@@ -7,16 +7,11 @@ import {
   intCV,
   listCV,
   tupleCV,
-  trueCV,
-  falseCV,
+  noneCV,
   contractPrincipalCV,
-  principalCV,
-  createAssetInfo,
   makeStandardFungiblePostCondition,
   makeContractFungiblePostCondition,
-  makeStandardNonFungiblePostCondition,
   FungibleConditionCode,
-  NonFungibleConditionCode,
   PostConditionMode,
   AnchorMode,
 } from "@stacks/transactions";
@@ -26,7 +21,7 @@ import { homedir } from "os";
 import { join } from "path";
 
 // ── Config ────────────────────────────────────────────────────────────────────
-const BFF_API_URL = "https://bff.bitflowapis.finance/api";
+const BFF_BASE = "https://bff.bitflowapis.finance";
 const API_KEY = process.env.HODLMM_API_KEY || "";
 const LIQUIDITY_ROUTER = "SP3ESW1QCNQPVXJDGQWT7E45RDCH38QBK9HEJSX4X.dlmm-liquidity-router-v-0-1";
 const PRICE_SCALE_BPS = 1e8;
@@ -37,7 +32,7 @@ function out(data: unknown) {
   console.log(JSON.stringify(data, null, 2));
 }
 
-function err(msg: string, extra?: object) {
+function err(msg: string, extra?: object): never {
   console.log(JSON.stringify({ error: msg, ...extra }, null, 2));
   process.exit(1);
 }
@@ -50,7 +45,7 @@ function headers() {
 }
 
 async function apiFetch(path: string, options?: RequestInit) {
-  const res = await fetch(`${BFF_API_URL}${path}`, {
+  const res = await fetch(`${BFF_BASE}${path}`, {
     ...options,
     headers: { ...headers(), ...(options?.headers || {}) },
   });
@@ -69,8 +64,8 @@ function loadWallet() {
     const wallet = JSON.parse(readFileSync(walletPath, "utf-8"));
     if (!wallet.privateKey) err("Wallet locked. Run: bun run wallet/wallet.ts unlock --password <password>");
     return wallet;
-  } catch (e) {
-    err("Could not load wallet. Run: bun run wallet/wallet.ts unlock");
+  } catch (e: any) {
+    err(`Could not load wallet: ${e.message}`);
   }
 }
 
@@ -78,11 +73,31 @@ function getSignedBinId(unsigned: number) {
   return unsigned - 500;
 }
 
+// ── Typed interfaces ───────────────────────────────────────────────────────────
+interface BinState {
+  is_active_bin: boolean;
+  bin_price: number;
+  reserve_x: number;
+  reserve_y: number;
+  bin_shares: number;
+  x_amount: number;
+  y_amount: number;
+}
+
+interface PoolFees {
+  x_protocol_fee: number;
+  x_provider_fee: number;
+  x_variable_fee: number;
+  y_protocol_fee: number;
+  y_provider_fee: number;
+  y_variable_fee: number;
+}
+
 // ── DLP calculation ────────────────────────────────────────────────────────────
-function calcMinDlp(bin: any, poolFees: any, slippage = 1) {
+function calcMinDlp(bin: BinState, poolFees: PoolFees, slippage = 1) {
   const { is_active_bin, bin_price, reserve_x, reserve_y, bin_shares, x_amount, y_amount } = bin;
-  const { x_protocol_fee = 0, x_provider_fee = 0, x_variable_fee = 0,
-          y_protocol_fee = 0, y_provider_fee = 0, y_variable_fee = 0 } = poolFees;
+  const { x_protocol_fee, x_provider_fee, x_variable_fee,
+          y_protocol_fee, y_provider_fee, y_variable_fee } = poolFees;
   const MIN_SHARES = 10000;
   const MIN_BURNT = 1000;
 
@@ -130,7 +145,7 @@ program.name("hodlmm").description("Bitflow HODLMM concentrated liquidity skill"
 // pools
 program.command("pools").description("List all available HODLMM pools").action(async () => {
   try {
-    const data = await apiFetch("/quotes/v1/pools");
+    const data = await apiFetch("/api/quotes/v1/pools");
     out({ success: true, ...data });
   } catch (e: any) { err(e.message); }
 });
@@ -138,7 +153,7 @@ program.command("pools").description("List all available HODLMM pools").action(a
 // pool
 program.command("pool <pool_id>").description("Get full pool data").action(async (pool_id) => {
   try {
-    const data = await apiFetch(`/app/v1/pools/${pool_id}`);
+    const data = await apiFetch(`/api/app/v1/pools/${pool_id}`);
     out({ success: true, pool_id, ...data });
   } catch (e: any) { err(e.message, { pool_id }); }
 });
@@ -146,7 +161,7 @@ program.command("pool <pool_id>").description("Get full pool data").action(async
 // pairs
 program.command("pairs").description("List all trading pairs").action(async () => {
   try {
-    const data = await apiFetch("/quotes/v1/pairs");
+    const data = await apiFetch("/api/quotes/v1/pairs");
     out({ success: true, ...data });
   } catch (e: any) { err(e.message); }
 });
@@ -154,7 +169,7 @@ program.command("pairs").description("List all trading pairs").action(async () =
 // tokens
 program.command("tokens").description("List all available tokens").action(async () => {
   try {
-    const data = await apiFetch("/quotes/v1/tokens");
+    const data = await apiFetch("/api/quotes/v1/tokens");
     out({ success: true, ...data });
   } catch (e: any) { err(e.message); }
 });
@@ -162,17 +177,15 @@ program.command("tokens").description("List all available tokens").action(async 
 // bins
 program.command("bins <pool_id>").description("Get all bins for a pool").action(async (pool_id) => {
   try {
-    const data = await apiFetch(`/quotes/v1/bins/${pool_id}`);
-    const binCount = data.bins?.length || 0;
-    const activeBin = data.active_bin_id;
-    out({ success: true, pool_id, active_bin: activeBin, bin_count: binCount, data });
+    const data = await apiFetch(`/api/quotes/v1/bins/${pool_id}`);
+    out({ success: true, pool_id, active_bin: data.active_bin_id, bin_count: data.bins?.length || 0, data });
   } catch (e: any) { err(e.message, { pool_id }); }
 });
 
 // bin-price-history
 program.command("bin-price-history <pool_id>").description("Get bin price history").action(async (pool_id) => {
   try {
-    const data = await apiFetch(`/app/v1/pools/${pool_id}/bin-price-history`);
+    const data = await apiFetch(`/api/app/v1/pools/${pool_id}/bin-price-history`);
     out({ success: true, pool_id, data });
   } catch (e: any) { err(e.message, { pool_id }); }
 });
@@ -183,12 +196,8 @@ program.command("position <pool_id>")
   .description("Get user liquidity position for a pool")
   .action(async (pool_id, opts) => {
     try {
-      let address = opts.address;
-      if (!address) {
-        const wallet = loadWallet();
-        address = wallet.stacksAddress;
-      }
-      const data = await apiFetch(`/app/v1/users/${address}/liquidity/${pool_id}`);
+      const address = opts.address || loadWallet().stacksAddress;
+      const data = await apiFetch(`/api/app/v1/users/${address}/liquidity/${pool_id}`);
       out({ success: true, pool_id, address, data });
     } catch (e: any) { err(e.message, { pool_id }); }
   });
@@ -199,12 +208,8 @@ program.command("position-bins <pool_id>")
   .description("Get user position bins for a pool")
   .action(async (pool_id, opts) => {
     try {
-      let address = opts.address;
-      if (!address) {
-        const wallet = loadWallet();
-        address = wallet.stacksAddress;
-      }
-      const data = await apiFetch(`/app/v1/users/${address}/positions/${pool_id}/bins`);
+      const address = opts.address || loadWallet().stacksAddress;
+      const data = await apiFetch(`/api/app/v1/users/${address}/positions/${pool_id}/bins`);
       out({ success: true, pool_id, address, data });
     } catch (e: any) { err(e.message, { pool_id }); }
   });
@@ -215,11 +220,10 @@ program.command("quote <input_token> <output_token> <amount>")
   .description("Get swap quote")
   .action(async (input_token, output_token, amount, opts) => {
     try {
-      const data = await apiFetch("/quotes/v1/quote/multi", {
+      const data = await apiFetch("/api/quotes/v1/quote/multi", {
         method: "POST",
         body: JSON.stringify({
-          input_token,
-          output_token,
+          input_token, output_token,
           amount_in: parseInt(amount),
           amm_strategy: "best",
           slippage_tolerance: parseFloat(opts.slippage),
@@ -237,9 +241,79 @@ program.command("health").description("Check HODLMM API health").action(async ()
   } catch (e: any) { err(e.message); }
 });
 
+// monitor
+program.command("monitor <pool_id>")
+  .option("--address <address>", "Stacks address (defaults to active wallet)")
+  .option("--range <bins>", "Dead bin threshold — bins away from active before flagging", "5")
+  .description("Monitor LP position health — returns hold | rebalance | check signal")
+  .action(async (pool_id, opts) => {
+    try {
+      const address = opts.address || loadWallet().stacksAddress;
+      const deadThreshold = parseInt(opts.range);
+
+      const [poolData, poolBins, userPositions] = await Promise.all([
+        apiFetch(`/api/app/v1/pools/${pool_id}`),
+        apiFetch(`/api/quotes/v1/bins/${pool_id}`),
+        apiFetch(`/api/app/v1/users/${address}/positions/${pool_id}/bins`).catch(() => ({ bins: [] })),
+      ]);
+
+      const activeBin: number = poolData.active_bin_id;
+      const binsWithLiq = (userPositions.bins || []).filter((b: any) => b.user_liquidity > 0);
+
+      if (binsWithLiq.length === 0) {
+        out({ success: true, pool_id, address, verdict: "no_position", message: "No active liquidity found in this pool." });
+        return;
+      }
+
+      const inRange: any[] = [];
+      const deadBins: any[] = [];
+
+      for (const bin of binsWithLiq) {
+        const distance = Math.abs(bin.bin_id - activeBin);
+        const poolBin = poolBins.bins.find((b: any) => b.bin_id === bin.bin_id);
+        const entry = {
+          bin_id: bin.bin_id,
+          distance_from_active: distance,
+          user_liquidity: bin.user_liquidity,
+          reserve_x: Number(poolBin?.reserve_x ?? 0),
+          reserve_y: Number(poolBin?.reserve_y ?? 0),
+          earning: distance <= deadThreshold,
+          side: bin.bin_id < activeBin ? "below (y-only)" : bin.bin_id > activeBin ? "above (x-only)" : "active",
+        };
+        if (distance <= deadThreshold) inRange.push(entry);
+        else deadBins.push(entry);
+      }
+
+      const totalLiq = binsWithLiq.reduce((s: number, b: any) => s + b.user_liquidity, 0);
+      const deadLiq = deadBins.reduce((s: number, b: any) => s + b.user_liquidity, 0);
+      const deadPct = Math.round((deadLiq / totalLiq) * 100);
+
+      let verdict: string;
+      let message: string;
+      if (deadBins.length === 0) {
+        verdict = "hold";
+        message = `All ${inRange.length} bin(s) within ${deadThreshold} of active bin ${activeBin}. Yield is flowing.`;
+      } else if (deadPct >= 50) {
+        verdict = "rebalance";
+        message = `${deadPct}% of liquidity in dead bins (>${deadThreshold} from active bin ${activeBin}). Move to active range to resume earning.`;
+      } else {
+        verdict = "check";
+        message = `${deadBins.length} dead bin(s) detected (${deadPct}% of liquidity). Monitor or rebalance if active bin continues moving.`;
+      }
+
+      out({
+        success: true, pool_id, address, verdict, message,
+        active_bin: activeBin, dead_threshold: deadThreshold,
+        summary: { total_bins: binsWithLiq.length, in_range_bins: inRange.length, dead_bins: deadBins.length, dead_liquidity_pct: deadPct },
+        in_range: inRange, dead: deadBins,
+      });
+    } catch (e: any) { err(e.message, { pool_id }); }
+  });
+
 // add-liquidity
 program.command("add-liquidity <pool_id> <bin_id> <x_amount> <y_amount>")
   .option("--slippage <slippage>", "Slippage tolerance %", "1")
+  .option("--fee <fee>", "Transaction fee in microSTX", "25000")
   .description("Add liquidity to a bin (simple/relative mode)")
   .action(async (pool_id, bin_id_str, x_amount_str, y_amount_str, opts) => {
     try {
@@ -248,11 +322,12 @@ program.command("add-liquidity <pool_id> <bin_id> <x_amount> <y_amount>")
       const x_amount = parseInt(x_amount_str);
       const y_amount = parseInt(y_amount_str);
       const slippage = parseFloat(opts.slippage);
+      const fee = parseInt(opts.fee);
 
       const [poolData, poolBins, userPositions] = await Promise.all([
-        apiFetch(`/quotes/v1/pools/${pool_id}`),
-        apiFetch(`/quotes/v1/bins/${pool_id}`),
-        apiFetch(`/app/v1/users/${wallet.stacksAddress}/positions/${pool_id}/bins`).catch(() => ({ bins: [] })),
+        apiFetch(`/api/app/v1/pools/${pool_id}`),
+        apiFetch(`/api/quotes/v1/bins/${pool_id}`),
+        apiFetch(`/api/app/v1/users/${wallet.stacksAddress}/positions/${pool_id}/bins`).catch(() => ({ bins: [] })),
       ]);
 
       const active_bin_id = poolData.active_bin_id;
@@ -260,23 +335,17 @@ program.command("add-liquidity <pool_id> <bin_id> <x_amount> <y_amount>")
       const pool_bin = poolBins.bins.find((b: any) => b.bin_id === bin_id);
       if (!pool_bin) err(`Bin ${bin_id} not found in pool`, { pool_id });
 
-      const userBinsMap = new Map((userPositions.bins || []).map((b: any) => [b.bin_id, b]));
-
-      const bin = {
+      const bin: BinState = {
         is_active_bin: bin_id === active_bin_id,
-        active_bin_offset: offset,
-        bin_id,
-        x_amount,
-        y_amount,
         bin_price: Number(pool_bin.price),
         reserve_x: Number(pool_bin.reserve_x),
         reserve_y: Number(pool_bin.reserve_y),
         bin_shares: Number(pool_bin.liquidity ?? 0),
-        user_liquidity: (userBinsMap.get(bin_id) as any)?.user_liquidity || 0,
-        has_ever_added_to_bin: userBinsMap.has(bin_id),
+        x_amount,
+        y_amount,
       };
 
-      const poolFees = {
+      const poolFees: PoolFees = {
         x_protocol_fee: poolData.x_protocol_fee || 0,
         x_provider_fee: poolData.x_provider_fee || 0,
         x_variable_fee: poolData.x_variable_fee || 0,
@@ -293,6 +362,8 @@ program.command("add-liquidity <pool_id> <bin_id> <x_amount> <y_amount>")
       const [poolAddr, poolName] = pool_id.split(".");
       const [xAddr, xName] = poolData.x_token.split(".");
       const [yAddr, yName] = poolData.y_token.split(".");
+      const xAsset = poolData.x_token_asset_name || xName;
+      const yAsset = poolData.y_token_asset_name || yName;
 
       const binPos = tupleCV({
         "active-bin-id-offset": intCV(offset),
@@ -312,14 +383,22 @@ program.command("add-liquidity <pool_id> <bin_id> <x_amount> <y_amount>")
           contractPrincipalCV(poolAddr, poolName),
           contractPrincipalCV(xAddr, xName),
           contractPrincipalCV(yAddr, yName),
-          // noneCV() for active_bin_tolerance
-          { type: 0x09 } as any,
+          noneCV(),
         ],
         senderKey: wallet.privateKey,
         network,
-        fee: 10000,
-        postConditions: [],
-        postConditionMode: PostConditionMode.Allow,
+        fee,
+        postConditions: [
+          makeStandardFungiblePostCondition(
+            wallet.stacksAddress, FungibleConditionCode.LessEqual, BigInt(x_amount),
+            { address: xAddr, contractName: xName, assetName: xAsset }
+          ),
+          makeStandardFungiblePostCondition(
+            wallet.stacksAddress, FungibleConditionCode.LessEqual, BigInt(y_amount),
+            { address: yAddr, contractName: yName, assetName: yAsset }
+          ),
+        ],
+        postConditionMode: PostConditionMode.Deny,
         anchorMode: AnchorMode.Any,
       });
 
@@ -331,17 +410,19 @@ program.command("add-liquidity <pool_id> <bin_id> <x_amount> <y_amount>")
 // withdraw-liquidity
 program.command("withdraw-liquidity <pool_id> <percentage>")
   .option("--slippage <slippage>", "Slippage tolerance %", "1")
+  .option("--fee <fee>", "Transaction fee in microSTX", "25000")
   .description("Withdraw percentage of all position bins (simple mode)")
   .action(async (pool_id, pct_str, opts) => {
     try {
       const wallet = loadWallet();
       const pct = parseFloat(pct_str);
       const slippage = parseFloat(opts.slippage);
+      const fee = parseInt(opts.fee);
       if (pct <= 0 || pct > 100) err("Percentage must be between 1 and 100");
 
       const [poolData, userPositions] = await Promise.all([
-        apiFetch(`/quotes/v1/pools/${pool_id}`),
-        apiFetch(`/app/v1/users/${wallet.stacksAddress}/positions/${pool_id}/bins`),
+        apiFetch(`/api/app/v1/pools/${pool_id}`),
+        apiFetch(`/api/app/v1/users/${wallet.stacksAddress}/positions/${pool_id}/bins`),
       ]);
 
       const activeBin = poolData.active_bin_id;
@@ -352,6 +433,8 @@ program.command("withdraw-liquidity <pool_id> <percentage>")
       const [poolAddr, poolName] = pool_id.split(".");
       const [xAddr, xName] = poolData.x_token.split(".");
       const [yAddr, yName] = poolData.y_token.split(".");
+      const xAsset = poolData.x_token_asset_name || xName;
+      const yAsset = poolData.y_token_asset_name || yName;
 
       let totalMinX = 0, totalMinY = 0;
       const positions = binsWithLiq.map((bin: any) => {
@@ -384,9 +467,18 @@ program.command("withdraw-liquidity <pool_id> <percentage>")
         ],
         senderKey: wallet.privateKey,
         network,
-        fee: 10000,
-        postConditions: [],
-        postConditionMode: PostConditionMode.Allow,
+        fee,
+        postConditions: [
+          makeContractFungiblePostCondition(
+            poolAddr, poolName, FungibleConditionCode.GreaterEqual, BigInt(totalMinX),
+            { address: xAddr, contractName: xName, assetName: xAsset }
+          ),
+          makeContractFungiblePostCondition(
+            poolAddr, poolName, FungibleConditionCode.GreaterEqual, BigInt(totalMinY),
+            { address: yAddr, contractName: yName, assetName: yAsset }
+          ),
+        ],
+        postConditionMode: PostConditionMode.Deny,
         anchorMode: AnchorMode.Any,
       });
 
@@ -398,6 +490,7 @@ program.command("withdraw-liquidity <pool_id> <percentage>")
 // move-liquidity
 program.command("move-liquidity <pool_id> <from_bin_id> <to_bin_offset> <amount>")
   .option("--slippage <slippage>", "Slippage tolerance %", "1")
+  .option("--fee <fee>", "Transaction fee in microSTX", "25000")
   .description("Move liquidity from a bin to offset relative to active bin")
   .action(async (pool_id, from_str, offset_str, amount_str, opts) => {
     try {
@@ -406,11 +499,12 @@ program.command("move-liquidity <pool_id> <from_bin_id> <to_bin_offset> <amount>
       const to_offset = parseInt(offset_str);
       const amount = parseInt(amount_str);
       const slippage = parseFloat(opts.slippage);
+      const fee = parseInt(opts.fee);
 
       const [poolData, poolBins, userPositions] = await Promise.all([
-        apiFetch(`/quotes/v1/pools/${pool_id}`),
-        apiFetch(`/quotes/v1/bins/${pool_id}`),
-        apiFetch(`/app/v1/users/${wallet.stacksAddress}/positions/${pool_id}/bins`),
+        apiFetch(`/api/app/v1/pools/${pool_id}`),
+        apiFetch(`/api/quotes/v1/bins/${pool_id}`),
+        apiFetch(`/api/app/v1/users/${wallet.stacksAddress}/positions/${pool_id}/bins`),
       ]);
 
       const activeBin = poolData.active_bin_id;
@@ -426,19 +520,17 @@ program.command("move-liquidity <pool_id> <from_bin_id> <to_bin_offset> <amount>
       const xAmt = Math.floor((amount * fromBin.reserve_x) / fromBin.liquidity);
       const yAmt = Math.floor((amount * fromBin.reserve_y) / fromBin.liquidity);
 
-      const moveBin = {
+      const moveBin: BinState = {
         is_active_bin: toBinId === activeBin,
-        active_bin_offset: to_offset,
-        bin_id: toBinId,
-        x_amount: xAmt,
-        y_amount: yAmt,
         bin_price: Number(toBin.price),
         reserve_x: Number(toBin.reserve_x),
         reserve_y: Number(toBin.reserve_y),
         bin_shares: Number(toBin.liquidity ?? 0),
+        x_amount: xAmt,
+        y_amount: yAmt,
       };
 
-      const poolFees = {
+      const poolFees: PoolFees = {
         x_protocol_fee: poolData.x_protocol_fee || 0,
         x_provider_fee: poolData.x_provider_fee || 0,
         x_variable_fee: poolData.x_variable_fee || 0,
@@ -475,7 +567,7 @@ program.command("move-liquidity <pool_id> <from_bin_id> <to_bin_offset> <amount>
         functionArgs: [listCV([movePos])],
         senderKey: wallet.privateKey,
         network,
-        fee: 10000,
+        fee,
         postConditions: [],
         postConditionMode: PostConditionMode.Allow,
         anchorMode: AnchorMode.Any,
@@ -483,100 +575,6 @@ program.command("move-liquidity <pool_id> <from_bin_id> <to_bin_offset> <amount>
 
       const result = await broadcastTransaction(tx, network);
       out({ success: true, txid: result.txid, pool_id, from_bin_id, to_bin_id: toBinId, amount });
-    } catch (e: any) { err(e.message, { pool_id }); }
-  });
-
-// monitor
-program.command("monitor <pool_id>")
-  .option("--address <address>", "Stacks address (defaults to active wallet)")
-  .option("--range <bins>", "Dead bin threshold — bins away from active before flagging", "5")
-  .description("Monitor LP position health — returns hold | rebalance | check signal")
-  .action(async (pool_id, opts) => {
-    try {
-      let address = opts.address;
-      if (!address) {
-        const wallet = loadWallet();
-        address = wallet.stacksAddress;
-      }
-      const deadThreshold = parseInt(opts.range);
-
-      const [poolData, poolBins, userPositions] = await Promise.all([
-        apiFetch(`/app/v1/pools/${pool_id}`),
-        apiFetch(`/quotes/v1/bins/${pool_id}`),
-        apiFetch(`/app/v1/users/${address}/positions/${pool_id}/bins`).catch(() => ({ bins: [] })),
-      ]);
-
-      const activeBin: number = poolData.active_bin_id;
-      const bins: any[] = userPositions.bins || [];
-      const binsWithLiq = bins.filter((b: any) => b.user_liquidity > 0);
-
-      if (binsWithLiq.length === 0) {
-        out({ success: true, pool_id, address, verdict: "no_position", message: "No active liquidity found in this pool." });
-        return;
-      }
-
-      // Classify bins
-      const inRange: any[] = [];
-      const deadBins: any[] = [];
-
-      for (const bin of binsWithLiq) {
-        const distance = Math.abs(bin.bin_id - activeBin);
-        const poolBin = poolBins.bins.find((b: any) => b.bin_id === bin.bin_id);
-        const reserveX = Number(poolBin?.reserve_x ?? 0);
-        const reserveY = Number(poolBin?.reserve_y ?? 0);
-        const earning = distance <= deadThreshold;
-
-        const entry = {
-          bin_id: bin.bin_id,
-          distance_from_active: distance,
-          user_liquidity: bin.user_liquidity,
-          reserve_x: reserveX,
-          reserve_y: reserveY,
-          earning,
-          side: bin.bin_id < activeBin ? "below (y-only)" : bin.bin_id > activeBin ? "above (x-only)" : "active",
-        };
-
-        if (earning) inRange.push(entry);
-        else deadBins.push(entry);
-      }
-
-      // Total value estimate
-      const totalUserLiq = binsWithLiq.reduce((s: number, b: any) => s + b.user_liquidity, 0);
-      const deadLiq = deadBins.reduce((s: number, b: any) => s + b.user_liquidity, 0);
-      const deadPct = Math.round((deadLiq / totalUserLiq) * 100);
-
-      // Verdict
-      let verdict: string;
-      let message: string;
-
-      if (deadBins.length === 0) {
-        verdict = "hold";
-        message = `All ${inRange.length} bin(s) are within ${deadThreshold} of active bin ${activeBin}. Yield is flowing.`;
-      } else if (deadPct >= 50) {
-        verdict = "rebalance";
-        message = `${deadPct}% of your liquidity is in dead bins (>${deadThreshold} from active bin ${activeBin}). Move to active range to resume earning.`;
-      } else {
-        verdict = "check";
-        message = `${deadBins.length} dead bin(s) detected (${deadPct}% of liquidity). Monitor closely or rebalance if active bin continues moving.`;
-      }
-
-      out({
-        success: true,
-        pool_id,
-        address,
-        verdict,
-        message,
-        active_bin: activeBin,
-        dead_threshold: deadThreshold,
-        summary: {
-          total_bins: binsWithLiq.length,
-          in_range_bins: inRange.length,
-          dead_bins: deadBins.length,
-          dead_liquidity_pct: deadPct,
-        },
-        in_range: inRange,
-        dead: deadBins,
-      });
     } catch (e: any) { err(e.message, { pool_id }); }
   });
 

--- a/hodlmm/hodlmm.ts
+++ b/hodlmm/hodlmm.ts
@@ -486,4 +486,98 @@ program.command("move-liquidity <pool_id> <from_bin_id> <to_bin_offset> <amount>
     } catch (e: any) { err(e.message, { pool_id }); }
   });
 
+// monitor
+program.command("monitor <pool_id>")
+  .option("--address <address>", "Stacks address (defaults to active wallet)")
+  .option("--range <bins>", "Dead bin threshold — bins away from active before flagging", "5")
+  .description("Monitor LP position health — returns hold | rebalance | check signal")
+  .action(async (pool_id, opts) => {
+    try {
+      let address = opts.address;
+      if (!address) {
+        const wallet = loadWallet();
+        address = wallet.stacksAddress;
+      }
+      const deadThreshold = parseInt(opts.range);
+
+      const [poolData, poolBins, userPositions] = await Promise.all([
+        apiFetch(`/app/v1/pools/${pool_id}`),
+        apiFetch(`/quotes/v1/bins/${pool_id}`),
+        apiFetch(`/app/v1/users/${address}/positions/${pool_id}/bins`).catch(() => ({ bins: [] })),
+      ]);
+
+      const activeBin: number = poolData.active_bin_id;
+      const bins: any[] = userPositions.bins || [];
+      const binsWithLiq = bins.filter((b: any) => b.user_liquidity > 0);
+
+      if (binsWithLiq.length === 0) {
+        out({ success: true, pool_id, address, verdict: "no_position", message: "No active liquidity found in this pool." });
+        return;
+      }
+
+      // Classify bins
+      const inRange: any[] = [];
+      const deadBins: any[] = [];
+
+      for (const bin of binsWithLiq) {
+        const distance = Math.abs(bin.bin_id - activeBin);
+        const poolBin = poolBins.bins.find((b: any) => b.bin_id === bin.bin_id);
+        const reserveX = Number(poolBin?.reserve_x ?? 0);
+        const reserveY = Number(poolBin?.reserve_y ?? 0);
+        const earning = distance <= deadThreshold;
+
+        const entry = {
+          bin_id: bin.bin_id,
+          distance_from_active: distance,
+          user_liquidity: bin.user_liquidity,
+          reserve_x: reserveX,
+          reserve_y: reserveY,
+          earning,
+          side: bin.bin_id < activeBin ? "below (y-only)" : bin.bin_id > activeBin ? "above (x-only)" : "active",
+        };
+
+        if (earning) inRange.push(entry);
+        else deadBins.push(entry);
+      }
+
+      // Total value estimate
+      const totalUserLiq = binsWithLiq.reduce((s: number, b: any) => s + b.user_liquidity, 0);
+      const deadLiq = deadBins.reduce((s: number, b: any) => s + b.user_liquidity, 0);
+      const deadPct = Math.round((deadLiq / totalUserLiq) * 100);
+
+      // Verdict
+      let verdict: string;
+      let message: string;
+
+      if (deadBins.length === 0) {
+        verdict = "hold";
+        message = `All ${inRange.length} bin(s) are within ${deadThreshold} of active bin ${activeBin}. Yield is flowing.`;
+      } else if (deadPct >= 50) {
+        verdict = "rebalance";
+        message = `${deadPct}% of your liquidity is in dead bins (>${deadThreshold} from active bin ${activeBin}). Move to active range to resume earning.`;
+      } else {
+        verdict = "check";
+        message = `${deadBins.length} dead bin(s) detected (${deadPct}% of liquidity). Monitor closely or rebalance if active bin continues moving.`;
+      }
+
+      out({
+        success: true,
+        pool_id,
+        address,
+        verdict,
+        message,
+        active_bin: activeBin,
+        dead_threshold: deadThreshold,
+        summary: {
+          total_bins: binsWithLiq.length,
+          in_range_bins: inRange.length,
+          dead_bins: deadBins.length,
+          dead_liquidity_pct: deadPct,
+        },
+        in_range: inRange,
+        dead: deadBins,
+      });
+    } catch (e: any) { err(e.message, { pool_id }); }
+  });
+
 program.parse();


### PR DESCRIPTION
Adds a new `hodlmm` skill for Bitflow's HODLMM concentrated liquidity engine on Stacks.

Submitted for the Bitflow DeFi Skills Competition ($100/day + $1,000 HODLMM bonus).

## What it does
- Query pools, pairs, tokens, bins, price history
- Check user positions and position bins
- Get swap quotes
- Add, withdraw, and move liquidity (simple/relative mode)
- API health monitoring

Built directly from Bitflow's official HODLMM API docs.