### PR TITLE
fix: hodlmm-range-keeper — final version with arc0btc review fixes

### DIFF
--- a/hodlmm-range-keeper/AGENT.md
+++ b/hodlmm-range-keeper/AGENT.md
@@ -1,0 +1,67 @@
+---
+name: hodlmm-range-keeper-agent
+skill: hodlmm-range-keeper
+description: "Agent behavior rules for the HODLMM Range Keeper — active position management skill."
+---
+
+# Agent Behavior — HODLMM Range Keeper
+
+## Decision order
+1. Run `doctor` to verify wallet, HODLMM API access, and MCP tool availability.
+2. Run `status` to assess all positions: drift, range efficiency, fee accrual.
+3. If any position shows `needsRecenter: true`:
+   a. Run `plan --pool <id>` to preview the re-center.
+   b. Confirm the plan is profitable and safe.
+   c. Run `recenter --pool <id> --confirm` to execute.
+4. If no positions need re-centering, report status and skip.
+5. For fully autonomous operation, use `run --confirm` which handles all steps internally.
+
+## Guardrails
+- **NEVER recenter without --confirm.** The flag is a safety gate on real fund movement.
+- **NEVER force a recenter** (`--force`) unless drift is critical and the user explicitly approves.
+- **NEVER recenter during cooldown.** The 30-minute cooldown prevents churn and excessive gas burn.
+- **NEVER proceed past a `blocked` status** without explicit user confirmation.
+- **ALWAYS run `status` or `plan` before `recenter`** to understand current drift and expected outcome.
+- **ALWAYS verify gas sufficiency** — the skill checks STX balance but the agent should surface low-gas warnings proactively.
+- **ALWAYS preserve fee baselines** — never manually edit `~/.hodlmm-range-keeper.json`.
+- Never expose secrets or private keys in args or logs.
+
+## Autonomous scheduling
+```
+1. Cron runs `run` every 15 minutes (dry-run)
+2. If any pool shows needsRecenter: true → run `run --confirm`
+3. On partial failure (withdraw succeeds, deposit fails) → alert user, do NOT retry automatically
+4. Run `history` daily to audit recenter activity
+```
+
+## Re-center strategy
+The skill re-centers by:
+1. Withdrawing all liquidity from current bins
+2. Separating fee growth from principal (fees are harvested/kept)
+3. Re-depositing principal into bins centered on the current active bin (+/- 2 bins = 5 bins total)
+4. Recording new baselines for the fresh position
+
+## Risk management
+- **Drift < 3 bins**: No action. Position is earning normally.
+- **Drift 3-5 bins**: Standard recenter. Most common scenario.
+- **Drift > 5 bins**: High urgency — position is mostly idle. Execute promptly.
+- **Range efficiency < 20%**: Emergency recenter even if drift is below threshold.
+- **Cooldown active**: Wait. Do not bypass.
+- **Gas > 50 STX**: Do not execute. Flag as anomalous.
+
+## On error
+- Log the error payload with pool ID and drift context
+- Do not retry recenter silently — each attempt costs gas
+- On "blocked": read the error, it explains the specific blocker
+- On partial failure (withdraw ok, deposit failed): funds are in wallet, not lost. Alert user.
+
+## On success
+- Confirm old center, new center, drift corrected, bins re-deployed
+- Report fees harvested vs. principal re-deployed
+- Log MCP tool calls and expected tx results for audit trail
+- Update state file with new baselines
+
+## Integration with other skills
+- Compose with `hodlmm-liquidity-tide` for timing signals — if tide is FALLING, defer non-urgent recenters
+- Compose with `hodlmm-fee-harvester` for fee tracking — range-keeper handles its own baselines but fee-harvester provides deeper per-bin analysis
+- After recenter, positions appear as new deposits to other skills

--- a/hodlmm-range-keeper/SKILL.md
+++ b/hodlmm-range-keeper/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: hodlmm-range-keeper
+description: "Active HODLMM position manager that monitors bin drift, estimates accrued fees, and re-centers liquidity around the active bin when profitable."
+metadata:
+  author: "tearful-saw"
+  author-agent: "Elegant Orb"
+  user-invocable: "false"
+  arguments: "doctor | status | plan | recenter | run | history | install-packs"
+  entry: "hodlmm-range-keeper/hodlmm-range-keeper.ts"
+  requires: "wallet, signing, settings"
+  tags: "defi, write, mainnet-only, requires-funds, l2"
+---
+
+# HODLMM Range Keeper
+
+## What it does
+Actively manages HODLMM concentrated-liquidity positions by monitoring active-bin drift, estimating fee accrual, and re-centering LP ranges when the market moves away. Unlike signal-only analytics skills, this closes the full management loop: detect drift, plan the re-center, simulate the outcome, execute via MCP tools, and verify. Supports autonomous `run` mode that scans all pools and re-centers any drifted position in a single cycle.
+
+## Why agents need it
+HODLMM concentrated liquidity earns fees only when the active bin is within your position range. When price moves, the active bin drifts away and your liquidity sits idle — earning nothing while exposed to impermanent loss. Manual monitoring is impractical across multiple pools. This skill turns passive LP deposits into actively managed positions: it tracks where your bins are, where the market is, and moves your liquidity to stay in range and keep earning.
+
+## Safety notes
+- **Writes to chain**: Withdraws liquidity and re-deposits into new bins. Real funds move.
+- **Drift threshold**: Will not re-center unless the active bin drifts >= 3 bins from your position center (configurable).
+- **Cooldown**: 30-minute cooldown between recenters on the same pool to prevent churn.
+- **Gas cap**: 50 STX maximum per cycle. Will not execute if gas estimate exceeds cap.
+- **Dust filter**: Ignores positions < 5,000 sats to avoid unprofitable micro-recenters.
+- **--confirm gate**: The `recenter` command requires explicit `--confirm` flag. Without it, nothing executes.
+- **Fee preservation**: Tracks deposit baselines per bin. On re-center, fees above baseline are harvested (kept); only principal is re-deployed.
+- **Mainnet only**: HODLMM is not available on testnet.
+- **MCP execution**: Actual on-chain transactions are emitted as MCP tool calls (`bitflow_hodlmm_remove_liquidity`, `bitflow_hodlmm_add_liquidity`). The agent runtime executes them.
+
+## Commands
+
+### doctor
+Check wallet, HODLMM API access, pool availability, existing positions, and MCP tool requirements. Read-only, safe to run anytime.
+```bash
+STX_ADDRESS=SP... bun run hodlmm-range-keeper/hodlmm-range-keeper.ts doctor
+```
+
+### status
+Analyze all LP positions: drift magnitude, range efficiency (% of bins in active range), estimated fees, and whether re-centering is needed. Records fee baselines locally on first observation; otherwise read-only.
+```bash
+STX_ADDRESS=SP... bun run hodlmm-range-keeper/hodlmm-range-keeper.ts status
+STX_ADDRESS=SP... bun run hodlmm-range-keeper/hodlmm-range-keeper.ts status --pool dlmm_1
+```
+
+### plan
+Dry-run a re-center: simulate withdraw and re-deposit, show expected bin layout, fees harvested, gas cost. No funds move.
+```bash
+STX_ADDRESS=SP... bun run hodlmm-range-keeper/hodlmm-range-keeper.ts plan --pool dlmm_1
+```
+
+### recenter
+Execute the re-center: withdraw from drifted bins, harvest fees, re-deposit principal around active bin. Requires --confirm.
+```bash
+STX_ADDRESS=SP... bun run hodlmm-range-keeper/hodlmm-range-keeper.ts recenter --pool dlmm_1 --confirm
+```
+
+### run
+Full autonomous cycle: scan all pools, assess drift, plan and execute recenters where needed. Use --confirm for live execution, omit for dry-run.
+```bash
+STX_ADDRESS=SP... bun run hodlmm-range-keeper/hodlmm-range-keeper.ts run
+STX_ADDRESS=SP... bun run hodlmm-range-keeper/hodlmm-range-keeper.ts run --confirm
+```
+
+### history
+Show past re-center events from local ledger. Useful for auditing position management.
+```bash
+bun run hodlmm-range-keeper/hodlmm-range-keeper.ts history
+bun run hodlmm-range-keeper/hodlmm-range-keeper.ts history --pool dlmm_1 --limit 10
+```
+
+## Output contract
+
+All outputs are JSON to stdout. Logs go to stderr.
+
+**Success:**
+```json
+{ "status": "success", "action": "status", "data": { "positionsAnalyzed": 2, "needsRecenter": 1, "positions": [...] }, "error": null }
+```
+
+**Recenter ready:**
+```json
+{ "status": "success", "action": "execute_mcp", "data": { "step1_withdraw": { "tool": "bitflow_hodlmm_remove_liquidity", "params": {...} }, "step2_deposit": { "tool": "bitflow_hodlmm_add_liquidity", "params": {...} }, "summary": {...} }, "error": null }
+```
+
+**Blocked:**
+```json
+{ "status": "blocked", "action": "recenter", "data": { "cooldownRemainingMinutes": 15 }, "error": "Cooldown active." }
+```
+
+**Error:**
+```json
+{ "status": "error", "action": "recenter", "data": null, "error": "Pool dlmm_99 not found." }
+```
+
+### install-packs
+No external packs required. Returns success immediately.
+```bash
+bun run hodlmm-range-keeper/hodlmm-range-keeper.ts install-packs --pack all
+```
+
+## Known constraints
+- Mainnet only — HODLMM has no testnet deployment
+- Fee estimation requires a baseline — first `status` after fresh install records current state as baseline (zero estimated fees until next check)
+- Position re-centering executes as two sequential MCP calls (withdraw then deposit) — partial failure is possible if the deposit tx fails after a successful withdraw. In that case, funds are in the wallet, not lost. State is recorded optimistically before MCP execution; on partial failure, baselines reset and the next `status` call re-establishes them from current on-chain state.
+- Active bin can move between the plan and recenter steps. The skill uses the latest active bin at execution time.
+- HODLMM API (`bff.bitflowapis.finance`) may lag 1-2 blocks behind chain state
+- Gas estimation is conservative (4 STX for 2 txs). Actual gas is typically lower.

--- a/hodlmm-range-keeper/hodlmm-range-keeper.ts
+++ b/hodlmm-range-keeper/hodlmm-range-keeper.ts
@@ -94,6 +94,7 @@ interface PoolState {
   baselines: Record<number, PositionBaseline>;
   lastRecenterAt: string | null;
   lastActiveBin: number | null;
+  pendingVerification?: boolean;
 }
 
 interface KeeperState {
@@ -285,6 +286,7 @@ function analyzePosition(
     needsRecenter,
     reason,
     cooldownRemaining,
+    pendingVerification: poolState.pendingVerification || false,
   };
 }
 
@@ -589,6 +591,12 @@ program
         }
       }
 
+      // Clear pending verification — on-chain state successfully read
+      if (poolState.pendingVerification) {
+        log(`Pool ${poolId}: clearing pending_verification — on-chain state re-established`);
+        poolState.pendingVerification = false;
+      }
+
       const health = analyzePosition(poolId, poolMeta.active_bin, significantBins, poolState);
       results.push(health);
 
@@ -767,9 +775,10 @@ program
 
     state.recenters.push(event);
 
-    // Update pool state
+    // Update pool state — mark pending until MCP execution confirms
     poolState.lastRecenterAt = new Date().toISOString();
     poolState.lastActiveBin = plan.newCenter;
+    poolState.pendingVerification = true;
 
     // Reset baselines for new deposit bins
     poolState.baselines = {};
@@ -860,14 +869,24 @@ program
     const pools = await fetchAllPools();
     const stxBalance = await fetchStxBalance(stxAddress);
 
+    // Fetch all positions in parallel (reads are safe to batch)
+    const positionFetches = await Promise.allSettled(
+      pools.map(async (poolMeta) => {
+        const userBins = await fetchUserPositions(poolMeta.pool_id, stxAddress);
+        return { poolMeta, userBins };
+      })
+    );
+
     const results: any[] = [];
     let recentersExecuted = 0;
     let remainingStxBalance = stxBalance;
 
-    for (const poolMeta of pools) {
+    // Iterate sequentially for execution decisions (fund operations must be serial)
+    for (const result of positionFetches) {
       if (recentersExecuted >= MAX_RECENTER_PER_CYCLE) break;
+      if (result.status !== "fulfilled") continue;
 
-      const userBins = await fetchUserPositions(poolMeta.pool_id, stxAddress);
+      const { poolMeta, userBins } = result.value;
       if (userBins.length === 0) continue;
 
       const significantBins = userBins.filter((b) => {
@@ -877,6 +896,12 @@ program
       if (significantBins.length === 0) continue;
 
       const poolState = getPoolState(state, poolMeta.pool_id);
+
+      // Clear pending verification — on-chain state successfully read
+      if (poolState.pendingVerification) {
+        log(`Pool ${poolMeta.pool_id}: clearing pending_verification — on-chain state re-established`);
+        poolState.pendingVerification = false;
+      }
 
       // Record baselines for new bins
       for (const bin of significantBins) {
@@ -942,6 +967,7 @@ program
 
           poolState.lastRecenterAt = new Date().toISOString();
           poolState.lastActiveBin = plan.newCenter;
+          poolState.pendingVerification = true;
           poolState.baselines = {};
           for (const bin of plan.depositBins) {
             poolState.baselines[bin.bin_id] = {

--- a/hodlmm-range-keeper/hodlmm-range-keeper.ts
+++ b/hodlmm-range-keeper/hodlmm-range-keeper.ts
@@ -1,0 +1,1021 @@
+#!/usr/bin/env bun
+/**
+ * hodlmm-range-keeper — Active HODLMM Position Manager
+ *
+ * Monitors active-bin drift relative to LP positions, estimates accrued fees,
+ * and re-centers liquidity into optimal bins when profitable and safe.
+ *
+ * Unlike signal-only skills, this skill closes the full loop:
+ *   detect drift → estimate P&L → simulate re-center → execute → verify
+ *
+ * Commands:
+ *   doctor   — check wallet, API access, positions, MCP tools
+ *   status   — show position health: drift, fees, range efficiency
+ *   plan     — dry-run re-center: simulate withdraw + re-deposit, show expected outcome
+ *   recenter — execute re-center: withdraw drifted liquidity, re-deposit around active bin
+ *   history  — show past re-center events from ledger
+ */
+
+import { Command } from "commander";
+import { readFileSync, writeFileSync, existsSync } from "fs";
+import { join } from "path";
+import { homedir } from "os";
+
+// ─── Config ───────────────────────────────────────────────────────────────
+const HODLMM_API = "https://bff.bitflowapis.finance/api/quotes/v1";
+const HODLMM_APP_API = "https://bff.bitflowapis.finance";
+const HIRO_API = "https://api.hiro.so";
+
+// Safety limits
+const MAX_GAS_STX = 50;
+const DEFAULT_GAS_ESTIMATE_STX = 4; // 2 txs: withdraw + deposit
+const MIN_POSITION_SATS = 5_000;
+const HODLMM_SLIPPAGE_PCT = 0.5;
+const DEFAULT_BIN_RANGE = 2; // +/- 2 bins around active bin = 5 bins total
+const MIN_HARVEST_MULTIPLIER = 2; // fees must cover 2x gas to justify recenter
+const MAX_RECENTER_PER_CYCLE = 3; // max pools per run
+const COOLDOWN_MS = 30 * 60 * 1000; // 30 min between recenters on same pool
+const DRIFT_THRESHOLD = 3; // active bin must drift >= 3 bins from position center
+
+// State
+const STATE_PATH = join(homedir(), ".hodlmm-range-keeper.json");
+
+// ─── Output ──────────────────────────────────────────────────────────────
+function output(status: string, action: string, data: any, error: any = null) {
+  console.log(JSON.stringify({ status, action, data, error }));
+}
+
+function log(...args: any[]) {
+  console.error("[range-keeper]", ...args);
+}
+
+// ─── Types ───────────────────────────────────────────────────────────────
+interface BinData {
+  bin_id: number;
+  reserve_x: string;
+  reserve_y: string;
+  userLiquidity?: number;
+  price?: number;
+}
+
+interface PoolMeta {
+  pool_id: string;
+  active_bin: number;
+  token_x: string;
+  token_y: string;
+  bin_step: number;
+}
+
+interface PositionBaseline {
+  binId: number;
+  depositX: string;
+  depositY: string;
+  recordedAt: string;
+}
+
+interface RecenterEvent {
+  poolId: string;
+  timestamp: string;
+  status?: "pending_verification" | "confirmed" | "failed";
+  oldCenter: number;
+  newCenter: number;
+  drift: number;
+  binsWithdrawn: number;
+  binsDeposited: number;
+  feesEstimatedX: number;
+  feesEstimatedY: number;
+  gasEstimateSTX: number;
+  mcpWithdrawCmd: string;
+  mcpDepositCmd: string;
+}
+
+interface PoolState {
+  poolId: string;
+  baselines: Record<number, PositionBaseline>;
+  lastRecenterAt: string | null;
+  lastActiveBin: number | null;
+}
+
+interface KeeperState {
+  pools: Record<string, PoolState>;
+  recenters: RecenterEvent[];
+}
+
+// ─── State Management ────────────────────────────────────────────────────
+function loadState(): KeeperState {
+  try {
+    if (existsSync(STATE_PATH)) {
+      return JSON.parse(readFileSync(STATE_PATH, "utf-8"));
+    }
+  } catch {}
+  return { pools: {}, recenters: [] };
+}
+
+function saveState(state: KeeperState): void {
+  if (state.recenters.length > 500) {
+    state.recenters = state.recenters.slice(-500);
+  }
+  writeFileSync(STATE_PATH, JSON.stringify(state, null, 2));
+}
+
+function getPoolState(state: KeeperState, poolId: string): PoolState {
+  if (!state.pools[poolId]) {
+    state.pools[poolId] = {
+      poolId,
+      baselines: {},
+      lastRecenterAt: null,
+      lastActiveBin: null,
+    };
+  }
+  return state.pools[poolId];
+}
+
+// ─── API Layer ───────────────────────────────────────────────────────────
+async function fetchJson(url: string): Promise<any> {
+  try {
+    const r = await fetch(url, { signal: AbortSignal.timeout(15_000) });
+    if (!r.ok) return null;
+    return r.json();
+  } catch {
+    return null;
+  }
+}
+
+async function fetchAllPools(): Promise<PoolMeta[]> {
+  const data = await fetchJson(`${HODLMM_API}/pools`);
+  return data?.pools || [];
+}
+
+async function fetchPoolBins(poolId: string): Promise<{ active_bin_id: number; bins: BinData[] } | null> {
+  return fetchJson(`${HODLMM_API}/bins/${poolId}`);
+}
+
+async function fetchUserPositions(poolId: string, address: string): Promise<BinData[]> {
+  const data = await fetchJson(
+    `${HODLMM_APP_API}/api/app/v1/users/${address}/positions/${poolId}/bins`
+  );
+  if (!data?.bins) return [];
+  return data.bins.map((b: any) => ({
+    bin_id: parseInt(b.bin_id),
+    reserve_x: String(b.reserve_x !== undefined && b.reserve_x !== null ? b.reserve_x : Math.floor(b.userLiquidity || 0)),
+    reserve_y: String(b.reserve_y !== undefined && b.reserve_y !== null ? b.reserve_y : "0"),
+    userLiquidity: b.userLiquidity || 0,
+    price: b.price || 0,
+  }));
+}
+
+async function fetchStxBalance(address: string): Promise<number> {
+  const data = await fetchJson(`${HIRO_API}/extended/v1/address/${address}/stx`);
+  return data ? parseInt(data.balance || "0") / 1e6 : 0;
+}
+
+// ─── Position Analysis ──────────────────────────────────────────────────
+interface PositionHealth {
+  poolId: string;
+  activeBin: number;
+  positionCenter: number;
+  positionBins: number[];
+  drift: number; // signed: positive = price moved up past position
+  driftAbs: number;
+  rangeEfficiency: number; // % of bins still in active range
+  totalValueX: number;
+  totalValueY: number;
+  estimatedFeesX: number;
+  estimatedFeesY: number;
+  needsRecenter: boolean;
+  reason: string;
+  cooldownRemaining: number; // ms until recenter allowed, 0 = ready
+}
+
+function analyzePosition(
+  poolId: string,
+  activeBin: number,
+  userBins: BinData[],
+  poolState: PoolState
+): PositionHealth {
+  if (userBins.length === 0) {
+    return {
+      poolId,
+      activeBin,
+      positionCenter: 0,
+      positionBins: [],
+      drift: 0,
+      driftAbs: 0,
+      rangeEfficiency: 0,
+      totalValueX: 0,
+      totalValueY: 0,
+      estimatedFeesX: 0,
+      estimatedFeesY: 0,
+      needsRecenter: false,
+      reason: "no position",
+      cooldownRemaining: 0,
+    };
+  }
+
+  const binIds = userBins.map((b) => b.bin_id).sort((a, b) => a - b);
+  const positionCenter = Math.round(binIds.reduce((s, b) => s + b, 0) / binIds.length);
+  const drift = activeBin - positionCenter;
+
+  // Range efficiency: how many of our bins are within DEFAULT_BIN_RANGE of active bin
+  const inRange = binIds.filter(
+    (b) => Math.abs(b - activeBin) <= DEFAULT_BIN_RANGE
+  ).length;
+  const rangeEfficiency = binIds.length > 0 ? (inRange / binIds.length) * 100 : 0;
+
+  // Total position value (BigInt for atomic-unit precision)
+  let totalValueX = 0n;
+  let totalValueY = 0n;
+  for (const bin of userBins) {
+    totalValueX += BigInt(bin.reserve_x || "0");
+    totalValueY += BigInt(bin.reserve_y || "0");
+  }
+
+  // Fee estimation against baselines
+  let estimatedFeesX = 0n;
+  let estimatedFeesY = 0n;
+  for (const bin of userBins) {
+    const baseline = poolState.baselines[bin.bin_id];
+    if (baseline) {
+      const currentX = BigInt(bin.reserve_x || "0");
+      const currentY = BigInt(bin.reserve_y || "0");
+      const baseX = BigInt(baseline.depositX || "0");
+      const baseY = BigInt(baseline.depositY || "0");
+      if (currentX > baseX) estimatedFeesX += currentX - baseX;
+      if (currentY > baseY) estimatedFeesY += currentY - baseY;
+    }
+  }
+
+  // Cooldown check
+  let cooldownRemaining = 0;
+  if (poolState.lastRecenterAt) {
+    const elapsed = Date.now() - new Date(poolState.lastRecenterAt).getTime();
+    cooldownRemaining = Math.max(0, COOLDOWN_MS - elapsed);
+  }
+
+  // Decision: needs recenter?
+  let needsRecenter = false;
+  let reason = "in range";
+
+  if (cooldownRemaining > 0) {
+    reason = `cooldown: ${Math.ceil(cooldownRemaining / 60_000)}m remaining`;
+  } else if (Math.abs(drift) >= DRIFT_THRESHOLD) {
+    needsRecenter = true;
+    reason = `drift ${drift > 0 ? "+" : ""}${drift} bins (threshold: ${DRIFT_THRESHOLD})`;
+  } else if (rangeEfficiency < 20 && binIds.length > 0) {
+    needsRecenter = true;
+    reason = `range efficiency ${rangeEfficiency.toFixed(0)}% — most bins out of range`;
+  } else if (rangeEfficiency >= 80) {
+    reason = `healthy — ${rangeEfficiency.toFixed(0)}% in range, drift ${drift > 0 ? "+" : ""}${drift}`;
+  } else {
+    reason = `monitoring — ${rangeEfficiency.toFixed(0)}% in range, drift ${drift > 0 ? "+" : ""}${drift}`;
+  }
+
+  return {
+    poolId,
+    activeBin,
+    positionCenter,
+    positionBins: binIds,
+    drift,
+    driftAbs: Math.abs(drift),
+    rangeEfficiency: Math.round(rangeEfficiency * 100) / 100,
+    totalValueX: Number(totalValueX),
+    totalValueY: Number(totalValueY),
+    estimatedFeesX: Number(estimatedFeesX),
+    estimatedFeesY: Number(estimatedFeesY),
+    needsRecenter,
+    reason,
+    cooldownRemaining,
+  };
+}
+
+// ─── Re-center Planning ──────────────────────────────────────────────────
+interface RecenterPlan {
+  poolId: string;
+  profitable: boolean;
+  withdrawBins: { bin_id: number; amount_x: string; amount_y: string }[];
+  depositBins: { bin_id: number; amount_x: string; amount_y: string }[];
+  totalWithdrawX: number;
+  totalWithdrawY: number;
+  feesHarvestedX: number;
+  feesHarvestedY: number;
+  principalRedeployX: number;
+  principalRedeployY: number;
+  gasEstimateSTX: number;
+  newCenter: number;
+  oldCenter: number;
+  drift: number;
+  mcpWithdrawCmd: string;
+  mcpDepositCmd: string;
+  rejectionReason: string | null;
+}
+
+function planRecenter(
+  health: PositionHealth,
+  userBins: BinData[],
+  poolState: PoolState
+): RecenterPlan {
+  const activeBin = health.activeBin;
+  const gasEstimate = DEFAULT_GAS_ESTIMATE_STX;
+  const newRange = DEFAULT_BIN_RANGE;
+
+  // Build withdraw list: all current bins
+  const withdrawBins = userBins.map((b) => ({
+    bin_id: b.bin_id,
+    amount_x: b.reserve_x || "0",
+    amount_y: b.reserve_y || "0",
+  }));
+
+  const totalWithdrawX = withdrawBins.reduce((s, b) => s + BigInt(b.amount_x), 0n);
+  const totalWithdrawY = withdrawBins.reduce((s, b) => s + BigInt(b.amount_y), 0n);
+
+  // Calculate fees (growth over baseline)
+  let totalBaselineX = 0n;
+  let totalBaselineY = 0n;
+  let hasBaseline = false;
+
+  for (const bin of userBins) {
+    const baseline = poolState.baselines[bin.bin_id];
+    if (baseline) {
+      hasBaseline = true;
+      totalBaselineX += BigInt(baseline.depositX || "0");
+      totalBaselineY += BigInt(baseline.depositY || "0");
+    }
+  }
+
+  const feesX = hasBaseline && totalWithdrawX > totalBaselineX ? totalWithdrawX - totalBaselineX : 0n;
+  const feesY = hasBaseline && totalWithdrawY > totalBaselineY ? totalWithdrawY - totalBaselineY : 0n;
+
+  // Principal = total - fees (what we re-deploy)
+  const principalX = totalWithdrawX - feesX;
+  const principalY = totalWithdrawY - feesY;
+
+  // Profitability check: is the re-center worth the gas?
+  // We don't require fees to cover gas — drift correction itself has value
+  // But if we're harvesting fees, they should exceed gas
+  let profitable = true;
+  let rejectionReason: string | null = null;
+
+  const minSats = BigInt(MIN_POSITION_SATS);
+  if (totalWithdrawX < minSats && totalWithdrawY < minSats) {
+    profitable = false;
+    rejectionReason = `position too small: ${totalWithdrawX} X + ${totalWithdrawY} Y (min ${MIN_POSITION_SATS})`;
+  }
+
+  if (gasEstimate > MAX_GAS_STX) {
+    profitable = false;
+    rejectionReason = `gas estimate ${gasEstimate} STX exceeds cap ${MAX_GAS_STX} STX`;
+  }
+
+  // Build deposit bins centered on active bin
+  const depositBins: { bin_id: number; amount_x: string; amount_y: string }[] = [];
+  const binCount = BigInt(newRange * 2 + 1);
+  const perBinX = principalX / binCount;
+  const perBinY = principalY / binCount;
+
+  for (let offset = -newRange; offset <= newRange; offset++) {
+    const binId = activeBin + offset;
+    // Below active bin: quote side (Y). Active bin: both sides. Above: base side (X)
+    if (offset < 0) {
+      depositBins.push({
+        bin_id: binId,
+        amount_x: "0",
+        amount_y: String(perBinY > 0n ? perBinY : perBinX),
+      });
+    } else if (offset === 0) {
+      // Active bin holds both X and Y proportionally
+      depositBins.push({
+        bin_id: binId,
+        amount_x: String(perBinX > 0n ? perBinX : 0n),
+        amount_y: String(perBinY > 0n ? perBinY : 0n),
+      });
+    } else {
+      depositBins.push({
+        bin_id: binId,
+        amount_x: String(perBinX > 0n ? perBinX : perBinY),
+        amount_y: "0",
+      });
+    }
+  }
+
+  // Build MCP command strings
+  const poolId = health.poolId;
+  const mcpWithdrawCmd = [
+    `bitflow_hodlmm_remove_liquidity`,
+    `pool_id: "${poolId}"`,
+    `bin_ids: [${withdrawBins.map((b) => b.bin_id).join(", ")}]`,
+    `slippage: ${HODLMM_SLIPPAGE_PCT}`,
+  ].join("\n");
+
+  const mcpDepositCmd = [
+    `bitflow_hodlmm_add_liquidity`,
+    `pool_id: "${poolId}"`,
+    `bins: [${depositBins.map((b) => `{bin_id: ${b.bin_id}, amount_x: ${b.amount_x}, amount_y: ${b.amount_y}}`).join(", ")}]`,
+    `slippage: ${HODLMM_SLIPPAGE_PCT}`,
+  ].join("\n");
+
+  return {
+    poolId,
+    profitable,
+    withdrawBins,
+    depositBins,
+    totalWithdrawX: Number(totalWithdrawX),
+    totalWithdrawY: Number(totalWithdrawY),
+    feesHarvestedX: Number(feesX),
+    feesHarvestedY: Number(feesY),
+    principalRedeployX: Number(principalX),
+    principalRedeployY: Number(principalY),
+    gasEstimateSTX: gasEstimate,
+    newCenter: activeBin,
+    oldCenter: health.positionCenter,
+    drift: health.drift,
+    mcpWithdrawCmd,
+    mcpDepositCmd,
+    rejectionReason,
+  };
+}
+
+// ─── CLI ─────────────────────────────────────────────────────────────────
+const program = new Command();
+
+program
+  .name("hodlmm-range-keeper")
+  .description(
+    "Active HODLMM position manager — monitors drift, plans recenters, executes when profitable"
+  );
+
+// Redirect Commander help/error output to stderr (JSON-only stdout)
+program.configureOutput({
+  writeOut: (str) => process.stderr.write(str),
+  writeErr: (str) => process.stderr.write(str),
+});
+
+// Global crash handler — always emit JSON
+process.on("unhandledRejection", (err) => {
+  output("error", "crash", null, String(err));
+  process.exit(1);
+});
+
+// ── doctor ───────────────────────────────────────────────────────────────
+program
+  .command("doctor")
+  .description("Check wallet, HODLMM API, positions, and MCP tool availability")
+  .action(async () => {
+    const stxAddress = process.env.STX_ADDRESS || "";
+    const checks: any = {
+      hodlmmApi: false,
+      pools: [],
+      stxBalance: 0,
+      positions: [],
+      stateExists: existsSync(STATE_PATH),
+      safetyLimits: {
+        maxGasSTX: MAX_GAS_STX,
+        driftThreshold: DRIFT_THRESHOLD,
+        cooldownMinutes: COOLDOWN_MS / 60_000,
+        minPositionSats: MIN_POSITION_SATS,
+        slippagePct: HODLMM_SLIPPAGE_PCT,
+        binRange: DEFAULT_BIN_RANGE,
+        maxRecenterPerCycle: MAX_RECENTER_PER_CYCLE,
+      },
+      mcpRequired: [
+        "bitflow_hodlmm_remove_liquidity",
+        "bitflow_hodlmm_add_liquidity",
+      ],
+    };
+
+    // Check HODLMM API
+    const pools = await fetchAllPools();
+    if (pools.length > 0) {
+      checks.hodlmmApi = true;
+      checks.pools = pools.map((p) => ({
+        poolId: p.pool_id,
+        activeBin: p.active_bin,
+        binStep: p.bin_step,
+        tokenX: p.token_x,
+        tokenY: p.token_y,
+      }));
+    }
+
+    // Check wallet
+    if (stxAddress) {
+      checks.stxBalance = await fetchStxBalance(stxAddress);
+
+      // Scan positions
+      const posResults = await Promise.allSettled(
+        pools.map(async (pool) => {
+          const bins = await fetchUserPositions(pool.pool_id, stxAddress);
+          if (bins.length > 0) {
+            return {
+              poolId: pool.pool_id,
+              bins: bins.length,
+              activeBin: pool.active_bin,
+            };
+          }
+          return null;
+        })
+      );
+
+      checks.positions = posResults
+        .filter(
+          (r): r is PromiseFulfilledResult<any> =>
+            r.status === "fulfilled" && r.value !== null
+        )
+        .map((r) => r.value);
+    } else {
+      checks.note = "Set STX_ADDRESS env var for full diagnostics";
+    }
+
+    checks.commands = [
+      "doctor",
+      "status",
+      "status --pool dlmm_1",
+      "plan --pool dlmm_1",
+      "recenter --pool dlmm_1 --confirm",
+      "history",
+    ];
+
+    output("success", "doctor", checks);
+  });
+
+// ── status ───────────────────────────────────────────────────────────────
+program
+  .command("status")
+  .description("Show position health: drift, fees, range efficiency. Records fee baselines locally on first observation.")
+  .option("--pool <id>", "Specific pool (default: all with positions)")
+  .action(async (opts) => {
+    const stxAddress = process.env.STX_ADDRESS;
+    if (!stxAddress) {
+      output("blocked", "status", null, "STX_ADDRESS env var required.");
+      return;
+    }
+
+    const state = loadState();
+    const pools = await fetchAllPools();
+    const poolIds = opts.pool ? [opts.pool] : pools.map((p) => p.pool_id);
+
+    // Fetch all positions in parallel (like doctor does)
+    const positionResults = await Promise.allSettled(
+      poolIds.map(async (poolId) => {
+        const poolMeta = pools.find((p) => p.pool_id === poolId);
+        if (!poolMeta) return null;
+        const userBins = await fetchUserPositions(poolId, stxAddress!);
+        if (userBins.length === 0) return null;
+        return { poolId, poolMeta, userBins };
+      })
+    );
+
+    const results: PositionHealth[] = [];
+
+    for (const result of positionResults) {
+      if (result.status !== "fulfilled" || !result.value) continue;
+      const { poolId, poolMeta, userBins } = result.value;
+
+      // Filter dust
+      const significantBins = userBins.filter((b) => {
+        const val = parseInt(b.reserve_x || "0") + (b.userLiquidity || 0);
+        return val >= MIN_POSITION_SATS;
+      });
+      if (significantBins.length === 0) continue;
+
+      // Record baselines for new bins
+      const poolState = getPoolState(state, poolId);
+      for (const bin of significantBins) {
+        if (!poolState.baselines[bin.bin_id]) {
+          poolState.baselines[bin.bin_id] = {
+            binId: bin.bin_id,
+            depositX: bin.reserve_x || "0",
+            depositY: bin.reserve_y || "0",
+            recordedAt: new Date().toISOString(),
+          };
+        }
+      }
+
+      const health = analyzePosition(poolId, poolMeta.active_bin, significantBins, poolState);
+      results.push(health);
+
+      // Update last seen active bin
+      poolState.lastActiveBin = poolMeta.active_bin;
+    }
+
+    saveState(state);
+
+    const summary = {
+      positionsAnalyzed: results.length,
+      needsRecenter: results.filter((r) => r.needsRecenter).length,
+      positions: results,
+    };
+
+    output("success", "status", summary);
+  });
+
+// ── plan ─────────────────────────────────────────────────────────────────
+program
+  .command("plan")
+  .description("Dry-run re-center: simulate withdraw + re-deposit")
+  .option("--pool <id>", "Pool to plan recenter for", "dlmm_1")
+  .action(async (opts) => {
+    const stxAddress = process.env.STX_ADDRESS;
+    if (!stxAddress) {
+      output("blocked", "plan", null, "STX_ADDRESS env var required.");
+      return;
+    }
+
+    const state = loadState();
+    const pools = await fetchAllPools();
+    const poolMeta = pools.find((p) => p.pool_id === opts.pool);
+
+    if (!poolMeta) {
+      output("error", "plan", null, `Pool ${opts.pool} not found.`);
+      return;
+    }
+
+    const userBins = await fetchUserPositions(opts.pool, stxAddress);
+    if (userBins.length === 0) {
+      output("blocked", "plan", null, `No position in ${opts.pool}.`);
+      return;
+    }
+
+    const significantBins = userBins.filter((b) => {
+      const val = parseInt(b.reserve_x || "0") + (b.userLiquidity || 0);
+      return val >= MIN_POSITION_SATS;
+    });
+
+    const poolState = getPoolState(state, opts.pool);
+    const health = analyzePosition(opts.pool, poolMeta.active_bin, significantBins, poolState);
+
+    if (!health.needsRecenter) {
+      output("success", "plan", {
+        poolId: opts.pool,
+        action: "none",
+        reason: health.reason,
+        health,
+      });
+      return;
+    }
+
+    const plan = planRecenter(health, significantBins, poolState);
+
+    output("success", "plan", {
+      poolId: opts.pool,
+      action: plan.profitable ? "recenter_ready" : "recenter_blocked",
+      plan,
+      health,
+      note: plan.profitable
+        ? "Run 'recenter --pool " + opts.pool + " --confirm' to execute"
+        : plan.rejectionReason,
+    });
+  });
+
+// ── recenter ─────────────────────────────────────────────────────────────
+program
+  .command("recenter")
+  .description("Execute re-center: withdraw + re-deposit around active bin")
+  .option("--pool <id>", "Pool to recenter", "dlmm_1")
+  .option("--confirm", "Required to execute (safety gate)")
+  .option("--force", "Skip drift threshold check")
+  .action(async (opts) => {
+    const stxAddress = process.env.STX_ADDRESS;
+    if (!stxAddress) {
+      output("blocked", "recenter", null, "STX_ADDRESS env var required.");
+      return;
+    }
+
+    if (!opts.confirm) {
+      output("blocked", "recenter", null, "Add --confirm to execute. This withdraws and re-deposits real funds.");
+      return;
+    }
+
+    const state = loadState();
+    const pools = await fetchAllPools();
+    const poolMeta = pools.find((p) => p.pool_id === opts.pool);
+
+    if (!poolMeta) {
+      output("error", "recenter", null, `Pool ${opts.pool} not found.`);
+      return;
+    }
+
+    // Check STX balance for gas
+    const stxBalance = await fetchStxBalance(stxAddress);
+    if (stxBalance < DEFAULT_GAS_ESTIMATE_STX) {
+      output("blocked", "recenter", {
+        stxBalance,
+        gasEstimate: DEFAULT_GAS_ESTIMATE_STX,
+      }, "Insufficient STX for gas.");
+      return;
+    }
+
+    const userBins = await fetchUserPositions(opts.pool, stxAddress);
+    if (userBins.length === 0) {
+      output("blocked", "recenter", null, `No position in ${opts.pool}.`);
+      return;
+    }
+
+    const significantBins = userBins.filter((b) => {
+      const val = parseInt(b.reserve_x || "0") + (b.userLiquidity || 0);
+      return val >= MIN_POSITION_SATS;
+    });
+
+    const poolState = getPoolState(state, opts.pool);
+    const health = analyzePosition(opts.pool, poolMeta.active_bin, significantBins, poolState);
+
+    // Cooldown enforcement
+    if (health.cooldownRemaining > 0) {
+      output("blocked", "recenter", {
+        cooldownRemainingMinutes: Math.ceil(health.cooldownRemaining / 60_000),
+      }, "Cooldown active. Wait before next recenter.");
+      return;
+    }
+
+    // Drift check (unless --force)
+    if (!health.needsRecenter && !opts.force) {
+      output("success", "recenter", {
+        action: "skipped",
+        reason: health.reason,
+        health,
+      });
+      return;
+    }
+
+    const plan = planRecenter(health, significantBins, poolState);
+
+    if (!plan.profitable) {
+      output("blocked", "recenter", { plan }, plan.rejectionReason);
+      return;
+    }
+
+    // Execute via MCP tool commands
+    // Step 1: Emit withdraw instruction
+    log(`Executing recenter for ${opts.pool}...`);
+    log(`Drift: ${plan.drift} bins, withdrawing ${plan.withdrawBins.length} bins`);
+    log(`Re-depositing into ${plan.depositBins.length} bins centered on active bin ${plan.newCenter}`);
+
+    // Record the recenter event (pending until MCP execution confirms)
+    const event: RecenterEvent = {
+      poolId: opts.pool,
+      timestamp: new Date().toISOString(),
+      status: "pending_verification",
+      oldCenter: plan.oldCenter,
+      newCenter: plan.newCenter,
+      drift: plan.drift,
+      binsWithdrawn: plan.withdrawBins.length,
+      binsDeposited: plan.depositBins.length,
+      feesEstimatedX: plan.feesHarvestedX,
+      feesEstimatedY: plan.feesHarvestedY,
+      gasEstimateSTX: plan.gasEstimateSTX,
+      mcpWithdrawCmd: plan.mcpWithdrawCmd,
+      mcpDepositCmd: plan.mcpDepositCmd,
+    };
+
+    state.recenters.push(event);
+
+    // Update pool state
+    poolState.lastRecenterAt = new Date().toISOString();
+    poolState.lastActiveBin = plan.newCenter;
+
+    // Reset baselines for new deposit bins
+    poolState.baselines = {};
+    for (const bin of plan.depositBins) {
+      poolState.baselines[bin.bin_id] = {
+        binId: bin.bin_id,
+        depositX: bin.amount_x,
+        depositY: bin.amount_y,
+        recordedAt: new Date().toISOString(),
+      };
+    }
+
+    saveState(state);
+
+    output("success", "recenter", {
+      action: "execute_mcp",
+      poolId: opts.pool,
+      step1_withdraw: {
+        tool: "bitflow_hodlmm_remove_liquidity",
+        params: {
+          pool_id: opts.pool,
+          bin_ids: plan.withdrawBins.map((b) => b.bin_id),
+          slippage: HODLMM_SLIPPAGE_PCT,
+        },
+      },
+      step2_deposit: {
+        tool: "bitflow_hodlmm_add_liquidity",
+        params: {
+          pool_id: opts.pool,
+          bins: plan.depositBins,
+          slippage: HODLMM_SLIPPAGE_PCT,
+        },
+      },
+      summary: {
+        oldCenter: plan.oldCenter,
+        newCenter: plan.newCenter,
+        drift: plan.drift,
+        binsWithdrawn: plan.withdrawBins.length,
+        binsDeposited: plan.depositBins.length,
+        feesHarvestedX: plan.feesHarvestedX,
+        feesHarvestedY: plan.feesHarvestedY,
+        principalRedeployX: plan.principalRedeployX,
+        principalRedeployY: plan.principalRedeployY,
+        gasEstimateSTX: plan.gasEstimateSTX,
+      },
+    });
+  });
+
+// ── history ──────────────────────────────────────────────────────────────
+program
+  .command("history")
+  .description("Show past re-center events")
+  .option("--pool <id>", "Filter by pool")
+  .option("--limit <n>", "Number of events", "20")
+  .action(async (opts) => {
+    const state = loadState();
+    let events = state.recenters;
+
+    if (opts.pool) {
+      events = events.filter((e) => e.poolId === opts.pool);
+    }
+
+    const limit = parseInt(opts.limit) || 20;
+    events = events.slice(-limit);
+
+    const stats = {
+      totalRecenters: state.recenters.length,
+      poolsManaged: Object.keys(state.pools).length,
+      recentEvents: events,
+    };
+
+    output("success", "history", stats);
+  });
+
+// ── run (alias for status + auto-recenter) ───────────────────────────────
+program
+  .command("run")
+  .description("Full autonomous cycle: status check → plan → recenter if needed")
+  .option("--confirm", "Allow execution of recenters (without this, dry-run only)")
+  .action(async (opts) => {
+    const stxAddress = process.env.STX_ADDRESS;
+    if (!stxAddress) {
+      output("blocked", "run", null, "STX_ADDRESS env var required.");
+      return;
+    }
+
+    const state = loadState();
+    const pools = await fetchAllPools();
+    const stxBalance = await fetchStxBalance(stxAddress);
+
+    const results: any[] = [];
+    let recentersExecuted = 0;
+    let remainingStxBalance = stxBalance;
+
+    for (const poolMeta of pools) {
+      if (recentersExecuted >= MAX_RECENTER_PER_CYCLE) break;
+
+      const userBins = await fetchUserPositions(poolMeta.pool_id, stxAddress);
+      if (userBins.length === 0) continue;
+
+      const significantBins = userBins.filter((b) => {
+        const val = parseInt(b.reserve_x || "0") + (b.userLiquidity || 0);
+        return val >= MIN_POSITION_SATS;
+      });
+      if (significantBins.length === 0) continue;
+
+      const poolState = getPoolState(state, poolMeta.pool_id);
+
+      // Record baselines for new bins
+      for (const bin of significantBins) {
+        if (!poolState.baselines[bin.bin_id]) {
+          poolState.baselines[bin.bin_id] = {
+            binId: bin.bin_id,
+            depositX: bin.reserve_x || "0",
+            depositY: bin.reserve_y || "0",
+            recordedAt: new Date().toISOString(),
+          };
+        }
+      }
+
+      const health = analyzePosition(
+        poolMeta.pool_id,
+        poolMeta.active_bin,
+        significantBins,
+        poolState
+      );
+
+      poolState.lastActiveBin = poolMeta.active_bin;
+
+      if (health.needsRecenter && opts.confirm) {
+        if (health.cooldownRemaining > 0) {
+          results.push({
+            poolId: poolMeta.pool_id,
+            action: "cooldown",
+            health,
+          });
+          continue;
+        }
+
+        if (remainingStxBalance < DEFAULT_GAS_ESTIMATE_STX) {
+          results.push({
+            poolId: poolMeta.pool_id,
+            action: "insufficient_gas",
+            stxBalance: remainingStxBalance,
+            health,
+          });
+          continue;
+        }
+
+        const plan = planRecenter(health, significantBins, poolState);
+
+        if (plan.profitable) {
+          // Record event (pending until MCP execution confirms)
+          const event: RecenterEvent = {
+            poolId: poolMeta.pool_id,
+            timestamp: new Date().toISOString(),
+            status: "pending_verification",
+            oldCenter: plan.oldCenter,
+            newCenter: plan.newCenter,
+            drift: plan.drift,
+            binsWithdrawn: plan.withdrawBins.length,
+            binsDeposited: plan.depositBins.length,
+            feesEstimatedX: plan.feesHarvestedX,
+            feesEstimatedY: plan.feesHarvestedY,
+            gasEstimateSTX: plan.gasEstimateSTX,
+            mcpWithdrawCmd: plan.mcpWithdrawCmd,
+            mcpDepositCmd: plan.mcpDepositCmd,
+          };
+          state.recenters.push(event);
+
+          poolState.lastRecenterAt = new Date().toISOString();
+          poolState.lastActiveBin = plan.newCenter;
+          poolState.baselines = {};
+          for (const bin of plan.depositBins) {
+            poolState.baselines[bin.bin_id] = {
+              binId: bin.bin_id,
+              depositX: bin.amount_x,
+              depositY: bin.amount_y,
+              recordedAt: new Date().toISOString(),
+            };
+          }
+
+          results.push({
+            poolId: poolMeta.pool_id,
+            action: "execute_mcp",
+            plan: {
+              step1_withdraw: {
+                tool: "bitflow_hodlmm_remove_liquidity",
+                params: {
+                  pool_id: poolMeta.pool_id,
+                  bin_ids: plan.withdrawBins.map((b) => b.bin_id),
+                  slippage: HODLMM_SLIPPAGE_PCT,
+                },
+              },
+              step2_deposit: {
+                tool: "bitflow_hodlmm_add_liquidity",
+                params: {
+                  pool_id: poolMeta.pool_id,
+                  bins: plan.depositBins,
+                  slippage: HODLMM_SLIPPAGE_PCT,
+                },
+              },
+            },
+            health,
+          });
+          recentersExecuted++;
+          remainingStxBalance -= DEFAULT_GAS_ESTIMATE_STX;
+        } else {
+          results.push({
+            poolId: poolMeta.pool_id,
+            action: "blocked",
+            reason: plan.rejectionReason,
+            health,
+          });
+        }
+      } else {
+        results.push({
+          poolId: poolMeta.pool_id,
+          action: health.needsRecenter ? "needs_recenter_dry_run" : "healthy",
+          health,
+        });
+      }
+    }
+
+    saveState(state);
+
+    output("success", "run", {
+      stxBalance,
+      poolsScanned: pools.length,
+      positionsFound: results.length,
+      recentersExecuted,
+      mode: opts.confirm ? "live" : "dry-run",
+      results,
+    });
+  });
+
+// ── install-packs ────────────────────────────────────────────────────────
+program
+  .command("install-packs")
+  .description("Install dependency packs (no external packs required)")
+  .option("--pack <name>", "Pack to install", "all")
+  .action(async () => {
+    output("success", "install-packs", {
+      installed: [],
+      note: "No external packs required. Uses built-in fetch and Commander.js.",
+    });
+  });
+
+program.parse(process.argv);


### PR DESCRIPTION
## Summary

Final version of `hodlmm-range-keeper` with all 5 review items from @arc0btc addressed:

1. **`reserve_x = 0` falsy fallback** — `||` → `!== undefined && !== null` so zero reserves don't fall through
2. **STX balance not decremented between recenters** — `remainingStxBalance` tracked and decremented per execution
3. **Sequential pool iteration in `status`** — parallelized with `Promise.allSettled`
4. **Dead code `fetchPoolAppStats`** — removed
5. **Unused `binIdsWithdraw` / `amountsWithdraw`** — removed

Also includes prior fixes from competition review rounds: BigInt precision in `planRecenter`, `reserve_y` mapping, `pending_verification` status tracking, `install-packs` stdout discipline.

Replaces files in #307 with the final reviewed version.

Fixes: tearful-saw/bff-skills@d326843