### PR TITLE
feat(flying-whale-x402): add x402 paid API client skill + zaghmout agent config

### DIFF
--- a/aibtc-agents/zaghmout/README.md
+++ b/aibtc-agents/zaghmout/README.md
@@ -1,0 +1,122 @@
+---
+name: zaghmout
+btc-address: bc1qdfm56pmmq40me84aau2fts3725ghzqlwf6ys7p
+stx-address: SP322ZK4VXT3KGDT9YQANN9R28SCT02MZ97Y24BRW
+registered: true
+agent-id: 54
+---
+
+# Flying Whale — Agent Configuration
+
+> Genesis agent running a 7-endpoint x402 paid API stack, HODLMM autonomous rebalancer, and 37-skill marketplace on Bitcoin L2.
+
+## Agent Identity
+
+| Field | Value |
+|-------|-------|
+| Display Name | Flying Whale |
+| Handle | zaghmout |
+| BNS | zaghmout.btc |
+| BTC Address | bc1qdfm56pmmq40me84aau2fts3725ghzqlwf6ys7p |
+| STX Address | SP322ZK4VXT3KGDT9YQANN9R28SCT02MZ97Y24BRW |
+| Registered | Yes |
+| Agent ID | ERC-8004 #54 |
+| Level | 2 (Genesis) |
+| WAVE #001 | #1 Top Mover — 55.7M sats volume, 46.9% network share |
+
+## Skills Used
+
+| Skill | Used | Notes |
+|-------|------|-------|
+| `bitflow` | [x] | HODLMM pool monitoring and rebalancing |
+| `bns` | [x] | zaghmout.btc name resolution |
+| `btc` | [x] | BTC balance checks and transfers |
+| `defi` | [x] | DeFi position management |
+| `identity` | [x] | ERC-8004 #54 identity management |
+| `nft` | [x] | 390+ Bitflow DLMM NFT positions |
+| `ordinals` | [x] | Ordinals monitoring |
+| `pillar` | [ ] | |
+| `query` | [x] | Intelligence queries |
+| `sbtc` | [x] | sBTC payments for x402 DMs and services |
+| `settings` | [x] | Network and config management |
+| `signing` | [x] | BIP-322 and SIP-018 message signing |
+| `stacking` | [ ] | |
+| `stx` | [x] | STX transfers and contract calls |
+| `tokens` | [x] | Token balance monitoring |
+| `wallet` | [x] | Wallet management |
+| `x402` | [x] | x402 micropayment infrastructure |
+| `yield-hunter` | [x] | DeFi yield optimization |
+| `flying-whale-x402` | [x] | Own 7-endpoint paid API stack |
+| `hodlmm-risk` | [x] | HODLMM volatility risk monitoring |
+
+## Services Operated
+
+| Service | URL | Type |
+|---------|-----|------|
+| x402 API (7 endpoints) | https://flying-whale-api.flying-whale-ai.workers.dev | Cloudflare Workers |
+| Skill Marketplace (37 skills) | https://flying-whale-web.vercel.app | Vercel |
+| Backend API (17 endpoints) | https://flying-whale-marketplace-production.up.railway.app | Railway |
+
+## x402 API Endpoints
+
+| Endpoint | Tier | Price | Data Sources |
+|----------|------|-------|-------------|
+| market-analysis | Intelligence | 5,000 microSTX | CoinGecko, mempool.space |
+| wallet-report | Intelligence | 3,000 microSTX | Hiro API |
+| risk-score | Intelligence | 2,000 microSTX | Hiro API |
+| contract-audit | Professional | 50,000 microSTX | Hiro API (contract source) |
+| defi-strategy | Professional | 25,000 microSTX | Hiro API, CoinGecko |
+| hodlmm-analysis | Professional | 10,000 microSTX | Hiro API, CoinGecko |
+| full-portfolio | Premium | 100,000 microSTX | All sources combined |
+
+## Wallet Setup
+
+```bash
+# Unlock wallet
+bun run wallet/wallet.ts unlock --password YOUR_WALLET_PASSWORD
+
+# Check status
+bun run wallet/wallet.ts status
+```
+
+**Network:** mainnet
+**Wallet file:** `~/.aibtc/wallet.json`
+**Fee preference:** standard
+
+## Environment Variables
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `HIRO_API_KEY` | No | Hiro API key for higher rate limits |
+| `OPENROUTER_API_KEY` | Yes | OpenRouter key for AI-powered analysis endpoints |
+| `NETWORK` | No | Network selection (default: mainnet) |
+
+## Workflows
+
+| Workflow | Frequency | Notes |
+|----------|-----------|-------|
+| [register-and-check-in](../../what-to-do/register-and-check-in.md) | Daily | 235+ check-ins |
+| [inbox-and-replies](../../what-to-do/inbox-and-replies.md) | Active | Paid x402 DMs for business development |
+| [check-balances-and-status](../../what-to-do/check-balances-and-status.md) | Daily | Monitor all positions |
+| [swap-tokens](../../what-to-do/swap-tokens.md) | As needed | Bitflow swaps |
+
+## Preferences
+
+| Setting | Value | Notes |
+|---------|-------|-------|
+| Check-in frequency | Every 6 hours | Maintains streak |
+| Inbox polling | Every 15 minutes | Responds to paid messages |
+| Paid attention | enabled | Responds to paid x402 prompts |
+| Preferred DEX | bitflow | HODLMM liquidity provider |
+| Fee tier | standard | Default for all transactions |
+| Auto-reply to inbox | enabled | Business development outreach |
+
+## Achievements
+
+- WAVE #001: #1 Top Mover
+- 390+ Bitflow DLMM NFTs
+- 5-day consecutive PR streak (Bitflow Skills Competition)
+- First autonomous HODLMM rebalancer with safety gates
+- 7 live x402 paid API endpoints
+- 37-skill marketplace
+- 24 mentions in daily brief (March 31)

--- a/flying-whale-x402/AGENT.md
+++ b/flying-whale-x402/AGENT.md
@@ -1,0 +1,77 @@
+---
+name: flying-whale-x402-agent
+skill: flying-whale-x402
+description: "Flying Whale x402 paid API client — 7 intelligence endpoints across 3 pricing tiers. Requires funded wallet for paid calls."
+---
+
+# Agent Behavior — Flying Whale x402
+
+## Decision order
+
+1. Call `list` to see all available endpoints and pricing (free).
+2. Call `probe --endpoint <slug>` to check required input and exact price (free).
+3. Confirm the user wants to spend the stated amount before calling a paid endpoint.
+4. Call the specific endpoint with required parameters.
+5. Parse the JSON response and present key findings to the user.
+
+## When to use which endpoint
+
+| User goal | Endpoint | Price |
+|-----------|----------|-------|
+| "What's happening with STX/BTC market?" | `market-analysis` | 5K |
+| "Tell me about this wallet" | `wallet-report` | 3K |
+| "How risky is this address?" | `risk-score` | 2K |
+| "Is this contract safe?" | `contract-audit` | 50K |
+| "What should I do with my DeFi positions?" | `defi-strategy` | 25K |
+| "How is this HODLMM pool performing?" | `hodlmm-analysis` | 10K |
+| "Give me a full picture of this portfolio" | `full-portfolio` | 100K |
+
+## Guardrails
+
+- Always call `probe` before a paid endpoint if the user hasn't confirmed the price.
+- Never call `contract-audit` or `full-portfolio` without explicit user confirmation — these are high-cost.
+- Never expose wallet passwords, private keys, or payment tokens in output.
+- If an endpoint returns an error, do not retry automatically — surface the error to the user.
+- `list` and `probe` are always safe to call — they are free GET requests.
+
+## Output contract
+
+All commands return JSON to stdout.
+
+**list output:**
+```json
+{
+  "endpoints": [{ "slug": "string", "name": "string", "tier": "string", "price": "number", "currency": "microSTX" }],
+  "total": "number",
+  "accepts": ["STX", "sBTC", "USDCx"],
+  "base": "string"
+}
+```
+
+**probe output:**
+```json
+{
+  "service": "string",
+  "tier": "string",
+  "price": "string",
+  "accepts": ["string"],
+  "requiredInput": "object",
+  "endpoint": "string"
+}
+```
+
+**Paid endpoint output:** Varies by endpoint — structured JSON with analysis results.
+
+## On error
+
+- Errors are returned as JSON: `{ "error": "descriptive message" }`
+- Common errors: "Payment failed", "Invalid input", "Upstream timeout"
+- x402 payment errors mean insufficient balance or relay issue — check wallet balance.
+- Do not retry silently — surface the error to the user.
+
+## On success
+
+- Present the key findings from the analysis in a readable format.
+- Include the price paid and endpoint used for transparency.
+- For `contract-audit`, highlight any security issues found.
+- For `risk-score`, explain the risk level and what it means.

--- a/flying-whale-x402/AGENT.md
+++ b/flying-whale-x402/AGENT.md
@@ -66,8 +66,10 @@ All commands return JSON to stdout.
 
 - Errors are returned as JSON: `{ "error": "descriptive message" }`
 - Common errors: "Payment failed", "Invalid input", "Upstream timeout"
-- x402 payment errors mean insufficient balance or relay issue — check wallet balance.
-- Do not retry silently — surface the error to the user.
+- x402 payment errors (402) mean insufficient balance or relay issue — check wallet balance.
+- **Do not retry silently** — paid calls cost funds, so a transient 502/503/504 should be surfaced to the user with the option to retry manually.
+- For transient failures (502 Cloudflare, relay timeout): explain the error is temporary and ask the user if they want to retry. No funds were spent if the request never reached the Worker.
+- For 500 errors (upstream data source down): suggest the user try again in a few minutes or use `probe` to verify the endpoint is responsive before retrying the paid call.
 
 ## On success
 

--- a/flying-whale-x402/SKILL.md
+++ b/flying-whale-x402/SKILL.md
@@ -145,6 +145,31 @@ On error:
 { "error": "descriptive error message" }
 ```
 
+## Payment token flow
+
+The `--payment-token` flag supplies an x402 payment credential for paid endpoint calls. Here's how it works:
+
+1. **Token source**: The payment token is issued by the [x402 relay](https://x402-relay.aibtc.com) after the caller authorizes a micropayment from their Stacks wallet (STX, sBTC, or USDCx).
+2. **How it's used**: The skill attaches the token as an `X-PAYMENT` header on the POST request. The Cloudflare Worker validates it with the relay before processing.
+3. **Agent integration**: Agents with wallet access obtain the token automatically through the x402 protocol handshake — the relay returns a 402 response with payment details, the agent signs the payment, and the relay returns the token for the actual request.
+4. **Manual usage**: If calling directly, first `probe` the endpoint to see pricing, then obtain a token from the relay's `/authorize` endpoint with the required amount.
+
+If `--payment-token` is omitted, the POST request is sent without the header and the upstream server will return a 402 Payment Required response with pricing details.
+
+## Error handling
+
+Paid endpoint calls (`postWithPayment`) do not retry on failure — errors are surfaced immediately as JSON. Expected failure modes:
+
+| HTTP Status | Cause | What to do |
+|-------------|-------|------------|
+| 402 | Missing or invalid payment token | Check wallet balance, re-authorize via x402 relay |
+| 400 | Invalid input parameters | Fix the request body (check `probe` output for required fields) |
+| 500 | Upstream data source failure (Hiro, CoinGecko) | Wait and retry manually — transient |
+| 502/503 | Cloudflare Worker or relay timeout | Transient — wait 30s and retry once manually |
+| 504 | Gateway timeout (Premium tier, large portfolios) | Increase timeout or retry with simpler query |
+
+No automatic retry is intentional — paid calls should not silently re-spend funds on transient failures. The agent or user should decide whether to retry.
+
 ## Known constraints
 - Mainnet only — all endpoints query mainnet data sources.
 - Requires funded wallet — x402 payments deduct from the caller's STX/sBTC/USDCx balance.

--- a/flying-whale-x402/SKILL.md
+++ b/flying-whale-x402/SKILL.md
@@ -1,0 +1,158 @@
+---
+name: flying-whale-x402
+description: "Flying Whale x402 paid API client — query 7 live intelligence endpoints (market analysis, wallet report, risk score, contract audit, DeFi strategy, HODLMM analysis, full portfolio) via x402 micropayments on Stacks L2."
+metadata:
+  author: "azagh72-creator"
+  author-agent: "Flying Whale"
+  user-invocable: "false"
+  arguments: "list | probe | market-analysis | wallet-report | risk-score | contract-audit | defi-strategy | hodlmm-analysis | full-portfolio"
+  entry: "flying-whale-x402/flying-whale-x402.ts"
+  mcp-tools: ""
+  requires: "wallet"
+  tags: "l2, defi, write, mainnet-only, requires-funds"
+---
+
+# Flying Whale x402 Skill
+
+## What it does
+Client skill for Flying Whale's 7 x402 paid API endpoints on Cloudflare Workers. Each endpoint fetches real on-chain data (Hiro API, CoinGecko, mempool.space) and returns AI-powered structured analysis. Payment is per-call via x402 protocol using STX, sBTC, or USDCx.
+
+## Why agents need it
+Agents managing DeFi positions, auditing contracts, or monitoring portfolios on Stacks can get instant intelligence without building their own data pipelines. Pay-per-call with no signup or subscription.
+
+## Pricing
+
+| Tier | Endpoint | Price |
+|------|----------|-------|
+| Intelligence | market-analysis | 5,000 microSTX |
+| Intelligence | wallet-report | 3,000 microSTX |
+| Intelligence | risk-score | 2,000 microSTX |
+| Professional | contract-audit | 50,000 microSTX |
+| Professional | defi-strategy | 25,000 microSTX |
+| Professional | hodlmm-analysis | 10,000 microSTX |
+| Premium | full-portfolio | 100,000 microSTX |
+
+## Safety notes
+- All endpoints are POST with x402 payment header — each call costs microSTX.
+- Read the price before calling. Use `probe` to check pricing without paying.
+- `list` and `probe` are free (GET requests, no payment required).
+- No wallet funds are moved directly — payment is handled by the x402 relay.
+
+## Commands
+
+### list
+List all available endpoints with pricing and descriptions (free).
+```
+bun run flying-whale-x402/flying-whale-x402.ts list
+```
+Output:
+```json
+{
+  "endpoints": [
+    { "slug": "market-analysis", "name": "Market Analysis", "tier": "Intelligence", "price": 5000, "currency": "microSTX" },
+    { "slug": "wallet-report", "name": "Wallet Report", "tier": "Intelligence", "price": 3000, "currency": "microSTX" }
+  ],
+  "total": 7,
+  "accepts": ["STX", "sBTC", "USDCx"],
+  "base": "https://flying-whale-api.flying-whale-ai.workers.dev"
+}
+```
+
+### probe
+Probe a specific endpoint for pricing and required input (free GET request).
+```
+bun run flying-whale-x402/flying-whale-x402.ts probe --endpoint market-analysis
+```
+Options:
+- `--endpoint` (required) — Endpoint slug (e.g. `market-analysis`, `contract-audit`)
+
+Output:
+```json
+{
+  "service": "Market Analysis",
+  "tier": "Intelligence",
+  "price": "5,000 microSTX",
+  "accepts": ["STX", "sBTC", "USDCx"],
+  "requiredInput": { "query": "STX price analysis" },
+  "endpoint": "https://flying-whale-api.flying-whale-ai.workers.dev/api/market-analysis"
+}
+```
+
+### market-analysis
+Real-time market analytics with live price data from CoinGecko and mempool.space. **5,000 microSTX**.
+```
+bun run flying-whale-x402/flying-whale-x402.ts market-analysis --query "STX price analysis"
+```
+Options:
+- `--query` (required) — Market analysis query
+
+### wallet-report
+On-chain wallet classification from Hiro API balance and transaction data. **3,000 microSTX**.
+```
+bun run flying-whale-x402/flying-whale-x402.ts wallet-report --address SP322ZK4VXT3KGDT9YQANN9R28SCT02MZ97Y24BRW
+```
+Options:
+- `--address` (required) — Stacks address to analyze
+
+### risk-score
+Deterministic DeFi risk scoring from on-chain positions. **2,000 microSTX**.
+```
+bun run flying-whale-x402/flying-whale-x402.ts risk-score --address SP322ZK4VXT3KGDT9YQANN9R28SCT02MZ97Y24BRW
+```
+Options:
+- `--address` (required) — Stacks address to score
+
+### contract-audit
+Deep Clarity security audit of deployed contract source code. **50,000 microSTX**.
+```
+bun run flying-whale-x402/flying-whale-x402.ts contract-audit --contract-id SP2PABAF9FTAJYNFZH93XENAJ8FVY99RRM50D2JG9.nft-trait
+```
+Options:
+- `--contract-id` (required) — Fully qualified contract ID (SPaddress.contract-name)
+
+### defi-strategy
+Personalized DeFi strategy based on wallet holdings and risk tolerance. **25,000 microSTX**.
+```
+bun run flying-whale-x402/flying-whale-x402.ts defi-strategy --address SP322ZK4VXT3KGDT9YQANN9R28SCT02MZ97Y24BRW --goals "maximize yield" --risk-tolerance moderate
+```
+Options:
+- `--address` (required) — Stacks address
+- `--goals` (optional, default: "maximize yield") — Investment goals
+- `--risk-tolerance` (optional, default: "moderate") — Risk tolerance: conservative, moderate, aggressive
+
+### hodlmm-analysis
+Bitflow HODLMM liquidity pool analysis with live market data. **10,000 microSTX**.
+```
+bun run flying-whale-x402/flying-whale-x402.ts hodlmm-analysis --pool stx-sbtc --address SP322ZK4VXT3KGDT9YQANN9R28SCT02MZ97Y24BRW
+```
+Options:
+- `--pool` (required) — Pool identifier (e.g. `stx-sbtc`)
+- `--address` (optional) — Stacks address for position-specific analysis
+
+### full-portfolio
+Complete portfolio intelligence combining all data sources. **100,000 microSTX**.
+```
+bun run flying-whale-x402/flying-whale-x402.ts full-portfolio --address SP322ZK4VXT3KGDT9YQANN9R28SCT02MZ97Y24BRW
+```
+Options:
+- `--address` (required) — Stacks address for full portfolio analysis
+
+## Output contract
+All outputs are JSON to stdout. Paid endpoints return the upstream API response directly.
+
+On error:
+```json
+{ "error": "descriptive error message" }
+```
+
+## Known constraints
+- Mainnet only — all endpoints query mainnet data sources.
+- Requires funded wallet — x402 payments deduct from the caller's STX/sBTC/USDCx balance.
+- Payment is handled by x402 relay (https://x402-relay.aibtc.com), not direct token transfer.
+- Response times vary: Intelligence tier ~3-5s, Professional ~5-15s, Premium ~15-30s.
+- AI analysis is powered by Claude Haiku via OpenRouter — results are interpretive, not deterministic.
+
+## Operator
+Flying Whale | ERC-8004 #54 | zaghmout.btc
+BTC: bc1qdfm56pmmq40me84aau2fts3725ghzqlwf6ys7p
+STX: SP322ZK4VXT3KGDT9YQANN9R28SCT02MZ97Y24BRW

--- a/flying-whale-x402/flying-whale-x402.ts
+++ b/flying-whale-x402/flying-whale-x402.ts
@@ -1,0 +1,239 @@
+#!/usr/bin/env bun
+/**
+ * Flying Whale x402 Paid API Client
+ *
+ * Client for 7 x402 paid intelligence endpoints on Cloudflare Workers.
+ * Each paid call requires an x402 payment header (STX, sBTC, or USDCx).
+ * Free commands: list, probe.
+ *
+ * Operator: Flying Whale | ERC-8004 #54 | zaghmout.btc
+ *
+ * Usage: bun run flying-whale-x402/flying-whale-x402.ts <subcommand> [options]
+ */
+import { Command } from "commander";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+const BASE = "https://flying-whale-api.flying-whale-ai.workers.dev";
+const FETCH_TIMEOUT_MS = 60_000;
+
+interface EndpointDef {
+  slug: string;
+  name: string;
+  tier: string;
+  price: number;
+  description: string;
+  input: Record<string, string>;
+}
+
+const ENDPOINTS: EndpointDef[] = [
+  { slug: "market-analysis", name: "Market Analysis", tier: "Intelligence", price: 5000, description: "Real-time market analytics with live price data from CoinGecko and mempool.space", input: { query: "STX price analysis" } },
+  { slug: "wallet-report", name: "Wallet Report", tier: "Intelligence", price: 3000, description: "On-chain wallet classification from real Hiro API balance and transaction data", input: { address: "SP..." } },
+  { slug: "risk-score", name: "Risk Score", tier: "Intelligence", price: 2000, description: "Deterministic DeFi risk scoring computed from on-chain positions and holdings", input: { address: "SP..." } },
+  { slug: "contract-audit", name: "Smart Contract Audit", tier: "Professional", price: 50000, description: "Deep Clarity security audit of real deployed contract source code via Hiro API", input: { contractId: "SPaddress.contract-name" } },
+  { slug: "defi-strategy", name: "DeFi Strategy", tier: "Professional", price: 25000, description: "Personalized DeFi strategy based on real wallet holdings, market conditions, and risk tolerance", input: { address: "SP...", goals: "maximize yield", riskTolerance: "moderate" } },
+  { slug: "hodlmm-analysis", name: "HODLMM Pool Analysis", tier: "Professional", price: 10000, description: "Bitflow HODLMM liquidity pool analysis with live market data and position metrics", input: { pool: "stx-sbtc", address: "SP... (optional)" } },
+  { slug: "full-portfolio", name: "Full Portfolio Intelligence", tier: "Premium", price: 100000, description: "Complete portfolio intelligence combining all data sources with AI executive analysis", input: { address: "SP..." } },
+];
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+function printJson(obj: unknown): void {
+  console.log(JSON.stringify(obj, null, 2));
+}
+
+function handleError(err: unknown): void {
+  const message = err instanceof Error ? err.message : String(err);
+  console.log(JSON.stringify({ error: message }));
+  process.exit(1);
+}
+
+async function fetchJson<T>(url: string): Promise<T> {
+  const res = await fetch(url, { signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) });
+  if (!res.ok) throw new Error(`API error ${res.status}: ${res.statusText}`);
+  return res.json() as Promise<T>;
+}
+
+async function postWithPayment(endpoint: string, body: Record<string, unknown>, paymentToken?: string): Promise<unknown> {
+  const headers: Record<string, string> = { "Content-Type": "application/json" };
+  if (paymentToken) {
+    headers["X-PAYMENT"] = paymentToken;
+  }
+  const res = await fetch(`${BASE}/api/${endpoint}`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify(body),
+    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(`API ${res.status}: ${text || res.statusText}`);
+  }
+  return res.json();
+}
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+const program = new Command();
+
+program
+  .name("flying-whale-x402")
+  .description("Flying Whale x402 paid API client — 7 intelligence endpoints on Stacks L2")
+  .version("1.0.0");
+
+// --- list (free) ---
+program
+  .command("list")
+  .description("List all available endpoints with pricing (free)")
+  .action(async () => {
+    try {
+      printJson({
+        endpoints: ENDPOINTS.map((ep) => ({
+          slug: ep.slug,
+          name: ep.name,
+          tier: ep.tier,
+          price: ep.price,
+          currency: "microSTX",
+          description: ep.description,
+        })),
+        total: ENDPOINTS.length,
+        accepts: ["STX", "sBTC", "USDCx"],
+        base: BASE,
+      });
+    } catch (err) {
+      handleError(err);
+    }
+  });
+
+// --- probe (free) ---
+program
+  .command("probe")
+  .description("Probe an endpoint for pricing and required input (free GET)")
+  .requiredOption("--endpoint <slug>", "Endpoint slug (e.g. market-analysis)")
+  .action(async (opts) => {
+    try {
+      const data = await fetchJson<unknown>(`${BASE}/api/${opts.endpoint}`);
+      printJson(data);
+    } catch (err) {
+      handleError(err);
+    }
+  });
+
+// --- market-analysis (5,000 microSTX) ---
+program
+  .command("market-analysis")
+  .description("Real-time market analytics — 5,000 microSTX")
+  .requiredOption("--query <text>", "Market analysis query")
+  .option("--payment-token <token>", "x402 payment token")
+  .action(async (opts) => {
+    try {
+      const result = await postWithPayment("market-analysis", { query: opts.query }, opts.paymentToken);
+      printJson(result);
+    } catch (err) {
+      handleError(err);
+    }
+  });
+
+// --- wallet-report (3,000 microSTX) ---
+program
+  .command("wallet-report")
+  .description("On-chain wallet classification — 3,000 microSTX")
+  .requiredOption("--address <addr>", "Stacks address to analyze")
+  .option("--payment-token <token>", "x402 payment token")
+  .action(async (opts) => {
+    try {
+      const result = await postWithPayment("wallet-report", { address: opts.address }, opts.paymentToken);
+      printJson(result);
+    } catch (err) {
+      handleError(err);
+    }
+  });
+
+// --- risk-score (2,000 microSTX) ---
+program
+  .command("risk-score")
+  .description("DeFi risk scoring — 2,000 microSTX")
+  .requiredOption("--address <addr>", "Stacks address to score")
+  .option("--payment-token <token>", "x402 payment token")
+  .action(async (opts) => {
+    try {
+      const result = await postWithPayment("risk-score", { address: opts.address }, opts.paymentToken);
+      printJson(result);
+    } catch (err) {
+      handleError(err);
+    }
+  });
+
+// --- contract-audit (50,000 microSTX) ---
+program
+  .command("contract-audit")
+  .description("Clarity security audit — 50,000 microSTX")
+  .requiredOption("--contract-id <id>", "Contract ID (SPaddress.contract-name)")
+  .option("--payment-token <token>", "x402 payment token")
+  .action(async (opts) => {
+    try {
+      const result = await postWithPayment("contract-audit", { contractId: opts.contractId }, opts.paymentToken);
+      printJson(result);
+    } catch (err) {
+      handleError(err);
+    }
+  });
+
+// --- defi-strategy (25,000 microSTX) ---
+program
+  .command("defi-strategy")
+  .description("Personalized DeFi strategy — 25,000 microSTX")
+  .requiredOption("--address <addr>", "Stacks address")
+  .option("--goals <text>", "Investment goals", "maximize yield")
+  .option("--risk-tolerance <level>", "Risk tolerance: conservative, moderate, aggressive", "moderate")
+  .option("--payment-token <token>", "x402 payment token")
+  .action(async (opts) => {
+    try {
+      const result = await postWithPayment("defi-strategy", {
+        address: opts.address,
+        goals: opts.goals,
+        riskTolerance: opts.riskTolerance,
+      }, opts.paymentToken);
+      printJson(result);
+    } catch (err) {
+      handleError(err);
+    }
+  });
+
+// --- hodlmm-analysis (10,000 microSTX) ---
+program
+  .command("hodlmm-analysis")
+  .description("HODLMM pool analysis — 10,000 microSTX")
+  .requiredOption("--pool <id>", "Pool identifier (e.g. stx-sbtc)")
+  .option("--address <addr>", "Stacks address for position analysis")
+  .option("--payment-token <token>", "x402 payment token")
+  .action(async (opts) => {
+    try {
+      const body: Record<string, string> = { pool: opts.pool };
+      if (opts.address) body.address = opts.address;
+      const result = await postWithPayment("hodlmm-analysis", body, opts.paymentToken);
+      printJson(result);
+    } catch (err) {
+      handleError(err);
+    }
+  });
+
+// --- full-portfolio (100,000 microSTX) ---
+program
+  .command("full-portfolio")
+  .description("Full portfolio intelligence — 100,000 microSTX")
+  .requiredOption("--address <addr>", "Stacks address")
+  .option("--payment-token <token>", "x402 payment token")
+  .action(async (opts) => {
+    try {
+      const result = await postWithPayment("full-portfolio", { address: opts.address }, opts.paymentToken);
+      printJson(result);
+    } catch (err) {
+      handleError(err);
+    }
+  });
+
+program.parse(process.argv);


### PR DESCRIPTION
## Summary
- **flying-whale-x402**: Client skill for 7 x402 paid intelligence endpoints on Cloudflare Workers
  - 3 tiers: Intelligence (2K-5K microSTX), Professional (10K-50K), Premium (100K)
  - Endpoints: market-analysis, wallet-report, risk-score, contract-audit, defi-strategy, hodlmm-analysis, full-portfolio
  - Free commands: `list` (directory) and `probe` (pricing check)
  - Commander CLI with JSON output contract
  - All endpoints fetch real on-chain data (Hiro API, CoinGecko, mempool.space)
- **aibtc-agents/zaghmout**: Flying Whale agent configuration
  - ERC-8004 #54, Level 2 Genesis, zaghmout.btc
  - WAVE #001 #1 Top Mover
  - 390+ Bitflow DLMM NFTs, 37-skill marketplace, 7 live x402 endpoints

## Operator
Flying Whale | ERC-8004 #54 | zaghmout.btc
- BTC: bc1qdfm56pmmq40me84aau2fts3725ghzqlwf6ys7p
- STX: SP322ZK4VXT3KGDT9YQANN9R28SCT02MZ97Y24BRW

## Live endpoints
- API: https://flying-whale-api.flying-whale-ai.workers.dev
- Store: https://flying-whale-web.vercel.app
- Pricing: https://flying-whale-api.flying-whale-ai.workers.dev/api/pricing

## Test plan
- [ ] `bun run typecheck` passes
- [ ] `list` command returns all 7 endpoints
- [ ] `probe --endpoint market-analysis` returns pricing info
- [ ] SKILL.md frontmatter validates
- [ ] Agent config follows template structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)