### PR TITLE
feat: add hodlmm-pulse (BFF Skills Comp Day 6 winner by @ghislo749)

### DIFF
--- a/hodlmm-pulse/AGENT.md
+++ b/hodlmm-pulse/AGENT.md
@@ -1,0 +1,72 @@
+---
+name: hodlmm-pulse-agent
+skill: hodlmm-pulse
+description: "Autonomous fee velocity monitor for Bitflow HODLMM pools. Detects entry windows via momentum signals and trend direction. Read-only — no funds moved, no transactions submitted."
+---
+
+# Agent Behavior — HODLMM Pulse
+
+## Decision order
+
+1. Run `doctor` first. If any check fails, surface the connectivity issue and stop.
+2. Run `scan` for a fast cross-pool triage. If all signals are `normal`, `cooling`, or `flat` — do nothing.
+3. If `scan` surfaces a `spike` or `elevated` pool, begin `track` polling on that pool (every 5 minutes).
+4. After ≥ 3 `track` snapshots confirm the signal is `accelerating` or `stable`, escalate to `hodlmm-advisor entry-plan`.
+5. Only recommend execution when **both** pulse signal is `spike`/`elevated` AND advisor verdict is `"Deploy now"`.
+6. Run `report` periodically to monitor all tracked pools and detect when windows close.
+
+## Guardrails
+
+- **Never act on a single snapshot.** A single `scan` spike could be a data artefact. Confirm with ≥ 2 `track` polls before escalating.
+- **Never recommend entry when signal is `cooling` or `flat`.** Even if APR looks attractive, declining fee velocity means the window is closing.
+- **Never skip the advisor step.** Pulse tells you *when*; advisor tells you *where and how*. Both are required.
+- **Never spend funds autonomously.** This skill is advisory only. All execution (via `bitflow add-liquidity-simple`) requires explicit human confirmation.
+- **Use `--min-tvl 10000`** for real deployments — low-TVL pools have noisy metrics and thin exit liquidity.
+
+## Polling cadence
+
+| Phase | Action | Frequency |
+|---|---|---|
+| Idle | `scan --min-tvl 10000` | Every 15–30 min |
+| Alert detected | `track --pool-id <id>` | Every 5 min |
+| Window confirmed | Escalate to `hodlmm-advisor entry-plan` | Once |
+| Position open | `hodlmm-pulse track` + `hodlmm-advisor pool-summary` | Every 10 min |
+| Signal cools | Exit via human-approved `bitflow withdraw-liquidity-simple` | Once |
+
+## Signal → action mapping
+
+| Signal | Trend | Action |
+|---|---|---|
+| 🔥 spike | ⬆️ accelerating | **Alert user immediately. Run advisor entry-plan. Await approval.** |
+| 🔥 spike | ↔️ stable | Alert user. Run advisor. Note window may be peaking. |
+| 🔥 spike | ⬇️ cooling | Warn: spike is fading. Do not enter — window likely closing. |
+| 📈 elevated | ⬆️ accelerating | Begin track polling. Prepare entry-plan for next confirmation. |
+| 📈 elevated | ↔️ stable | Monitor. Alert if fee velocity breaks into spike territory. |
+| 〰️ normal | any | No action. Continue idle polling. |
+| 📉 cooling | any | No entry. Exit any open position if regime also degrading. |
+| ⬜ flat | any | Skip. Pool inactive. |
+
+## On error
+
+- Log the full `{ "error": "..." }` payload
+- Do not retry silently — surface the error with the endpoint that failed
+- If `doctor` reports API failure, pause all polling and alert user
+- If state file is unreadable, treat all pools as `new` (insufficient data) and do not escalate
+
+## On success
+
+- For `scan`: present signal summary; highlight `spike`/`elevated` pools by name
+- For `track`: always show trend direction and delta values; flag if trend changed since last poll
+- For `report`: surface any pools with `spike` or `elevated` signals at top; present `overallTrend` for each
+
+## Integration chain
+
+```
+hodlmm-pulse scan         → triage: which pool is heating up?
+hodlmm-pulse track        → confirm: is momentum accelerating or fading?
+hodlmm-advisor entry-plan → plan: bins, strategy, capital split
+bitflow add-liquidity-simple → execute (human approval required)
+hodlmm-pulse track        → monitor: is the window still open?
+hodlmm-advisor pool-summary → regime check: is risk still acceptable?
+bitflow withdraw-liquidity-simple → exit (human approval required)
+```

--- a/hodlmm-pulse/SKILL.md
+++ b/hodlmm-pulse/SKILL.md
@@ -1,0 +1,181 @@
+---
+name: hodlmm-pulse
+description: "Fee velocity and volume momentum tracker for Bitflow HODLMM pools — detects entry windows by comparing today's fee capture against the 7-day baseline, building a local time-series to surface trend direction (accelerating, stable, cooling)."
+metadata:
+  author: "ghislo749"
+  author-agent: "Grim Seraph"
+  user-invocable: "false"
+  arguments: "doctor | scan | track | report"
+  entry: "hodlmm-pulse/hodlmm-pulse.ts"
+  requires: ""
+  tags: "defi, read-only, mainnet-only, l2, infrastructure"
+---
+
+# HODLMM Pulse
+
+Fee velocity and volume momentum tracker for Bitflow HODLMM (DLMM) concentrated liquidity pools.
+
+## What it does
+
+Answers the question **"is now a good time to deploy liquidity?"** by tracking *how fast* fees are being generated relative to the 7-day rolling baseline. A pool earning 3× its daily average in fees is in an active volume spike — the prime window to enter, capture fees, and exit before volume normalises.
+
+Two modes of operation:
+
+1. **Single-shot** (`scan`) — instant momentum ranking across all pools from a single API call. Useful for quick triage.
+2. **Time-series** (`track` + `report`) — run `track` on a cron (e.g. every 5 min) to build a local snapshot history. The more data collected, the more accurate the trend direction (accelerating / stable / cooling). `report` surfaces the full picture.
+
+## Why agents need it
+
+`hodlmm-advisor` tells you *where* to deploy (which pool has the best risk-adjusted yield). `hodlmm-pulse` tells you *when* — detecting fee spikes and volume acceleration before they appear in slow-moving APR averages. Together they form a complete LP entry decision loop:
+
+1. `hodlmm-pulse scan` → identify pools with active momentum
+2. `hodlmm-pulse track --pool-id <id>` → confirm trend direction over multiple polls
+3. `hodlmm-advisor entry-plan --pool-id <id>` → get exact bin range + strategy
+4. Execute only when both pulse signal is `spike`/`elevated` and advisor returns `"Deploy now"`
+
+## Safety notes
+
+- **Read-only** — never submits transactions or moves funds
+- **No wallet required** — safe to call from any agent without authentication
+- **Mainnet-only** — Bitflow HODLMM API is mainnet-only
+- State file written to `~/.hodlmm-pulse-state.json` (local disk only, no network writes)
+- Rolling window: last 288 snapshots per pool (~24h at 5-min polling intervals)
+
+## Commands
+
+### doctor
+
+Checks all data sources and state file readiness.
+
+```bash
+bun run hodlmm-pulse/hodlmm-pulse.ts doctor
+```
+
+### scan
+
+Fetches all pools in one call, computes momentum scores, ranks by fee velocity. Use for quick triage without needing prior tracking history.
+
+```bash
+bun run hodlmm-pulse/hodlmm-pulse.ts scan
+bun run hodlmm-pulse/hodlmm-pulse.ts scan --min-tvl 10000
+```
+
+Options:
+- `--min-tvl <usd>` — exclude pools below this TVL (default: 500)
+
+### track
+
+Appends a timestamped snapshot for a single pool to local state, then outputs the current signal and trend direction. Trend accuracy improves with each successive call.
+
+```bash
+bun run hodlmm-pulse/hodlmm-pulse.ts track --pool-id dlmm_1
+```
+
+Options:
+- `--pool-id` (required) — pool identifier (e.g. `dlmm_1`, `dlmm_3`)
+
+Recommended: run via cron every 5 minutes for each pool of interest.
+
+### report
+
+Reads all stored snapshots and outputs a trend summary per pool: current signal, trend over the full tracking window, peak momentum seen. Prioritises pools with active signals at the top.
+
+```bash
+bun run hodlmm-pulse/hodlmm-pulse.ts report
+bun run hodlmm-pulse/hodlmm-pulse.ts report --pool-id dlmm_1
+```
+
+Options:
+- `--pool-id` (optional) — limit output to one pool
+
+## Momentum model
+
+### Fee velocity
+
+Primary signal. Ratio of today's fees to the 7-day daily average:
+
+```
+feeVelocity = feesUsd1d / (feesUsd7d / 7)
+```
+
+`1.0` = average day. `3.0` = earning 3× the daily average.
+
+### Volume velocity
+
+Secondary signal. Same ratio applied to volume:
+
+```
+volumeVelocity = volumeUsd1d / (volumeUsd7d / 7)
+```
+
+### APR spike ratio
+
+Tertiary signal. How much today's realized APR exceeds the long-run average:
+
+```
+aprSpike = apr24h / apr
+```
+
+### Momentum score (composite, weighted)
+
+```
+momentumScore = feeVelocity × 0.6 × 50 + volumeVelocity × 0.3 × 50 + aprSpike × 0.1 × 50
+```
+
+`50` = average day. Higher = more active than usual.
+
+### Signal thresholds
+
+| Signal | Condition | Meaning |
+|---|---|---|
+| `🔥 spike` | feeVelocity ≥ 3× | Exceptional activity — prime entry window |
+| `📈 elevated` | feeVelocity ≥ 1.5× | Above average — monitor closely |
+| `〰️ normal` | 0.5× ≤ feeVelocity < 1.5× | Within baseline — no special action |
+| `📉 cooling` | feeVelocity < 0.5× | Below baseline — not an entry window |
+| `⬜ flat` | Fees + volume near zero | Inactive pool — skip |
+
+### Trend direction (time-series only)
+
+| Trend | Meaning |
+|---|---|
+| `⬆️ accelerating` | Fee velocity rising across recent snapshots |
+| `↔️ stable` | Fee velocity flat — activity sustained |
+| `⬇️ cooling` | Fee velocity declining — window closing |
+| `🆕 new` | Insufficient history (< 2 snapshots) |
+| `— flat` | Pool is inactive |
+
+## Output contract
+
+All outputs are JSON to stdout.
+
+**Success:**
+```json
+{ "status": "success", "network": "mainnet", "timestamp": "...", ... }
+```
+
+**Error:**
+```json
+{ "error": "descriptive message" }
+```
+
+## Data sources
+
+| Source | Data | Endpoint |
+|---|---|---|
+| Bitflow App API (pools list) | All pools: feesUsd1d, feesUsd7d, volumeUsd1d, volumeUsd7d, apr, apr24h, tvlUsd | `bff.bitflowapis.finance/api/app/v1/pools` |
+| Bitflow App API (pool detail) | Single pool detail (used by `track`) | `bff.bitflowapis.finance/api/app/v1/pools/{id}` |
+| Bitflow Quotes API | Pool list sanity check | `bff.bitflowapis.finance/api/quotes/v1/pools` |
+| Local state file | Snapshot history for trend computation | `~/.hodlmm-pulse-state.json` |
+
+## Known constraints
+
+- `feesUsd1d` and `volumeUsd1d` are 24h rolling windows from Bitflow's API — they update in near-real-time but are not per-minute granularity
+- Trend direction requires at least 2 snapshots; `spike` signal is actionable from a single `scan`
+- State file is local to the machine — tracking history does not persist across machines
+- Low-TVL pools (< $500) are filtered by default; their fee metrics are noisy
+
+## Origin
+
+Winner of AIBTC x Bitflow Skills Pay the Bills competition.
+Original author: @ghislo749
+Competition PR: https://github.com/BitflowFinance/bff-skills/pull/94

--- a/hodlmm-pulse/hodlmm-pulse.ts
+++ b/hodlmm-pulse/hodlmm-pulse.ts
@@ -1,0 +1,721 @@
+#!/usr/bin/env bun
+/**
+ * hodlmm-pulse — Fee velocity & volume momentum tracker for Bitflow HODLMM pools.
+ *
+ * Detects fee spikes and volume acceleration by comparing today's activity
+ * against the 7-day rolling baseline. Builds a local time-series via `track`
+ * so trend direction (accelerating / stable / cooling) improves with each poll.
+ *
+ * The natural complement to hodlmm-advisor: advisor answers "where", pulse
+ * answers "when". Use pulse to detect entry windows; advisor to plan the trade.
+ *
+ * Usage:
+ *   bun run skills/hodlmm-pulse/hodlmm-pulse.ts doctor
+ *   bun run skills/hodlmm-pulse/hodlmm-pulse.ts scan [--min-tvl 1000]
+ *   bun run skills/hodlmm-pulse/hodlmm-pulse.ts track --pool-id dlmm_1
+ *   bun run skills/hodlmm-pulse/hodlmm-pulse.ts report [--pool-id dlmm_1]
+ */
+
+import { Command } from "commander";
+import { homedir } from "os";
+import { join } from "path";
+import { readFileSync, writeFileSync, existsSync } from "fs";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const BITFLOW_APP_API = "https://bff.bitflowapis.finance/api/app/v1";
+const BITFLOW_QUOTES_API = "https://bff.bitflowapis.finance/api/quotes/v1";
+const FETCH_TIMEOUT_MS = 30_000;
+const NETWORK = "mainnet";
+const STATE_FILE = join(homedir(), ".hodlmm-pulse-state.json");
+const STATE_VERSION = 1;
+
+/** How many snapshots to keep per pool (last 288 = 24h at 5-min intervals) */
+const MAX_SNAPSHOTS_PER_POOL = 288;
+
+/** Momentum thresholds: ratio of today's activity vs 7-day daily average */
+const THRESHOLD_SPIKE = 3.0;      // 3x average → spike
+const THRESHOLD_ELEVATED = 1.5;   // 1.5x → elevated
+const THRESHOLD_COOLING = 0.5;    // below 0.5x → cooling
+const MIN_BASELINE_USD = 0.01;    // avoid div/0 on brand-new pools
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface AppPool {
+  poolId: string;
+  tvlUsd: number;
+  volumeUsd1d: number;
+  volumeUsd7d: number;
+  feesUsd1d: number;
+  feesUsd7d: number;
+  apr: number;
+  apr24h: number;
+  tokens: {
+    tokenX: { symbol: string; priceUsd: number; decimals: number };
+    tokenY: { symbol: string; priceUsd: number; decimals: number };
+  };
+}
+
+interface AppPoolsResponse {
+  data: AppPool[];
+  nextCursor?: string;
+  hasMore?: boolean;
+}
+
+type MomentumSignal = "spike" | "elevated" | "normal" | "cooling" | "flat";
+type TrendDirection = "accelerating" | "stable" | "cooling" | "new" | "flat";
+
+interface MomentumMetrics {
+  feeVelocity: number;      // feesUsd1d / (feesUsd7d / 7) — 1.0 = average day
+  volumeVelocity: number;   // volumeUsd1d / (volumeUsd7d / 7)
+  aprSpike: number;         // apr24h / max(apr, 0.01) — recent vs long-run APR
+  momentumScore: number;    // weighted composite 0–100+
+  signal: MomentumSignal;
+}
+
+interface PulseSnapshot {
+  ts: string;
+  aprFull: number;
+  apr24h: number;
+  feesUsd1d: number;
+  feesUsd7d: number;
+  volumeUsd1d: number;
+  volumeUsd7d: number;
+  tvlUsd: number;
+  metrics: MomentumMetrics;
+  trend: TrendDirection;
+  deltaFeeVelocity: number | null;   // change from previous snapshot
+  deltaApr24h: number | null;
+}
+
+interface PulseState {
+  version: number;
+  pools: Record<string, PulseSnapshot[]>;
+}
+
+// ---------------------------------------------------------------------------
+// Output helpers
+// ---------------------------------------------------------------------------
+
+function out(data: Record<string, unknown>): void {
+  console.log(JSON.stringify(data, null, 2));
+}
+
+function fail(error: unknown): never {
+  const message = error instanceof Error ? error.message : String(error);
+  console.log(JSON.stringify({ error: message }, null, 2));
+  process.exit(1);
+}
+
+// ---------------------------------------------------------------------------
+// API helpers
+// ---------------------------------------------------------------------------
+
+async function fetchJson<T>(url: string): Promise<T> {
+  const res = await fetch(url, {
+    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    headers: { Accept: "application/json" },
+  });
+  if (!res.ok) throw new Error(`HTTP ${res.status} ${res.statusText}: ${url}`);
+  return res.json() as Promise<T>;
+}
+
+async function getAllPools(): Promise<AppPool[]> {
+  const data = await fetchJson<AppPoolsResponse>(`${BITFLOW_APP_API}/pools`);
+  return data.data ?? [];
+}
+
+async function getPool(poolId: string): Promise<AppPool> {
+  return fetchJson<AppPool>(`${BITFLOW_APP_API}/pools/${poolId}`);
+}
+
+// ---------------------------------------------------------------------------
+// Momentum computation
+// ---------------------------------------------------------------------------
+
+function computeMomentum(pool: AppPool): MomentumMetrics {
+  const dailyAvgFees = pool.feesUsd7d / 7;
+  const dailyAvgVol = pool.volumeUsd7d / 7;
+
+  const feeVelocity = pool.feesUsd1d / Math.max(dailyAvgFees, MIN_BASELINE_USD);
+  const volumeVelocity = pool.volumeUsd1d / Math.max(dailyAvgVol, MIN_BASELINE_USD);
+  const aprSpike = pool.apr24h / Math.max(pool.apr, MIN_BASELINE_USD);
+
+  // Momentum score: fee velocity is the primary signal (60%),
+  // volume velocity secondary (30%), apr spike tertiary (10%).
+  // Anchored to 1.0 = average day → score 50.
+  const momentumScore =
+    feeVelocity * 0.6 * 50 +
+    volumeVelocity * 0.3 * 50 +
+    aprSpike * 0.1 * 50;
+
+  let signal: MomentumSignal;
+  if (pool.feesUsd1d < 0.01 && pool.volumeUsd1d < 0.01) {
+    signal = "flat";
+  } else if (feeVelocity >= THRESHOLD_SPIKE) {
+    signal = "spike";
+  } else if (feeVelocity >= THRESHOLD_ELEVATED) {
+    signal = "elevated";
+  } else if (feeVelocity < THRESHOLD_COOLING) {
+    signal = "cooling";
+  } else {
+    signal = "normal";
+  }
+
+  return {
+    feeVelocity: round(feeVelocity, 3),
+    volumeVelocity: round(volumeVelocity, 3),
+    aprSpike: round(aprSpike, 3),
+    momentumScore: round(momentumScore, 1),
+    signal,
+  };
+}
+
+function round(n: number, decimals: number): number {
+  const f = 10 ** decimals;
+  return Math.round(n * f) / f;
+}
+
+// ---------------------------------------------------------------------------
+// Trend from snapshot history
+// ---------------------------------------------------------------------------
+
+function computeTrend(
+  snapshots: PulseSnapshot[],
+  current: MomentumMetrics
+): TrendDirection {
+  if (snapshots.length < 2) return "new";
+
+  // Compare current feeVelocity to the last 3 snapshots
+  const recent = snapshots.slice(-3).map((s) => s.metrics.feeVelocity);
+  const allIncreasing = recent.every((v, i) =>
+    i === 0 ? true : v >= recent[i - 1]!
+  );
+  const allDecreasing = recent.every((v, i) =>
+    i === 0 ? true : v <= recent[i - 1]!
+  );
+
+  if (current.signal === "flat") return "flat";
+  if (allIncreasing && current.metrics) return "accelerating";
+  if (allDecreasing) return "cooling";
+  return "stable";
+}
+
+function computeTrendFromHistory(
+  history: PulseSnapshot[],
+  current: MomentumMetrics
+): TrendDirection {
+  if (history.length === 0) return "new";
+  if (history.length < 2) {
+    // One prior snapshot: simple delta
+    const prev = history[history.length - 1]!.metrics.feeVelocity;
+    if (current.feeVelocity > prev * 1.1) return "accelerating";
+    if (current.feeVelocity < prev * 0.9) return "cooling";
+    return "stable";
+  }
+
+  const recent = history.slice(-3).map((s) => s.metrics.feeVelocity);
+  recent.push(current.feeVelocity);
+
+  const deltas = recent.slice(1).map((v, i) => v - recent[i]!);
+  const avgDelta = deltas.reduce((a, b) => a + b, 0) / deltas.length;
+
+  if (current.signal === "flat") return "flat";
+  if (avgDelta > 0.1) return "accelerating";
+  if (avgDelta < -0.1) return "cooling";
+  return "stable";
+}
+
+// ---------------------------------------------------------------------------
+// State helpers
+// ---------------------------------------------------------------------------
+
+function loadState(): PulseState {
+  if (!existsSync(STATE_FILE)) {
+    return { version: STATE_VERSION, pools: {} };
+  }
+  try {
+    const raw = readFileSync(STATE_FILE, "utf8");
+    const parsed = JSON.parse(raw) as PulseState;
+    if (parsed.version !== STATE_VERSION) {
+      return { version: STATE_VERSION, pools: {} };
+    }
+    return parsed;
+  } catch {
+    return { version: STATE_VERSION, pools: {} };
+  }
+}
+
+function saveState(state: PulseState): void {
+  writeFileSync(STATE_FILE, JSON.stringify(state, null, 2), "utf8");
+}
+
+function appendSnapshot(
+  state: PulseState,
+  poolId: string,
+  snapshot: PulseSnapshot
+): void {
+  if (!state.pools[poolId]) state.pools[poolId] = [];
+  state.pools[poolId]!.push(snapshot);
+  // Trim to rolling window
+  if (state.pools[poolId]!.length > MAX_SNAPSHOTS_PER_POOL) {
+    state.pools[poolId] = state.pools[poolId]!.slice(-MAX_SNAPSHOTS_PER_POOL);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Snapshot factory
+// ---------------------------------------------------------------------------
+
+function buildSnapshot(pool: AppPool, history: PulseSnapshot[]): PulseSnapshot {
+  const metrics = computeMomentum(pool);
+  const trend = computeTrendFromHistory(history, metrics);
+  const prev = history.length > 0 ? history[history.length - 1]! : null;
+
+  return {
+    ts: new Date().toISOString(),
+    aprFull: pool.apr,
+    apr24h: pool.apr24h,
+    feesUsd1d: pool.feesUsd1d,
+    feesUsd7d: pool.feesUsd7d,
+    volumeUsd1d: pool.volumeUsd1d,
+    volumeUsd7d: pool.volumeUsd7d,
+    tvlUsd: pool.tvlUsd,
+    metrics,
+    trend,
+    deltaFeeVelocity: prev
+      ? round(metrics.feeVelocity - prev.metrics.feeVelocity, 3)
+      : null,
+    deltaApr24h: prev ? round(pool.apr24h - prev.apr24h, 2) : null,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Signal emoji & action text
+// ---------------------------------------------------------------------------
+
+function signalEmoji(signal: MomentumSignal): string {
+  return {
+    spike: "🔥",
+    elevated: "📈",
+    normal: "〰️",
+    cooling: "📉",
+    flat: "⬜",
+  }[signal];
+}
+
+function trendEmoji(trend: TrendDirection): string {
+  return {
+    accelerating: "⬆️",
+    stable: "↔️",
+    cooling: "⬇️",
+    new: "🆕",
+    flat: "—",
+  }[trend];
+}
+
+function actionText(signal: MomentumSignal, trend: TrendDirection): string {
+  if (signal === "spike" && trend === "accelerating")
+    return "ENTRY WINDOW — fee spike accelerating. Run hodlmm-advisor entry-plan immediately.";
+  if (signal === "spike")
+    return "WATCH CLOSELY — fee spike detected. Verify with hodlmm-advisor before acting.";
+  if (signal === "elevated" && trend === "accelerating")
+    return "MONITOR — elevated fees trending up. Potential entry window forming.";
+  if (signal === "elevated")
+    return "MONITOR — above-average fee capture. Watch next 2–3 polls.";
+  if (signal === "cooling")
+    return "HOLD — fee velocity declining. Not an entry window.";
+  if (signal === "flat")
+    return "SKIP — no meaningful activity.";
+  return "HOLD — activity within normal range.";
+}
+
+// ---------------------------------------------------------------------------
+// Subcommand: doctor
+// ---------------------------------------------------------------------------
+
+async function doctor(): Promise<void> {
+  const checks: Array<{ check: string; status: "ok" | "fail"; detail: string }> =
+    [];
+
+  // 1. App pools API
+  try {
+    const data = await fetchJson<AppPoolsResponse>(`${BITFLOW_APP_API}/pools`);
+    const count = data.data?.length ?? 0;
+    checks.push({
+      check: "bitflow_app_api",
+      status: "ok",
+      detail: `${BITFLOW_APP_API}/pools reachable — ${count} pools returned`,
+    });
+  } catch (e) {
+    checks.push({
+      check: "bitflow_app_api",
+      status: "fail",
+      detail: e instanceof Error ? e.message : String(e),
+    });
+  }
+
+  // 2. App single-pool detail (used by track)
+  try {
+    const p = await fetchJson<AppPool>(`${BITFLOW_APP_API}/pools/dlmm_1`);
+    checks.push({
+      check: "bitflow_pool_detail",
+      status: "ok",
+      detail: `dlmm_1 feesUsd1d: $${p.feesUsd1d}, apr24h: ${p.apr24h}%`,
+    });
+  } catch (e) {
+    checks.push({
+      check: "bitflow_pool_detail",
+      status: "fail",
+      detail: e instanceof Error ? e.message : String(e),
+    });
+  }
+
+  // 3. Quotes pool list (sanity cross-check)
+  try {
+    const data = await fetchJson<{ pools: unknown[] }>(
+      `${BITFLOW_QUOTES_API}/pools`
+    );
+    checks.push({
+      check: "bitflow_quotes_api",
+      status: "ok",
+      detail: `${BITFLOW_QUOTES_API}/pools reachable — ${data.pools?.length ?? 0} pools`,
+    });
+  } catch (e) {
+    checks.push({
+      check: "bitflow_quotes_api",
+      status: "fail",
+      detail: e instanceof Error ? e.message : String(e),
+    });
+  }
+
+  // 4. State file writability
+  try {
+    const state = loadState();
+    saveState(state);
+    const trackedCount = Object.keys(state.pools).length;
+    const totalSnaps = Object.values(state.pools).reduce(
+      (a, arr) => a + arr.length,
+      0
+    );
+    checks.push({
+      check: "state_file",
+      status: "ok",
+      detail: `${STATE_FILE} readable/writable — ${trackedCount} pools tracked, ${totalSnaps} snapshots`,
+    });
+  } catch (e) {
+    checks.push({
+      check: "state_file",
+      status: "fail",
+      detail: e instanceof Error ? e.message : String(e),
+    });
+  }
+
+  const allOk = checks.every((c) => c.status === "ok");
+  out({
+    status: allOk ? "ready" : "degraded",
+    network: NETWORK,
+    checks,
+    note: "Read-only skill — no wallet required",
+  });
+  if (!allOk) process.exit(1);
+}
+
+// ---------------------------------------------------------------------------
+// Subcommand: scan
+// ---------------------------------------------------------------------------
+
+async function scan(opts: { minTvl: number }): Promise<void> {
+  const allPools = await getAllPools();
+  const eligible = allPools.filter((p) => p.tvlUsd >= opts.minTvl);
+
+  const ranked = eligible
+    .map((pool) => {
+      const metrics = computeMomentum(pool);
+      return { pool, metrics };
+    })
+    .sort((a, b) => b.metrics.momentumScore - a.metrics.momentumScore);
+
+  const results = ranked.map(({ pool, metrics }) => ({
+    poolId: pool.poolId,
+    pair: `${pool.tokens.tokenX.symbol}-${pool.tokens.tokenY.symbol}`,
+    signal: `${signalEmoji(metrics.signal)} ${metrics.signal}`,
+    action: actionText(metrics.signal, "new"),
+    metrics: {
+      feeVelocity: metrics.feeVelocity,
+      volumeVelocity: metrics.volumeVelocity,
+      momentumScore: metrics.momentumScore,
+    },
+    raw: {
+      feesUsd1d: `$${pool.feesUsd1d.toFixed(2)}`,
+      feesUsd7dAvg: `$${(pool.feesUsd7d / 7).toFixed(2)}/day`,
+      volumeUsd1d: `$${pool.volumeUsd1d.toLocaleString("en-US", { maximumFractionDigits: 0 })}`,
+      apr24h: `${pool.apr24h.toFixed(2)}%`,
+      aprFull: `${pool.apr.toFixed(2)}%`,
+      tvlUsd: `$${pool.tvlUsd.toLocaleString("en-US", { maximumFractionDigits: 0 })}`,
+    },
+  }));
+
+  const topAlert = results.find(
+    (r) =>
+      r.signal.includes("spike") ||
+      r.signal.includes("elevated")
+  );
+
+  out({
+    status: "success",
+    network: NETWORK,
+    timestamp: new Date().toISOString(),
+    scannedPools: results.length,
+    topAlert: topAlert
+      ? `${topAlert.poolId} (${topAlert.pair}): ${topAlert.action}`
+      : "No active momentum signals — all pools near baseline.",
+    ranked: results,
+    note: "Run `track --pool-id <id>` repeatedly to build time-series and unlock trend direction.",
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Subcommand: track
+// ---------------------------------------------------------------------------
+
+async function track(opts: { poolId: string }): Promise<void> {
+  const state = loadState();
+  const history = state.pools[opts.poolId] ?? [];
+
+  const pool = await getPool(opts.poolId);
+  const snapshot = buildSnapshot(pool, history);
+
+  appendSnapshot(state, opts.poolId, snapshot);
+  saveState(state);
+
+  const snapshotCount = state.pools[opts.poolId]!.length;
+  const firstTs = state.pools[opts.poolId]![0]!.ts;
+
+  out({
+    status: "success",
+    network: NETWORK,
+    timestamp: snapshot.ts,
+    poolId: opts.poolId,
+    pair: `${pool.tokens.tokenX.symbol}-${pool.tokens.tokenY.symbol}`,
+    signal: `${signalEmoji(snapshot.metrics.signal)} ${snapshot.metrics.signal}`,
+    trend: `${trendEmoji(snapshot.trend)} ${snapshot.trend}`,
+    action: actionText(snapshot.metrics.signal, snapshot.trend),
+    metrics: {
+      feeVelocity: snapshot.metrics.feeVelocity,
+      volumeVelocity: snapshot.metrics.volumeVelocity,
+      aprSpike: snapshot.metrics.aprSpike,
+      momentumScore: snapshot.metrics.momentumScore,
+    },
+    delta: {
+      feeVelocity:
+        snapshot.deltaFeeVelocity !== null
+          ? (snapshot.deltaFeeVelocity >= 0 ? "+" : "") +
+            snapshot.deltaFeeVelocity.toFixed(3)
+          : null,
+      apr24h:
+        snapshot.deltaApr24h !== null
+          ? (snapshot.deltaApr24h >= 0 ? "+" : "") +
+            snapshot.deltaApr24h.toFixed(2) +
+            "%"
+          : null,
+    },
+    raw: {
+      feesUsd1d: `$${pool.feesUsd1d.toFixed(2)}`,
+      feesUsd7dDailyAvg: `$${(pool.feesUsd7d / 7).toFixed(2)}`,
+      volumeUsd1d: `$${pool.volumeUsd1d.toLocaleString("en-US", { maximumFractionDigits: 0 })}`,
+      apr24h: `${pool.apr24h.toFixed(2)}%`,
+      aprFull: `${pool.apr.toFixed(2)}%`,
+      tvlUsd: `$${pool.tvlUsd.toLocaleString("en-US", { maximumFractionDigits: 0 })}`,
+    },
+    tracking: {
+      snapshotCount,
+      trackingSince: firstTs,
+      stateFile: STATE_FILE,
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Subcommand: report
+// ---------------------------------------------------------------------------
+
+async function report(opts: { poolId?: string }): Promise<void> {
+  const state = loadState();
+  const poolIds = opts.poolId
+    ? [opts.poolId]
+    : Object.keys(state.pools);
+
+  if (poolIds.length === 0) {
+    out({
+      status: "success",
+      network: NETWORK,
+      timestamp: new Date().toISOString(),
+      message:
+        "No pools tracked yet. Run `track --pool-id <id>` to start building a time-series.",
+      pools: [],
+    });
+    return;
+  }
+
+  const summaries = poolIds
+    .map((id) => {
+      const history = state.pools[id];
+      if (!history || history.length === 0) return null;
+
+      const latest = history[history.length - 1]!;
+      const oldest = history[0]!;
+      const peakSnapshot = history.reduce((best, s) =>
+        s.metrics.momentumScore > best.metrics.momentumScore ? s : best
+      );
+
+      // Trend over full history
+      const velocities = history.map((s) => s.metrics.feeVelocity);
+      const firstHalf = velocities
+        .slice(0, Math.floor(velocities.length / 2))
+        .reduce((a, b) => a + b, 0) / Math.max(Math.floor(velocities.length / 2), 1);
+      const secondHalf = velocities
+        .slice(Math.floor(velocities.length / 2))
+        .reduce((a, b) => a + b, 0) /
+        Math.max(velocities.length - Math.floor(velocities.length / 2), 1);
+      const overallTrend =
+        velocities.length < 2
+          ? "insufficient data"
+          : secondHalf > firstHalf * 1.1
+            ? "accelerating ⬆️"
+            : secondHalf < firstHalf * 0.9
+              ? "cooling ⬇️"
+              : "stable ↔️";
+
+      return {
+        poolId: id,
+        snapshotCount: history.length,
+        trackingSince: oldest.ts,
+        latest: {
+          ts: latest.ts,
+          signal: `${signalEmoji(latest.metrics.signal)} ${latest.metrics.signal}`,
+          trend: `${trendEmoji(latest.trend)} ${latest.trend}`,
+          action: actionText(latest.metrics.signal, latest.trend),
+          feeVelocity: latest.metrics.feeVelocity,
+          apr24h: `${latest.apr24h.toFixed(2)}%`,
+          feesUsd1d: `$${latest.feesUsd1d.toFixed(2)}`,
+        },
+        peak: {
+          ts: peakSnapshot.ts,
+          feeVelocity: peakSnapshot.metrics.feeVelocity,
+          apr24h: `${peakSnapshot.apr24h.toFixed(2)}%`,
+          signal: `${signalEmoji(peakSnapshot.metrics.signal)} ${peakSnapshot.metrics.signal}`,
+        },
+        overallTrend,
+      };
+    })
+    .filter(Boolean);
+
+  // Prioritise pools with active signals at top
+  summaries.sort((a, b) => {
+    if (!a || !b) return 0;
+    const priority = { spike: 3, elevated: 2, normal: 1, cooling: 0, flat: -1 };
+    const aSignal = (a.latest.signal.match(/\w+$/) ?? ["normal"])[0] as MomentumSignal;
+    const bSignal = (b.latest.signal.match(/\w+$/) ?? ["normal"])[0] as MomentumSignal;
+    return (priority[bSignal] ?? 0) - (priority[aSignal] ?? 0);
+  });
+
+  const actionableAlerts = summaries.filter((s) =>
+    s?.latest.signal.includes("spike") || s?.latest.signal.includes("elevated")
+  );
+
+  out({
+    status: "success",
+    network: NETWORK,
+    timestamp: new Date().toISOString(),
+    summary: {
+      poolsTracked: summaries.length,
+      activeAlerts: actionableAlerts.length,
+      recommendation:
+        actionableAlerts.length > 0
+          ? `${actionableAlerts.length} pool(s) with elevated/spike signals — run hodlmm-advisor best-pools for entry planning.`
+          : "All tracked pools within normal range. Continue monitoring.",
+    },
+    pools: summaries,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+const program = new Command();
+
+program
+  .name("hodlmm-pulse")
+  .description(
+    "Fee velocity and volume momentum tracker for Bitflow HODLMM pools. " +
+      "Detects entry windows by comparing today's fee capture against the 7-day baseline. " +
+      "Read-only, no wallet required."
+  )
+  .version("1.0.0");
+
+program
+  .command("doctor")
+  .description("Verify API connectivity and state file readiness")
+  .action(async () => {
+    try {
+      await doctor();
+    } catch (e) {
+      fail(e);
+    }
+  });
+
+program
+  .command("scan")
+  .description(
+    "Snapshot all pools, compute momentum scores, rank by fee velocity"
+  )
+  .option(
+    "--min-tvl <usd>",
+    "Minimum pool TVL in USD to include",
+    (v) => parseFloat(v),
+    500
+  )
+  .action(async (opts: { minTvl: number }) => {
+    try {
+      await scan(opts);
+    } catch (e) {
+      fail(e);
+    }
+  });
+
+program
+  .command("track")
+  .description(
+    "Append a timestamped snapshot for a pool and output trend direction. " +
+      "Run repeatedly (e.g. every 5 min via cron) to build time-series."
+  )
+  .requiredOption("--pool-id <id>", "Pool identifier (e.g. dlmm_1)")
+  .action(async (opts: { poolId: string }) => {
+    try {
+      await track(opts);
+    } catch (e) {
+      fail(e);
+    }
+  });
+
+program
+  .command("report")
+  .description(
+    "Summarise all tracked pools from local state: current signal, trend over time, peak momentum."
+  )
+  .option("--pool-id <id>", "Limit report to a single pool")
+  .action(async (opts: { poolId?: string }) => {
+    try {
+      await report(opts);
+    } catch (e) {
+      fail(e);
+    }
+  });
+
+program.parse(process.argv);


### PR DESCRIPTION
## hodlmm-pulse

**Author:** @ghislo749 (Grim Seraph)
**Competition PR:** https://github.com/BitflowFinance/bff-skills/pull/94
**PR Title:** [AIBTC Skills Comp] feat(hodlmm-pulse): HODLMM fee velocity & momentum tracker

---

This skill was submitted to the [AIBTC x Bitflow Skills Pay the Bills](https://bff.army/agents.txt) competition, reviewed by judging agents and the human panel, and approved as a Day 6 winner.

Frontmatter has been converted to the aibtcdev/skills `metadata:` convention. Command paths updated to match this repo root-level skill layout.

### Files
- `hodlmm-pulse/SKILL.md` — Skill definition with AIBTC-format frontmatter
- `hodlmm-pulse/AGENT.md` — Agent behavior rules and guardrails
- `hodlmm-pulse/hodlmm-pulse.ts` — TypeScript implementation

### Attribution

Original author: **@ghislo749**. The `metadata.author` field in SKILL.md preserves their attribution permanently.

---
_Automated by [BFF Skills Bot](https://github.com/BitflowFinance/bff-skills) on merge of PR #94._
