### PR TITLE
feat(transactions): nonce-tracker integration and retry logic for sponsor-builder

### DIFF
--- a/src/lib/transactions/builder.ts
+++ b/src/lib/transactions/builder.ts
@@ -58,6 +58,8 @@ export interface ContractCallOptions {
   postConditions?: PostCondition[];
   /** Optional fee in micro-STX. If omitted, fee is auto-estimated. */
   fee?: bigint;
+  /** Optional explicit nonce. If omitted, auto-fetched from network. */
+  nonce?: bigint;
 }
 
 export interface ContractDeployOptions {
@@ -65,18 +67,22 @@ export interface ContractDeployOptions {
   codeBody: string;
   /** Optional fee in micro-STX. If omitted, fee is auto-estimated. */
   fee?: bigint;
+  /** Optional explicit nonce. If omitted, auto-fetched from network. */
+  nonce?: bigint;
 }
 
 /**
  * Transfer STX tokens to a recipient
  * @param fee Optional fee in micro-STX. If omitted, fee is auto-estimated.
+ * @param nonce Optional explicit nonce. If omitted, auto-fetched from network.
  */
 export async function transferStx(
   account: Account,
   recipient: string,
   amount: bigint,
   memo?: string,
-  fee?: bigint
+  fee?: bigint,
+  nonce?: bigint
 ): Promise<TransferResult> {
   const networkName = getStacksNetwork(account.network);
 
@@ -87,6 +93,7 @@ export async function transferStx(
     network: networkName,
     memo: memo || "",
     ...(fee !== undefined && { fee }),
+    ...(nonce !== undefined && { nonce }),
   });
 
   const broadcastResponse = await broadcastTransaction({
@@ -125,6 +132,7 @@ export async function callContract(
     postConditionMode: options.postConditionMode || PostConditionMode.Deny,
     postConditions: options.postConditions || [],
     ...(options.fee !== undefined && { fee: options.fee }),
+    ...(options.nonce !== undefined && { nonce: options.nonce }),
   });
 
   const broadcastResponse = await broadcastTransaction({
@@ -159,6 +167,7 @@ export async function deployContract(
     senderKey: account.privateKey,
     network: networkName,
     ...(options.fee !== undefined && { fee: options.fee }),
+    ...(options.nonce !== undefined && { nonce: options.nonce }),
   });
 
   const broadcastResponse = await broadcastTransaction({

--- a/src/lib/transactions/index.ts
+++ b/src/lib/transactions/index.ts
@@ -6,3 +6,4 @@ export * from "./inscription-builder.js";
 export * from "./inscription-transfer-builder.js";
 export * from "./runestone-builder.js";
 export * from "./rune-transfer-builder.js";
+export * from "./retry-strategy.js";

--- a/src/lib/transactions/retry-strategy.ts
+++ b/src/lib/transactions/retry-strategy.ts
@@ -1,0 +1,225 @@
+/**
+ * Shared retry strategy for Stacks transaction submission.
+ *
+ * Provides error classification for both the relay /sponsor endpoint and
+ * direct Hiro broadcast errors. Used by sponsor-builder.ts and builder.ts
+ * to drive retry loops with correct back-off and nonce lifecycle handling.
+ *
+ * Design:
+ * - No external dependencies — pure classification logic
+ * - classifyRelayError: for relay /sponsor responses (409, 502, 503, 429, 500)
+ * - classifyBroadcastError: for direct Hiro broadcast error strings
+ * - sleep: shared utility to avoid importing it everywhere
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/**
+ * Category of error for routing retry logic.
+ *
+ * - NONCE_CONFLICT: relay sponsor nonce collision — resubmit same serialized tx
+ * - BROADCAST_FAILED: relay signed but Hiro rejected — resubmit same serialized tx
+ * - NONCE_DO_UNAVAILABLE: transient relay infra — resubmit same serialized tx
+ * - RATE_LIMITED: 429 — sleep retryAfter, then resubmit
+ * - SENDER_NONCE_CONFLICT: our sender nonce already in mempool — re-acquire and rebuild
+ * - SPONSOR_FAILED: relay could not sign sponsorship — non-retryable
+ * - TRANSIENT: other transient network error — short sleep, retry
+ * - FATAL: non-retryable error
+ */
+export type RetryCategory =
+  | "NONCE_CONFLICT"
+  | "BROADCAST_FAILED"
+  | "NONCE_DO_UNAVAILABLE"
+  | "RATE_LIMITED"
+  | "SENDER_NONCE_CONFLICT"
+  | "SPONSOR_FAILED"
+  | "TRANSIENT"
+  | "FATAL";
+
+export interface RetryInfo {
+  retryable: boolean;
+  delayMs: number;
+  /** True when relay's sponsor nonce collided — resubmit same serialized tx hex */
+  relaySideConflict: boolean;
+  /** True when our sender nonce is stale/duplicated — re-acquire nonce and rebuild tx */
+  senderSideConflict: boolean;
+  category: RetryCategory;
+}
+
+/** Minimal relay response fields needed for classification (avoids circular imports). */
+interface RelayErrorBody {
+  code?: string;
+  retryable?: boolean;
+  retryAfter?: number;
+  error?: string;
+  details?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Relay error classification
+// ---------------------------------------------------------------------------
+
+/**
+ * Classify a /sponsor relay error response.
+ *
+ * The relay sets `code`, `retryable`, and `retryAfter` fields on error
+ * responses. HTTP status is optional — the body fields are preferred.
+ *
+ * @param body    - Parsed relay error response body
+ * @param status  - Optional HTTP status code (used when body.code is absent)
+ */
+export function classifyRelayError(body: RelayErrorBody, status?: number): RetryInfo {
+  const code = body.code ?? "";
+  const retryAfterMs = body.retryAfter != null ? body.retryAfter * 1000 : 5_000;
+
+  // 409 / NONCE_CONFLICT — relay sponsor nonce collision, resubmit same tx
+  if (code === "NONCE_CONFLICT" || status === 409) {
+    return {
+      retryable: true,
+      delayMs: body.retryAfter != null ? body.retryAfter * 1000 : 30_000,
+      relaySideConflict: true,
+      senderSideConflict: false,
+      category: "NONCE_CONFLICT",
+    };
+  }
+
+  // 502 / BROADCAST_FAILED — relay signed but Hiro rejected broadcast, resubmit same tx
+  if (code === "BROADCAST_FAILED" || status === 502) {
+    return {
+      retryable: true,
+      delayMs: retryAfterMs,
+      relaySideConflict: false,
+      senderSideConflict: false,
+      category: "BROADCAST_FAILED",
+    };
+  }
+
+  // 503 / NONCE_DO_UNAVAILABLE — transient relay infra, resubmit same tx
+  if (code === "NONCE_DO_UNAVAILABLE" || status === 503) {
+    return {
+      retryable: true,
+      delayMs: body.retryAfter != null ? body.retryAfter * 1000 : 3_000,
+      relaySideConflict: false,
+      senderSideConflict: false,
+      category: "NONCE_DO_UNAVAILABLE",
+    };
+  }
+
+  // 429 — rate limited, sleep retryAfter
+  if (status === 429) {
+    return {
+      retryable: true,
+      delayMs: retryAfterMs,
+      relaySideConflict: false,
+      senderSideConflict: false,
+      category: "RATE_LIMITED",
+    };
+  }
+
+  // 500 / SPONSOR_FAILED — relay could not sign, non-retryable
+  if (code === "SPONSOR_FAILED" || status === 500) {
+    return {
+      retryable: false,
+      delayMs: 0,
+      relaySideConflict: false,
+      senderSideConflict: false,
+      category: "SPONSOR_FAILED",
+    };
+  }
+
+  // Check body error text for sender-side nonce errors relayed from Hiro
+  const errorText = `${body.error ?? ""} ${body.details ?? ""}`;
+  const senderConflict = classifyBroadcastError(errorText);
+  if (senderConflict.senderSideConflict) {
+    return senderConflict;
+  }
+
+  // Honour relay-provided retryable flag as a catch-all
+  if (body.retryable) {
+    return {
+      retryable: true,
+      delayMs: retryAfterMs,
+      relaySideConflict: false,
+      senderSideConflict: false,
+      category: "TRANSIENT",
+    };
+  }
+
+  return {
+    retryable: false,
+    delayMs: 0,
+    relaySideConflict: false,
+    senderSideConflict: false,
+    category: "FATAL",
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Direct broadcast error classification
+// ---------------------------------------------------------------------------
+
+/**
+ * Classify a direct Hiro broadcast error message.
+ *
+ * Returns SENDER_NONCE_CONFLICT when the nonce is already in the mempool
+ * (safe to re-acquire and retry). Returns TRANSIENT for network errors.
+ * Returns FATAL for all other errors.
+ *
+ * @param errorMessage - Error string from broadcastTransaction or fetch
+ */
+export function classifyBroadcastError(errorMessage: string): RetryInfo {
+  const msg = errorMessage.toLowerCase();
+
+  // ConflictingNonceInMempool / BadNonce — nonce NOT consumed by Hiro, safe to re-acquire
+  if (
+    msg.includes("conflictingnonceinthemempool") ||
+    msg.includes("conflicting_nonce") ||
+    msg.includes("conflictingnonce") ||
+    msg.includes("badnonce") ||
+    msg.includes("bad_nonce")
+  ) {
+    return {
+      retryable: true,
+      delayMs: 0,
+      relaySideConflict: false,
+      senderSideConflict: true,
+      category: "SENDER_NONCE_CONFLICT",
+    };
+  }
+
+  // Transient network errors — short sleep, retry with same tx
+  if (
+    msg.includes("network") ||
+    msg.includes("timeout") ||
+    msg.includes("econnreset") ||
+    msg.includes("enotfound") ||
+    msg.includes("fetch failed")
+  ) {
+    return {
+      retryable: true,
+      delayMs: 5_000,
+      relaySideConflict: false,
+      senderSideConflict: false,
+      category: "TRANSIENT",
+    };
+  }
+
+  return {
+    retryable: false,
+    delayMs: 0,
+    relaySideConflict: false,
+    senderSideConflict: false,
+    category: "FATAL",
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Utility
+// ---------------------------------------------------------------------------
+
+/** Sleep for ms milliseconds. */
+export function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/src/lib/transactions/sponsor-builder.ts
+++ b/src/lib/transactions/sponsor-builder.ts
@@ -6,6 +6,8 @@ import {
 import { getStacksNetwork, type Network } from "../config/networks.js";
 import { getSponsorRelayUrl, getSponsorApiKey } from "../config/sponsor.js";
 import type { Account, ContractCallOptions, TransferResult } from "./builder.js";
+import { acquireNonce, releaseNonce } from "../services/nonce-tracker.js";
+import { classifyRelayError, sleep } from "./retry-strategy.js";
 
 export interface SponsoredTransferOptions {
   senderKey: string;
@@ -98,6 +100,170 @@ export async function sponsoredContractCall(
 }
 
 /**
+ * Sponsored contract call with nonce-tracker integration and retry logic.
+ *
+ * Acquires a sender nonce from nonce-tracker before building the transaction,
+ * ensuring concurrent dispatch cycles don't collide on the same nonce.
+ *
+ * Retry behaviour:
+ * - Relay-side conflict (NONCE_CONFLICT): sleep retryAfter, resubmit same serialized tx
+ * - Sender-side conflict (ConflictingNonceInMempool): release as rejected, re-acquire, rebuild
+ * - Transient errors: sleep, resubmit same serialized tx
+ * - Non-retryable errors: release as broadcast, throw
+ *
+ * @param account     - Wallet account (must have privateKey + address)
+ * @param options     - Contract call options (nonce field ignored; managed internally)
+ * @param network     - Target network
+ * @param maxAttempts - Maximum submission attempts (default: 3)
+ */
+export async function sponsoredContractCallWithRetry(
+  account: Account,
+  options: ContractCallOptions,
+  network: Network,
+  maxAttempts = 3
+): Promise<TransferResult> {
+  const apiKey = resolveSponsorApiKey(account);
+  const networkName = getStacksNetwork(network);
+  const stxAddress = account.address;
+
+  let acquired = await acquireNonce(stxAddress);
+  let nonce = acquired.nonce;
+  let serializedTx: string | null = null;
+
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    // Build (or rebuild after nonce re-acquisition)
+    if (serializedTx === null) {
+      const transaction = await makeContractCall({
+        contractAddress: options.contractAddress,
+        contractName: options.contractName,
+        functionName: options.functionName,
+        functionArgs: options.functionArgs,
+        senderKey: account.privateKey,
+        network: networkName,
+        postConditionMode: options.postConditionMode || PostConditionMode.Deny,
+        postConditions: options.postConditions || [],
+        sponsored: true,
+        fee: 0n,
+        nonce: BigInt(nonce),
+      });
+      serializedTx = transaction.serialize();
+    }
+
+    const response = await submitToSponsorRelay(serializedTx, network, apiKey);
+
+    if (response.success && response.txid) {
+      await releaseNonce(stxAddress, nonce, true, undefined, response.txid);
+      return { txid: response.txid, rawTx: serializedTx };
+    }
+
+    // Last attempt — give up
+    if (attempt === maxAttempts - 1) {
+      await releaseNonce(stxAddress, nonce, false, "broadcast");
+      throw new Error(formatRelayError(response));
+    }
+
+    const retry = classifyRelayError(response);
+
+    if (!retry.retryable) {
+      await releaseNonce(stxAddress, nonce, false, "broadcast");
+      throw new Error(formatRelayError(response));
+    }
+
+    if (retry.senderSideConflict) {
+      // Nonce not consumed by Hiro — safe to roll back and re-acquire a fresh one
+      await releaseNonce(stxAddress, nonce, false, "rejected");
+      acquired = await acquireNonce(stxAddress);
+      nonce = acquired.nonce;
+      serializedTx = null; // Force rebuild with new nonce
+      // No sleep — re-acquire already syncs from Hiro
+    } else {
+      // Relay-side conflict, transient, rate-limited: resubmit same serialized tx
+      await sleep(retry.delayMs);
+    }
+  }
+
+  // Should not reach here but TypeScript requires a return path
+  await releaseNonce(stxAddress, nonce, false, "broadcast");
+  throw new Error(`sponsoredContractCallWithRetry: exhausted ${maxAttempts} attempts`);
+}
+
+/**
+ * Sponsored STX transfer with nonce-tracker integration and retry logic.
+ *
+ * Same retry semantics as sponsoredContractCallWithRetry.
+ *
+ * @param account     - Wallet account (must have privateKey + address)
+ * @param recipient   - Recipient Stacks address
+ * @param amount      - Amount in micro-STX
+ * @param memo        - Optional memo string
+ * @param network     - Target network
+ * @param maxAttempts - Maximum submission attempts (default: 3)
+ */
+export async function transferStxSponsoredWithRetry(
+  account: Account,
+  recipient: string,
+  amount: bigint,
+  memo: string | undefined,
+  network: Network,
+  maxAttempts = 3
+): Promise<TransferResult> {
+  const apiKey = resolveSponsorApiKey(account);
+  const networkName = getStacksNetwork(network);
+  const stxAddress = account.address;
+
+  let acquired = await acquireNonce(stxAddress);
+  let nonce = acquired.nonce;
+  let serializedTx: string | null = null;
+
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    if (serializedTx === null) {
+      const transaction = await makeSTXTokenTransfer({
+        recipient,
+        amount,
+        senderKey: account.privateKey,
+        network: networkName,
+        memo: memo || "",
+        sponsored: true,
+        fee: 0n,
+        nonce: BigInt(nonce),
+      });
+      serializedTx = transaction.serialize();
+    }
+
+    const response = await submitToSponsorRelay(serializedTx, network, apiKey);
+
+    if (response.success && response.txid) {
+      await releaseNonce(stxAddress, nonce, true, undefined, response.txid);
+      return { txid: response.txid, rawTx: serializedTx };
+    }
+
+    if (attempt === maxAttempts - 1) {
+      await releaseNonce(stxAddress, nonce, false, "broadcast");
+      throw new Error(formatRelayError(response));
+    }
+
+    const retry = classifyRelayError(response);
+
+    if (!retry.retryable) {
+      await releaseNonce(stxAddress, nonce, false, "broadcast");
+      throw new Error(formatRelayError(response));
+    }
+
+    if (retry.senderSideConflict) {
+      await releaseNonce(stxAddress, nonce, false, "rejected");
+      acquired = await acquireNonce(stxAddress);
+      nonce = acquired.nonce;
+      serializedTx = null;
+    } else {
+      await sleep(retry.delayMs);
+    }
+  }
+
+  await releaseNonce(stxAddress, nonce, false, "broadcast");
+  throw new Error(`transferStxSponsoredWithRetry: exhausted ${maxAttempts} attempts`);
+}
+
+/**
  * Build and submit a sponsored STX transfer transaction
  */
 export async function transferStxSponsored(
@@ -121,9 +287,10 @@ export async function transferStxSponsored(
 }
 
 /**
- * Submit a serialized transaction to the sponsor relay
+ * Submit a serialized transaction to the sponsor relay.
+ * Exported to allow resubmission of the same serialized tx in retry loops.
  */
-async function submitToSponsorRelay(
+export async function submitToSponsorRelay(
   transaction: string,
   network: Network,
   apiKey: string


### PR DESCRIPTION
## Summary

- **New `retry-strategy.ts`** (Phase 1a): shared error classification engine for all transaction paths. Classifies relay `/sponsor` codes (NONCE_CONFLICT, BROADCAST_FAILED, NONCE_DO_UNAVAILABLE, SPONSOR_FAILED, RATE_LIMITED, SENDER_NONCE_CONFLICT) and direct Hiro broadcast errors (ConflictingNonceInMempool, BadNonce). Includes `sleep()` utility.
- **Modified `sponsor-builder.ts`** (Phase 1b): adds `sponsoredContractCallWithRetry()` and `transferStxSponsoredWithRetry()` that acquire sender nonces from nonce-tracker before building transactions. Retries relay-side conflicts with same serialized tx hex; re-acquires nonce and rebuilds on sender-side conflicts. `submitToSponsorRelay()` is now exported.
- **Updated `transactions/index.ts`**: exports `retry-strategy.js`.

Existing `sponsoredContractCall` and `transferStxSponsored` are **unchanged** — backward compatible.

## Motivation

Sequential Zest supply ops in back-to-back dispatch cycles were generating `ConflictingNonceInMempool` errors because `makeContractCall` auto-fetches sender nonce from Hiro on each call, but Hiro's mempool view lags behind transactions we've already broadcast. The nonce-tracker serialises nonce assignment across concurrent processes using a file lock, preventing collisions.

## Test plan

- [ ] `bun run typecheck` passes (verified locally — clean)
- [ ] `sponsoredContractCallWithRetry` handles relay NONCE_CONFLICT (resubmits same hex)
- [ ] `sponsoredContractCallWithRetry` handles ConflictingNonceInMempool (re-acquires nonce, rebuilds tx)
- [ ] `sponsoredContractCallWithRetry` succeeds on first attempt with correct nonce
- [ ] Existing `sponsoredContractCall` callers unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)