### PR TITLE
fix(relay-diagnostic): read pool state fields and align URL/thresholds

### DIFF
--- a/relay-diagnostic/relay-diagnostic.ts
+++ b/relay-diagnostic/relay-diagnostic.ts
@@ -103,7 +103,16 @@ async function checkRelayHealth(
   try {
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), 30000);
-    let healthData: { status?: string; version?: string };
+    let healthData: {
+      status?: string;
+      version?: string;
+      nonce?: {
+        circuitBreakerOpen?: boolean;
+        poolStatus?: string;
+        effectiveCapacity?: number;
+        conflictsDetected?: number;
+      };
+    };
     try {
       const healthRes = await fetch(`${relayUrl}/health`, {
         method: "GET",
@@ -128,6 +137,19 @@ async function checkRelayHealth(
 
     if (healthData.status !== "ok") {
       issues.push(`Relay status: ${healthData.status ?? "unknown"}`);
+    }
+
+    if (healthData.nonce?.circuitBreakerOpen) {
+      issues.push("Relay nonce circuit breaker is OPEN — sponsored transactions will fail");
+    }
+    if (healthData.nonce?.poolStatus && healthData.nonce.poolStatus !== "healthy") {
+      issues.push(`Relay nonce pool status: ${healthData.nonce.poolStatus}`);
+    }
+    if (healthData.nonce?.effectiveCapacity !== undefined && healthData.nonce.effectiveCapacity < 3) {
+      issues.push(`Relay nonce pool capacity low: ${healthData.nonce.effectiveCapacity} wallets available`);
+    }
+    if (healthData.nonce?.conflictsDetected !== undefined && healthData.nonce.conflictsDetected > 5) {
+      issues.push(`Relay nonce conflicts elevated: ${healthData.nonce.conflictsDetected} detected`);
     }
 
     const sponsorAddress = SPONSOR_ADDRESSES[network];
@@ -162,7 +184,7 @@ async function checkRelayHealth(
       issues.push(
         `Mempool desync detected: sponsor nonce ${lastExecuted} (executed) vs ${lastMempool} (mempool), gap of ${desyncGap}`
       );
-    } else if (nonceInfo.detected_mempool_nonces.length > 10) {
+    } else if (nonceInfo.detected_mempool_nonces.length > 5) {
       issues.push(
         `Sponsor has ${nonceInfo.detected_mempool_nonces.length} transactions stuck in mempool`
       );

--- a/settings/SKILL.md
+++ b/settings/SKILL.md
@@ -192,7 +192,7 @@ bun run settings/settings.ts check-relay-health [--relay-url <url>] [--sponsor-a
 ```
 
 Options:
-- `--relay-url` (optional) — Base URL of the sponsor relay (default: `https://sponsor.aibtc.dev`)
+- `--relay-url` (optional) — Base URL of the sponsor relay (default: `https://x402-relay.aibtc.com`)
 - `--sponsor-address` (optional) — STX address of the relay sponsor (default: `SP1PMPPVCMVW96FSWFV30KJQ4MNBMZ8MRWR3JWQ7`)
 
 Output (healthy):
@@ -200,7 +200,7 @@ Output (healthy):
 {
   "healthy": true,
   "relay": {
-    "url": "https://sponsor.aibtc.dev",
+    "url": "https://x402-relay.aibtc.com",
     "reachable": true,
     "status": "ok",
     "version": "1.0.0"
@@ -222,7 +222,7 @@ Output (issues detected):
 ```json
 {
   "healthy": false,
-  "relay": { "url": "https://sponsor.aibtc.dev", "reachable": false, "error": "fetch failed" },
+  "relay": { "url": "https://x402-relay.aibtc.com", "reachable": false, "error": "fetch failed" },
   "sponsor": {
     "address": "SP1PMPPVCMVW96FSWFV30KJQ4MNBMZ8MRWR3JWQ7",
     "lastExecutedNonce": 732,

--- a/settings/settings.ts
+++ b/settings/settings.ts
@@ -307,7 +307,7 @@ program
   .option(
     "--relay-url <url>",
     "Base URL of the sponsor relay",
-    "https://sponsor.aibtc.dev"
+    "https://x402-relay.aibtc.com"
   )
   .option(
     "--sponsor-address <address>",
@@ -380,6 +380,18 @@ program
 
         if (!relayReachable) {
           issues.push(`Relay unreachable: ${relayError ?? "unknown error"}`);
+        }
+
+        if (relayHealth) {
+          const nonce = (relayHealth as Record<string, unknown>).nonce as
+            | Record<string, unknown>
+            | undefined;
+          if (nonce?.circuitBreakerOpen === true) {
+            issues.push("Relay nonce circuit breaker is OPEN — sponsored transactions will fail");
+          }
+          if (nonce?.poolStatus && nonce.poolStatus !== "healthy") {
+            issues.push(`Relay nonce pool status: ${String(nonce.poolStatus)}`);
+          }
         }
 
         if (nonceData) {

--- a/settings/settings.ts
+++ b/settings/settings.ts
@@ -392,6 +392,12 @@ program
           if (nonce?.poolStatus && nonce.poolStatus !== "healthy") {
             issues.push(`Relay nonce pool status: ${String(nonce.poolStatus)}`);
           }
+          if (nonce?.effectiveCapacity !== undefined && typeof nonce.effectiveCapacity === "number" && nonce.effectiveCapacity < 3) {
+            issues.push(`Relay nonce pool capacity low: ${nonce.effectiveCapacity} wallets available`);
+          }
+          if (nonce?.conflictsDetected !== undefined && typeof nonce.conflictsDetected === "number" && nonce.conflictsDetected > 5) {
+            issues.push(`Relay nonce conflicts elevated: ${nonce.conflictsDetected} detected`);
+          }
         }
 
         if (nonceData) {


### PR DESCRIPTION
## Summary
- Read `nonce.circuitBreakerOpen`, `poolStatus`, `effectiveCapacity`, `conflictsDetected` from relay `/health` — previously ignored, causing healthy reports when pool is degraded
- Align mempool congestion threshold to `>5` in relay-diagnostic (was `>10`, settings.ts already used `>5`)
- Fix default relay URL in settings.ts from `sponsor.aibtc.dev` to `x402-relay.aibtc.com` to match `sponsor.ts`
- Add pool state checks to settings.ts `check-relay-health` command

Fixes #262

## Test plan
- [ ] Run `relay-diagnostic check-health` and verify pool state fields appear in output
- [ ] Run `settings check-relay-health` and verify it uses the correct relay URL
- [ ] Confirm circuit breaker and pool status warnings surface when relay is degraded

🤖 Generated with [Claude Code](https://claude.com/claude-code)