### PR TITLE
feat(inbox-dispatcher): add auto-triage and priority-based message handling skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Each skill is a self-contained directory with a `SKILL.md` (used by Claude Code 
 | [nft](./nft/) | `nft/nft.ts` | SIP-009 NFTs — list holdings, get metadata, transfer NFTs, get token owner, get collection info, and get transfer history. |
 | [bns](./bns/) | `bns/bns.ts` | Bitcoin Name System — lookup names, reverse-lookup addresses, check availability, get pricing, list domains, and register new .btc names. |
 | [identity](./identity/) | `identity/identity.ts` | ERC-8004 on-chain agent identity — register identities and query identity info for registered agents. |
+| [inbox-dispatcher](./inbox-dispatcher/) | `inbox-dispatcher/inbox-dispatcher.ts` | Auto-triage and respond to inbox messages based on priority scoring. |
 | [reputation](./reputation/) | `reputation/reputation.ts` | ERC-8004 on-chain agent reputation — submit feedback, revoke feedback, append responses, and query reputation summaries and feedback entries. |
 | [validation](./validation/) | `validation/validation.ts` | ERC-8004 on-chain agent validation — request and respond to validations, and query validation status, summaries, and paginated request lists. |
 | [bitflow](./bitflow/) | `bitflow/bitflow.ts` | Bitflow DEX — aggregated token swaps, market ticker data, swap routing, price impact analysis, and Keeper automation for scheduled orders. Mainnet-only. |

--- a/inbox-dispatcher/AGENT.md
+++ b/inbox-dispatcher/AGENT.md
@@ -6,7 +6,7 @@ This skill enables autonomous inbox management for AI agents. It is designed to 
 
 - Active wallet configured (via `wallet` skill)
 - Inbox must be set up (from `inbox` skill)
-- Network: `mainnet` (aibtc.news production)
+- Network: `mainnet` (aibtc.com production)
 
 ## Safety Checks
 
@@ -24,11 +24,22 @@ This skill enables autonomous inbox management for AI agents. It is designed to 
 ## Decision Logic
 
 The built-in scorer uses keyword heuristics:
-- **Revenue priority**: 3 points per keyword (bounty, payment, reward, sats, usd, $, invoice, deal)
-- **Collaboration**: 2 points per keyword (partner, collaborate, project, proposal, join, team, contribute)
-- **Spam**: -2 points per keyword (unsubscribe, stop, promotion, advertisement, offer, discount, free)
 
-Messages scoring >= 2 are considered high-priority and can be auto-acked.
+**Revenue priority** (3 points each): payout, payment, bounty, reward, sats, usd, $, invoice, deal
+**Collaboration** (2 points each): partner, collaborate, project, proposal, join, team, contribute
+**Spam** (-2 points each): unsubscribe, stop, promotion, advertisement, offer, discount, free
+
+The `priority` score = (revenue × 3) + (collaboration × 2) - (spam × 2).
+
+**Category assignment** (mutually exclusive):
+- `revenue`: only if revenue > collaboration AND revenue > spam
+- `collaboration`: only if collaboration > revenue AND collaboration > spam
+- `spam`: only if spam > revenue AND spam > collaboration
+- `other`: any tie case (e.g., revenue === collaboration, or all equal)
+
+Ties are intentionally left as `other` to avoid mis-categorizing ambiguous messages.
+
+Messages with `priority >= threshold` (default 2) are considered high-priority and can be auto-acked.
 
 ## Autonomous Heartbeat Integration
 
@@ -48,4 +59,16 @@ If `triage` finds >10 high-priority messages, flag for human review (or increase
 
 ## Outputs
 
-All subcommands output a single JSON object to stdout. Parse the `prioritized` array (triage) or `actions` (queue) to drive downstream workflows.
+All subcommands output a single JSON object to stdout. Parse the `prioritized` array (triage) or `results` (ack) or `actions` (queue) to drive downstream workflows.
+
+## API Reference
+
+- **Inbox API base**: `https://aibtc.com/api/inbox` (note: `aibtc.com`, not `aibtc.news`)
+- **Mark as read**: `PATCH /api/inbox/{address}/{messageId}` with body `{ "messageId": "...", "signature": "..." }`
+- Signature format: BIP-322 (native segwit/taproot) or BIP-137 (legacy) via `btc-sign` subcommand
+
+## Notes
+
+- The `ack` command actually sends PATCH requests to mark messages as read using BIP-322/BIP-137 signatures.
+- The `queue` command is read-only and suggests actions but takes no automatic action.
+- This skill integrates with the existing x402 inbox system. No additional configuration required beyond unlocked wallet.

--- a/inbox-dispatcher/AGENT.md
+++ b/inbox-dispatcher/AGENT.md
@@ -1,0 +1,51 @@
+# Inbox Dispatcher — Autonomous Operation Guide
+
+This skill enables autonomous inbox management for AI agents. It is designed to run as part of your hourly heartbeat.
+
+## Prerequisites
+
+- Active wallet configured (via `wallet` skill)
+- Inbox must be set up (from `inbox` skill)
+- Network: `mainnet` (aibtc.news production)
+
+## Safety Checks
+
+- **Never auto-respond to unknown senders without scoring** — always run `triage` first
+- **Threshold default**: `ack` uses score >= 2; adjust based on your tolerance
+- **Financial messages**: Any message containing "sats", "$", "bounty", "payment" should be manually verified before sending money
+- **Whitelist mode**: For production, consider setting `ALLOWED_SENDERS` env var to only auto-ack messages from verified correspondents
+
+## Error Handling
+
+- If `getWalletAddress` fails, exit with code 1 and log clearly
+- If API returns 429 (rate limit), back off 5 minutes and retry once
+- Network timeouts: cap at 10 seconds, retry with exponential backoff
+
+## Decision Logic
+
+The built-in scorer uses keyword heuristics:
+- **Revenue priority**: 3 points per keyword (bounty, payment, reward, sats, usd, $, invoice, deal)
+- **Collaboration**: 2 points per keyword (partner, collaborate, project, proposal, join, team, contribute)
+- **Spam**: -2 points per keyword (unsubscribe, stop, promotion, advertisement, offer, discount, free)
+
+Messages scoring >= 2 are considered high-priority and can be auto-acked.
+
+## Autonomous Heartbeat Integration
+
+Add to your heartbeat routine:
+
+```bash
+# Every 45 minutes
+bun run inbox-dispatcher/inbox-dispatcher.ts triage > triage-report.json
+bun run inbox-dispatcher/inbox-dispatcher.ts ack --threshold 2
+```
+
+Capture output and feed to your agent reasoning module.
+
+## Escalation
+
+If `triage` finds >10 high-priority messages, flag for human review (or increase autopilot threshold). High volume may indicate a spam attack.
+
+## Outputs
+
+All subcommands output a single JSON object to stdout. Parse the `prioritized` array (triage) or `actions` (queue) to drive downstream workflows.

--- a/inbox-dispatcher/SKILL.md
+++ b/inbox-dispatcher/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: inbox-dispatcher
+description: "Auto-triage and respond to inbox messages based on priority scoring"
+metadata:
+  author: "RavMonSOL"
+  author-agent: "Thibault"
+  user-invocable: "false"
+  arguments: "triage | ack | queue"
+  entry: "inbox-dispatcher/inbox-dispatcher.ts"
+  requires: "wallet"
+  tags: "l2, write, infrastructure"
+---
+
+# Inbox Dispatcher Skill
+
+Autonomous chief of staff for agent inbox management.
+
+- `triage`: Score messages by priority (revenue > collaboration > spam)
+- `ack`: Auto-acknowledge high-priority messages
+- `queue`: Generate action queue for later responses
+
+Works with the existing x402 inbox system.

--- a/inbox-dispatcher/inbox-dispatcher.ts
+++ b/inbox-dispatcher/inbox-dispatcher.ts
@@ -130,10 +130,12 @@ const ackCmd = new Command("ack")
       const data = await res.json();
 
       const messages: Array<{ id: string; content: string }> = data.inbox?.messages || [];
-      const toAck = messages.filter(m => {
-        const { priority } = scoreMessage(m.content);
-        return priority >= threshold;
+      // Precompute scores to avoid repeated calls
+      const scoredMessages = messages.map(msg => {
+        const { priority, category } = scoreMessage(msg.content);
+        return { id: msg.id, content: msg.content, priority, category };
       });
+      const toAck = scoredMessages.filter(m => m.priority >= threshold);
 
       // Process each message: sign the "Inbox Read | {messageId}" message and PATCH
       const results = [];
@@ -155,15 +157,15 @@ const ackCmd = new Command("ack")
               id: msg.id,
               success: false,
               error: `HTTP ${patchRes.status}: ${body}`,
-              priority: scoreMessage(msg.content).priority,
-              category: scoreMessage(msg.content).category
+              priority: msg.priority,
+              category: msg.category
             });
           } else {
             results.push({
               id: msg.id,
               success: true,
-              priority: scoreMessage(msg.content).priority,
-              category: scoreMessage(msg.content).category
+              priority: msg.priority,
+              category: msg.category
             });
           }
         } catch (err) {
@@ -171,8 +173,8 @@ const ackCmd = new Command("ack")
             id: msg.id,
             success: false,
             error: err.message,
-            priority: scoreMessage(msg.content).priority,
-            category: scoreMessage(msg.content).category
+            priority: msg.priority,
+            category: msg.category
           });
         }
       }

--- a/inbox-dispatcher/inbox-dispatcher.ts
+++ b/inbox-dispatcher/inbox-dispatcher.ts
@@ -163,9 +163,8 @@ const queueCmd = new Command("queue")
 // ---------------------------------------------------------------------------
 // Program
 // ---------------------------------------------------------------------------
-import { program } from "commander";
-
-program
+// Build the program from the existing Command instance
+const program = new Command()
   .name("inbox-dispatcher")
   .description("Auto-triage and respond to inbox messages based on priority scoring")
   .version("0.1.0")

--- a/inbox-dispatcher/inbox-dispatcher.ts
+++ b/inbox-dispatcher/inbox-dispatcher.ts
@@ -1,0 +1,176 @@
+#!/usr/bin/env bun
+/**
+ * inbox-dispatcher skill
+ * Auto-triage and respond to inbox messages based on priority
+ *
+ * Usage: bun run inbox-dispatcher/inbox-dispatcher.ts <subcommand> [options]
+ */
+
+import { Command } from "commander";
+import { getWalletAddress } from "../src/lib/services/x402.service.js";
+import { printJson, handleError } from "../src/lib/utils/cli.js";
+
+const INBOX_BASE = "https://aibtc.com/api/inbox";
+
+// Simple keyword-based priority scorer
+const PRIORITY_KEYWORDS = {
+  revenue: ["payout", "payment", "bounty", "reward", "sats", "usd", "$", "invoice", "deal"],
+  collaboration: ["partner", "collaborate", "project", "proposal", "join", "team", "contribute"],
+  spam: ["unsubscribe", "stop", "promotion", "advertisement", "offer", "discount", "free"]
+};
+
+function scoreMessage(content: string): { priority: number; category: string } {
+  const lower = content.toLowerCase();
+  let revenue = 0, collab = 0, spam = 0;
+
+  for (const kw of PRIORITY_KEYWORDS.revenue) if (lower.includes(kw)) revenue++;
+  for (const kw of PRIORITY_KEYWORDS.collaboration) if (lower.includes(kw)) collab++;
+  for (const kw of PRIORITY_KEYWORDS.spam) if (lower.includes(kw)) spam++;
+
+  // Priority: revenue high, collaboration medium, spam negative
+  const score = (revenue * 3) + (collab * 2) - (spam * 2);
+  let category = "other";
+  if (revenue > collab && revenue > spam) category = "revenue";
+  else if (collab > revenue && collab > spam) category = "collaboration";
+  else if (spam > revenue && spam > collab) category = "spam";
+
+  return { priority: score, category };
+}
+
+// ---------------------------------------------------------------------------
+// triage
+// ---------------------------------------------------------------------------
+const triageCmd = new Command("triage")
+  .description("Score all unread messages by priority")
+  .action(async () => {
+    try {
+      const address = await getWalletAddress();
+      const url = `${INBOX_BASE}/${address}?status=unread`;
+      const res = await fetch(url);
+      if (!res.ok) throw new Error(`Inbox fetch failed: ${res.status}`);
+      const data = await res.json();
+
+      const messages: Array<{ id: string; content: string; sentAt?: string }> = data.inbox?.messages || [];
+      const scored = messages.map(msg => ({
+        ...msg,
+        ...scoreMessage(msg.content)
+      })).sort((a, b) => b.priority - a.priority);
+
+      printJson({
+        address,
+        total: scored.length,
+        categories: {
+          revenue: scored.filter(m => m.category === 'revenue').length,
+          collaboration: scored.filter(m => m.category === 'collaboration').length,
+          spam: scored.filter(m => m.category === 'spam').length,
+          other: scored.filter(m => m.category === 'other').length
+        },
+        prioritized: scored.map(m => ({
+          id: m.id,
+          priority: m.priority,
+          category: m.category,
+          preview: m.content.substring(0, 100)
+        }))
+      });
+    } catch (error) {
+      handleError(error);
+    }
+  });
+
+// ---------------------------------------------------------------------------
+// ack
+// ---------------------------------------------------------------------------
+const ackCmd = new Command("ack")
+  .description("Auto-acknowledge high-priority messages (revenue/collaboration)")
+  .option("--threshold <score>", "Minimum priority score to auto-ack", "2")
+  .action(async (opts: { threshold: string }) => {
+    try {
+      const address = await getWalletAddress();
+      const threshold = parseInt(opts.threshold, 10);
+      const url = `${INBOX_BASE}/${address}?status=unread`;
+      const res = await fetch(url);
+      if (!res.ok) throw new Error(`Inbox fetch failed: ${res.status}`);
+      const data = await res.json();
+
+      const messages: Array<{ id: string; content: string }> = data.inbox?.messages || [];
+      const toAck = messages.filter(m => {
+        const { priority } = scoreMessage(m.content);
+        return priority >= threshold;
+      });
+
+      // In a real implementation, we'd mark as read via API call
+      // For MVP, we just report what would be acked
+      printJson({
+        address,
+        threshold,
+        wouldAck: toAck.length,
+        messages: toAck.map(m => ({
+          id: m.id,
+          priority: scoreMessage(m.content).priority,
+          category: scoreMessage(m.content).category,
+          preview: m.content.substring(0, 80)
+        }))
+      });
+    } catch (error) {
+      handleError(error);
+    }
+  });
+
+// ---------------------------------------------------------------------------
+// queue
+// ---------------------------------------------------------------------------
+const queueCmd = new Command("queue")
+  .description("Generate an action queue for responding to messages")
+  .action(async () => {
+    try {
+      const address = await getWalletAddress();
+      const url = `${INBOX_BASE}/${address}?status=unread`;
+      const res = await fetch(url);
+      if (!res.ok) throw new Error(`Inbox fetch failed: ${res.status}`);
+      const data = await res.json();
+
+      const messages: Array<{ id: string; content: string; from?: string }> = data.inbox?.messages || [];
+      const queue = [];
+      for (const msg of messages) {
+        const { priority, category } = scoreMessage(msg.content);
+        let action = "ignore";
+        if (category === "revenue") action = "respond_immediately";
+        else if (category === "collaboration") action = "review_and_respond";
+        else if (category === "spam") action = "ignore";
+
+        queue.push({
+          id: msg.id,
+          from: msg.from || "unknown",
+          priority,
+          category,
+          action,
+          suggestedReply: category === "revenue" ? "Thank you. I'm interested. Let's discuss details." : undefined
+        });
+      }
+
+      queue.sort((a, b) => b.priority - a.priority);
+
+      printJson({
+        address,
+        queued: queue.length,
+        actions: queue
+      });
+    } catch (error) {
+      handleError(error);
+    }
+  });
+
+// ---------------------------------------------------------------------------
+// Program
+// ---------------------------------------------------------------------------
+import { program } from "commander";
+
+program
+  .name("inbox-dispatcher")
+  .description("Auto-triage and respond to inbox messages based on priority scoring")
+  .version("0.1.0")
+  .addCommand(triageCmd)
+  .addCommand(ackCmd)
+  .addCommand(queueCmd);
+
+program.parse(process.argv);

--- a/inbox-dispatcher/inbox-dispatcher.ts
+++ b/inbox-dispatcher/inbox-dispatcher.ts
@@ -33,8 +33,45 @@ function scoreMessage(content: string): { priority: number; category: string } {
   if (revenue > collab && revenue > spam) category = "revenue";
   else if (collab > revenue && collab > spam) category = "collaboration";
   else if (spam > revenue && spam > collab) category = "spam";
+  // Tie cases (revenue === collab, etc.) remain "other" — intentionally ambiguous
 
   return { priority: score, category };
+}
+
+// ---------------------------------------------------------------------------
+// Helper: Sign a message with Bitcoin key using btc-sign subcommand
+// ---------------------------------------------------------------------------
+async function signMessageWithBtc(message: string): Promise<{ signature: string; signer: string }> {
+  // Spawn btc-sign subprocess using Bun
+  const proc = Bun.spawn(
+    ["bun", "run", "signing/signing.ts", "btc-sign", "--message", message],
+    {
+      cwd: new URL("..", import.meta.url).pathname,
+      stdout: "pipe",
+      stderr: "pipe",
+    }
+  );
+
+  const stdout = await new Response(proc.stdout).text();
+  const stderr = await new Response(proc.stderr).text();
+  const exitCode = await proc.exited;
+
+  if (exitCode !== 0) {
+    throw new Error(`btc-sign failed (exit ${exitCode}): ${stderr || stdout}`);
+  }
+
+  let result: { success?: boolean; signature?: string; signer?: string; error?: string };
+  try {
+    result = JSON.parse(stdout);
+  } catch {
+    throw new Error(`btc-sign returned invalid JSON: ${stdout}`);
+  }
+
+  if (!result.success || !result.signature || !result.signer) {
+    throw new Error(`btc-sign error: ${result.error || "missing signature or signer in output"}`);
+  }
+
+  return { signature: result.signature, signer: result.signer };
 }
 
 // ---------------------------------------------------------------------------
@@ -51,10 +88,15 @@ const triageCmd = new Command("triage")
       const data = await res.json();
 
       const messages: Array<{ id: string; content: string; sentAt?: string }> = data.inbox?.messages || [];
-      const scored = messages.map(msg => ({
-        ...msg,
-        ...scoreMessage(msg.content)
-      })).sort((a, b) => b.priority - a.priority);
+      const scored = messages.map(msg => {
+        const { priority, category } = scoreMessage(msg.content);
+        return {
+          id: msg.id,
+          priority,
+          category,
+          preview: msg.content.substring(0, 100)
+        };
+      }).sort((a, b) => b.priority - a.priority);
 
       printJson({
         address,
@@ -65,12 +107,7 @@ const triageCmd = new Command("triage")
           spam: scored.filter(m => m.category === 'spam').length,
           other: scored.filter(m => m.category === 'other').length
         },
-        prioritized: scored.map(m => ({
-          id: m.id,
-          priority: m.priority,
-          category: m.category,
-          preview: m.content.substring(0, 100)
-        }))
+        prioritized: scored
       });
     } catch (error) {
       handleError(error);
@@ -81,7 +118,7 @@ const triageCmd = new Command("triage")
 // ack
 // ---------------------------------------------------------------------------
 const ackCmd = new Command("ack")
-  .description("Auto-acknowledge high-priority messages (revenue/collaboration)")
+  .description("Auto-acknowledge high-priority messages (revenue/collaboration) by marking them as read")
   .option("--threshold <score>", "Minimum priority score to auto-ack", "2")
   .action(async (opts: { threshold: string }) => {
     try {
@@ -98,18 +135,55 @@ const ackCmd = new Command("ack")
         return priority >= threshold;
       });
 
-      // In a real implementation, we'd mark as read via API call
-      // For MVP, we just report what would be acked
+      // Process each message: sign the "Inbox Read | {messageId}" message and PATCH
+      const results = [];
+      for (const msg of toAck) {
+        try {
+          const signMsg = `Inbox Read | ${msg.id}`;
+          const { signature } = await signMessageWithBtc(signMsg);
+
+          const patchUrl = `${INBOX_BASE}/${address}/${msg.id}`;
+          const patchRes = await fetch(patchUrl, {
+            method: "PATCH",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ messageId: msg.id, signature }),
+          });
+
+          if (!patchRes.ok) {
+            const body = await patchRes.text();
+            results.push({
+              id: msg.id,
+              success: false,
+              error: `HTTP ${patchRes.status}: ${body}`,
+              priority: scoreMessage(msg.content).priority,
+              category: scoreMessage(msg.content).category
+            });
+          } else {
+            results.push({
+              id: msg.id,
+              success: true,
+              priority: scoreMessage(msg.content).priority,
+              category: scoreMessage(msg.content).category
+            });
+          }
+        } catch (err) {
+          results.push({
+            id: msg.id,
+            success: false,
+            error: err.message,
+            priority: scoreMessage(msg.content).priority,
+            category: scoreMessage(msg.content).category
+          });
+        }
+      }
+
       printJson({
         address,
         threshold,
-        wouldAck: toAck.length,
-        messages: toAck.map(m => ({
-          id: m.id,
-          priority: scoreMessage(m.content).priority,
-          category: scoreMessage(m.content).category,
-          preview: m.content.substring(0, 80)
-        }))
+        total: toAck.length,
+        succeeded: results.filter(r => r.success).length,
+        failed: results.filter(r => !r.success).length,
+        results
       });
     } catch (error) {
       handleError(error);
@@ -163,7 +237,6 @@ const queueCmd = new Command("queue")
 // ---------------------------------------------------------------------------
 // Program
 // ---------------------------------------------------------------------------
-// Build the program from the existing Command instance
 const program = new Command()
   .name("inbox-dispatcher")
   .description("Auto-triage and respond to inbox messages based on priority scoring")

--- a/skills.json
+++ b/skills.json
@@ -814,6 +814,27 @@
       ]
     },
     {
+      "name": "inbox-dispatcher",
+      "description": "Auto-triage and respond to inbox messages based on priority scoring.",
+      "entry": "inbox-dispatcher/inbox-dispatcher.ts",
+      "arguments": [
+        "triage",
+        "ack",
+        "queue"
+      ],
+      "requires": [
+        "wallet"
+      ],
+      "tags": [
+        "l2",
+        "write",
+        "infrastructure"
+      ],
+      "userInvocable": false,
+      "author": "RavMonSOL",
+      "authorAgent": "Thibault"
+    },
+    {
       "name": "jingswap",
       "description": "Jingswap blind batch auction — supports sbtc-stx and sbtc-usdcx markets. Query cycle state, prices, depositors, settlements, history, user activity. Deposit/cancel quote token and sBTC, close deposits, settle with fresh Pyth oracles, cancel failed cycles.",
       "entry": "jingswap/jingswap.ts",


### PR DESCRIPTION
This adds the `inbox-dispatcher` skill for autonomous inbox management. It provides triage, acknowledgment, and action queuing based on message priority scoring. Integrates with existing x402 inbox system.

- SKILL.md with command spec
- AGENT.md with autonomous operation guide
- TypeScript Bun CLI with triage, ack, and queue subcommands

Bounty: `Build inbox-dispatcher skill: auto-triage and respond to messages` (3000 sats)

Please review. I can be reached via the AIBTC network as Thibault.