### PR TITLE
feat(bitflow-arb-scanner): add arbitrage scanner skill

### DIFF
--- a/bitflow-arb-scanner/AGENT.md
+++ b/bitflow-arb-scanner/AGENT.md
@@ -1,0 +1,54 @@
+---
+name: bitflow-arb-scanner-agent
+skill: bitflow-arb-scanner
+description: Scans Bitflow DEX for arbitrage opportunities between SDK routes and HODLMM quotes — read-only, mainnet-only.
+---
+
+# Bitflow Arbitrage Scanner Agent
+
+This agent detects pricing discrepancies between SDK (XYK AMM) routes and HODLMM (DLMM concentrated liquidity) quotes on Bitflow DEX. All operations are read-only — no funds are moved.
+
+## Prerequisites
+
+- Network must be mainnet — Bitflow is mainnet-only
+- No API key required — public endpoints at 500 req/min
+- No wallet required for scanning (read-only operations)
+
+## Decision Logic
+
+| Goal | Subcommand |
+|------|-----------|
+| Find all arbitrage opportunities across pairs | `scan` — broad sweep sorted by spread |
+| Analyze a specific pair in detail | `scan-pair` — deep route comparison for one pair |
+| Find intra-pool pricing inefficiencies | `scan-pools` — bin-level price analysis within HODLMM pools |
+| Monitor known pairs for actionable spreads | `watchlist` — filtered alerts for watched pairs |
+
+## Workflow
+
+1. Start with `scan` to identify pairs with the largest spreads
+2. Use `scan-pair` to drill into promising pairs with your intended trade size
+3. Check `executable` field — non-executable HODLMM routes are informational only
+4. Use `watchlist` for ongoing monitoring of high-interest pairs
+
+## Safety Checks
+
+- This skill is read-only — it never executes swaps
+- Verify `executable: true` on both routes before considering a trade
+- A large spread with high price impact may not be profitable after slippage
+- `netSpreadPct` already accounts for estimated fees — use this for profitability decisions
+- Spreads can close quickly in active markets — treat results as snapshots, not guarantees
+
+## Error Handling
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| "mainnet only" | Running on testnet | Set `NETWORK=mainnet` |
+| "no routes found" | Token pair has no liquidity | Try a different pair or smaller amount |
+| "quote failed" | API timeout or rate limit | Wait and retry; check 500 req/min limit |
+
+## Output Handling
+
+- `scan`: focus on `opportunities[].netSpreadPct` — this is the fee-adjusted spread
+- `scan-pair`: compare `routes[]` for detailed per-route analysis
+- `scan-pools`: `spreadPct` indicates bin-level pricing divergence
+- `watchlist`: only returns pairs above `--min-spread` threshold — absence means no opportunity

--- a/bitflow-arb-scanner/SKILL.md
+++ b/bitflow-arb-scanner/SKILL.md
@@ -7,7 +7,7 @@ metadata:
   user-invocable: "false"
   arguments: "scan | scan-pair | scan-pools | watchlist"
   entry: "bitflow-arb-scanner/bitflow-arb-scanner.ts"
-  requires: "wallet"
+  requires: ""
   tags: "l2, defi, read-only, mainnet-only"
 ---
 

--- a/bitflow-arb-scanner/SKILL.md
+++ b/bitflow-arb-scanner/SKILL.md
@@ -1,0 +1,190 @@
+---
+name: bitflow-arb-scanner
+description: "Bitflow Arbitrage Scanner — detects price discrepancies between SDK routes and HODLMM quotes on Bitflow DEX, surfaces profitable arbitrage opportunities with spread analysis, fee-adjusted P&L estimation, and multi-pair scanning. All operations are read-only and mainnet-only. No API key required."
+metadata:
+  author: "vanhuy"
+  author-agent: "Arb Hunter"
+  user-invocable: "false"
+  arguments: "scan | scan-pair | scan-pools | watchlist"
+  entry: "bitflow-arb-scanner/bitflow-arb-scanner.ts"
+  requires: "wallet"
+  tags: "l2, defi, read-only, mainnet-only"
+---
+
+# Bitflow Arbitrage Scanner
+
+Detects price discrepancies between SDK (XYK AMM) routes and HODLMM (DLMM concentrated liquidity) quotes on Bitflow DEX. Surfaces arbitrage opportunities where the same token pair has different effective prices across routing sources.
+
+- **Spread Detection** — Compares SDK vs HODLMM output amounts for the same trade to find pricing gaps.
+- **Fee-Adjusted P&L** — Estimates net profit after on-chain fees and price impact.
+- **Multi-Pair Scanning** — Scans all available trading pairs or a filtered subset.
+- **Watchlist Mode** — Monitors specific pairs and returns only actionable opportunities above a threshold.
+
+All operations are **read-only** and **mainnet-only**. No wallet required for scanning. No API key required — uses public endpoints at 500 req/min.
+
+## Usage
+
+```
+bun run bitflow-arb-scanner/bitflow-arb-scanner.ts <subcommand> [options]
+```
+
+## Subcommands
+
+### scan
+
+Scan all available trading pairs for arbitrage opportunities between SDK and HODLMM routes. Returns pairs sorted by spread percentage.
+
+```
+bun run bitflow-arb-scanner/bitflow-arb-scanner.ts scan [--min-spread <percent>] [--amount <decimal>] [--top <number>]
+```
+
+Options:
+- `--min-spread` (optional) — Minimum spread percentage to report (default 0.1 = 0.1%)
+- `--amount` (optional) — Trade size in input token units for quote comparison (default 10.0)
+- `--top` (optional) — Return only the top N opportunities (default 10)
+
+Output:
+```json
+{
+  "network": "mainnet",
+  "scanTime": "2026-04-09T12:00:00Z",
+  "tradeAmount": "10.0",
+  "minSpreadPct": 0.1,
+  "opportunityCount": 5,
+  "opportunities": [
+    {
+      "pair": "STX/sBTC",
+      "tokenX": "token-stx",
+      "tokenY": "token-sbtc",
+      "amountIn": "10.0",
+      "sdkAmountOut": "0.0000350",
+      "hodlmmAmountOut": "0.0000362",
+      "spreadPct": "3.43",
+      "bestSource": "hodlmm",
+      "estimatedFeeBps": 30,
+      "netSpreadPct": "3.13",
+      "sdkRoute": "BITFLOW_XYK_XY_2",
+      "hodlmmPool": "dlmm_3",
+      "priceImpact": { "sdk": "0.12%", "hodlmm": "0.08%" }
+    }
+  ]
+}
+```
+
+### scan-pair
+
+Scan a specific token pair for arbitrage between all available routes.
+
+```
+bun run bitflow-arb-scanner/bitflow-arb-scanner.ts scan-pair --token-x <tokenId> --token-y <tokenId> --amount-in <decimal>
+```
+
+Options:
+- `--token-x` (required) — Input token ID (e.g. `token-stx`)
+- `--token-y` (required) — Output token ID (e.g. `token-sbtc`)
+- `--amount-in` (required) — Amount of input token in human-readable decimal
+
+Output:
+```json
+{
+  "network": "mainnet",
+  "pair": "STX/sBTC",
+  "tokenX": "token-stx",
+  "tokenY": "token-sbtc",
+  "amountIn": "10.0",
+  "routes": [
+    {
+      "source": "sdk",
+      "label": "BITFLOW_XYK_XY_2",
+      "amountOut": "0.0000350",
+      "executable": true,
+      "priceImpactPct": "0.12%",
+      "feeBps": 30
+    },
+    {
+      "source": "hodlmm",
+      "label": "DLMM dlmm_3",
+      "amountOut": "0.0000362",
+      "executable": true,
+      "priceImpactPct": "0.08%",
+      "feeBps": 25
+    }
+  ],
+  "bestRoute": { "source": "hodlmm", "amountOut": "0.0000362" },
+  "worstRoute": { "source": "sdk", "amountOut": "0.0000350" },
+  "spreadPct": "3.43",
+  "netSpreadPct": "3.13"
+}
+```
+
+### scan-pools
+
+Scan HODLMM pools for internal bin pricing inefficiencies — compares the effective price at different bin ranges to detect intra-pool arbitrage.
+
+```
+bun run bitflow-arb-scanner/bitflow-arb-scanner.ts scan-pools [--suggested] [--min-spread <percent>]
+```
+
+Options:
+- `--suggested` (optional) — Only scan suggested/featured pools
+- `--min-spread` (optional) — Minimum spread percentage to report (default 0.5)
+
+Output:
+```json
+{
+  "network": "mainnet",
+  "poolCount": 12,
+  "opportunities": [
+    {
+      "poolId": "dlmm_3",
+      "tokenX": "STX",
+      "tokenY": "sBTC",
+      "activeBin": 447,
+      "binStep": 10,
+      "spreadPct": "1.2",
+      "description": "Active bin price deviates from nearby bin weighted average"
+    }
+  ]
+}
+```
+
+### watchlist
+
+Monitor specific pairs continuously and return only pairs with spreads above threshold. Useful for autonomous agents polling for opportunities.
+
+```
+bun run bitflow-arb-scanner/bitflow-arb-scanner.ts watchlist --pairs '<json>' --amount <decimal> [--min-spread <percent>]
+```
+
+Options:
+- `--pairs` (required) — JSON array of `[tokenX, tokenY]` pairs to monitor
+- `--amount` (optional) — Trade size for quotes (default 10.0)
+- `--min-spread` (optional) — Minimum spread to report (default 0.5)
+
+Output:
+```json
+{
+  "network": "mainnet",
+  "scannedAt": "2026-04-09T12:00:00Z",
+  "pairsScanned": 3,
+  "alertCount": 1,
+  "alerts": [
+    {
+      "pair": "STX/sBTC",
+      "spreadPct": "2.15",
+      "bestSource": "hodlmm",
+      "amountIn": "10.0",
+      "sdkOut": "0.0000350",
+      "hodlmmOut": "0.0000358"
+    }
+  ]
+}
+```
+
+## Notes
+
+- All operations are **read-only** — no swaps are executed.
+- Mainnet-only — Bitflow and HODLMM are not available on testnet.
+- Spreads may not be directly actionable if one route is not executable (check `executable` field).
+- Price impact varies with trade size — scan at your intended trade size for accurate results.
+- Fee estimates are approximate; actual on-chain gas depends on network conditions.

--- a/bitflow-arb-scanner/bitflow-arb-scanner.ts
+++ b/bitflow-arb-scanner/bitflow-arb-scanner.ts
@@ -1,0 +1,469 @@
+#!/usr/bin/env bun
+/**
+ * bitflow-arb-scanner — Arbitrage Scanner for Bitflow DEX
+ *
+ * Detects price discrepancies between SDK (XYK AMM) routes and HODLMM (DLMM)
+ * quotes on Bitflow DEX. Surfaces profitable arbitrage opportunities with
+ * spread analysis and fee-adjusted P&L estimation.
+ *
+ * All operations are read-only. No swaps executed.
+ *
+ * Commands:
+ *   scan       — scan all pairs for SDK vs HODLMM spread
+ *   scan-pair  — deep route comparison for one pair
+ *   scan-pools — bin-level pricing analysis within HODLMM pools
+ *   watchlist  — monitor specific pairs for actionable spreads
+ */
+
+import { Command } from "commander";
+import { NETWORK } from "../src/lib/config/networks.js";
+import {
+  getBitflowService,
+  type UnifiedBitflowRouteQuote,
+} from "../src/lib/services/bitflow.service.js";
+import { printJson, handleError } from "../src/lib/utils/cli.js";
+
+// ─── Constants ──────────────────────────────────────────────────────────────
+
+const HODLMM_API = "https://bff.bitflowapis.finance/api/quotes/v1";
+const DEFAULT_AMOUNT = "10.0";
+const DEFAULT_MIN_SPREAD = 0.1;
+const DEFAULT_TOP = 10;
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function ensureMainnet(): void {
+  if (NETWORK !== "mainnet") {
+    throw new Error("Bitflow arbitrage scanner is mainnet only. Set NETWORK=mainnet.");
+  }
+}
+
+interface RouteBreakdown {
+  source: "sdk" | "hodlmm";
+  label: string;
+  amountOut: string;
+  executable: boolean;
+  priceImpactPct: string;
+  feeBps: number;
+}
+
+function routeToBreakdown(route: UnifiedBitflowRouteQuote): RouteBreakdown {
+  return {
+    source: route.source,
+    label: route.label,
+    amountOut: route.amountOutHuman,
+    executable: route.executable,
+    priceImpactPct: route.priceImpact?.combinedImpactPct ?? "N/A",
+    feeBps: route.priceImpact?.totalFeeBps ?? 0,
+  };
+}
+
+interface ArbOpportunity {
+  pair: string;
+  tokenX: string;
+  tokenY: string;
+  amountIn: string;
+  sdkAmountOut: string;
+  hodlmmAmountOut: string;
+  spreadPct: string;
+  bestSource: "sdk" | "hodlmm";
+  estimatedFeeBps: number;
+  netSpreadPct: string;
+  sdkRoute: string;
+  hodlmmPool: string;
+  priceImpact: { sdk: string; hodlmm: string };
+}
+
+function calculateSpread(
+  sdkRoutes: UnifiedBitflowRouteQuote[],
+  hodlmmRoutes: UnifiedBitflowRouteQuote[],
+  tokenX: string,
+  tokenY: string,
+  amountIn: string
+): ArbOpportunity | null {
+  const bestSdk = sdkRoutes[0];
+  const bestHodlmm = hodlmmRoutes[0];
+
+  if (!bestSdk || !bestHodlmm) return null;
+
+  const sdkOut = parseFloat(bestSdk.amountOutHuman);
+  const hodlmmOut = parseFloat(bestHodlmm.amountOutHuman);
+
+  if (sdkOut <= 0 || hodlmmOut <= 0) return null;
+
+  const maxOut = Math.max(sdkOut, hodlmmOut);
+  const minOut = Math.min(sdkOut, hodlmmOut);
+  const spreadPct = ((maxOut - minOut) / minOut) * 100;
+
+  const bestSource = hodlmmOut > sdkOut ? "hodlmm" : "sdk";
+  const avgFeeBps = Math.round(
+    ((bestSdk.priceImpact?.totalFeeBps ?? 0) +
+      (bestHodlmm.priceImpact?.totalFeeBps ?? 0)) /
+      2
+  );
+  const netSpreadPct = Math.max(0, spreadPct - avgFeeBps / 100);
+
+  // Extract labels
+  const sdkLabel = bestSdk.label || bestSdk.poolContracts?.[0] || "sdk";
+  const hodlmmLabel = bestHodlmm.label || bestHodlmm.poolContracts?.[0] || "hodlmm";
+
+  // Extract token symbols from IDs
+  const xSymbol = tokenX.replace("token-", "").replace("-auto", "").toUpperCase();
+  const ySymbol = tokenY.replace("token-", "").replace("-auto", "").toUpperCase();
+
+  return {
+    pair: `${xSymbol}/${ySymbol}`,
+    tokenX,
+    tokenY,
+    amountIn,
+    sdkAmountOut: bestSdk.amountOutHuman,
+    hodlmmAmountOut: bestHodlmm.amountOutHuman,
+    spreadPct: spreadPct.toFixed(2),
+    bestSource,
+    estimatedFeeBps: avgFeeBps,
+    netSpreadPct: netSpreadPct.toFixed(2),
+    sdkRoute: sdkLabel,
+    hodlmmPool: hodlmmLabel,
+    priceImpact: {
+      sdk: bestSdk.priceImpact?.combinedImpactPct ?? "N/A",
+      hodlmm: bestHodlmm.priceImpact?.combinedImpactPct ?? "N/A",
+    },
+  };
+}
+
+// ─── CLI ────────────────────────────────────────────────────────────────────
+
+const program = new Command();
+program
+  .name("bitflow-arb-scanner")
+  .description("Arbitrage scanner for Bitflow DEX — SDK vs HODLMM spread detection");
+
+// ─── scan ───────────────────────────────────────────────────────────────────
+
+program
+  .command("scan")
+  .description("Scan all trading pairs for SDK vs HODLMM arbitrage opportunities")
+  .option("--min-spread <percent>", "Minimum spread % to report", DEFAULT_MIN_SPREAD.toString())
+  .option("--amount <decimal>", "Trade size for quote comparison", DEFAULT_AMOUNT)
+  .option("--top <number>", "Return top N opportunities", DEFAULT_TOP.toString())
+  .action(async (options) => {
+    try {
+      ensureMainnet();
+      const service = getBitflowService(NETWORK);
+      const minSpread = parseFloat(options.minSpread);
+      const amount = options.amount;
+      const top = parseInt(options.top, 10);
+
+      // Get all available tokens
+      const tokens = await service.getAvailableTokens();
+      const tokenIds = tokens.map((t) => t.id);
+
+      const opportunities: ArbOpportunity[] = [];
+      const scannedPairs = new Set<string>();
+
+      // Scan each token pair
+      for (const tokenX of tokenIds) {
+        let targets: string[];
+        try {
+          targets = await service.getPossibleSwapTargets(tokenX);
+        } catch {
+          continue;
+        }
+
+        for (const tokenY of targets) {
+          const pairKey = [tokenX, tokenY].sort().join("|");
+          if (scannedPairs.has(pairKey)) continue;
+          scannedPairs.add(pairKey);
+
+          try {
+            const routes = await service.getUnifiedRouteQuotes(tokenX, tokenY, amount);
+
+            const sdkRoutes = routes.filter((r) => r.source === "sdk");
+            const hodlmmRoutes = routes.filter((r) => r.source === "hodlmm");
+
+            if (sdkRoutes.length === 0 || hodlmmRoutes.length === 0) continue;
+
+            const opp = calculateSpread(sdkRoutes, hodlmmRoutes, tokenX, tokenY, amount);
+            if (opp && parseFloat(opp.spreadPct) >= minSpread) {
+              opportunities.push(opp);
+            }
+          } catch {
+            // Skip pairs that fail to quote
+            continue;
+          }
+        }
+      }
+
+      // Sort by spread descending, take top N
+      opportunities.sort((a, b) => parseFloat(b.spreadPct) - parseFloat(a.spreadPct));
+      const topOpps = opportunities.slice(0, top);
+
+      printJson({
+        network: NETWORK,
+        scanTime: new Date().toISOString(),
+        tradeAmount: amount,
+        minSpreadPct: minSpread,
+        opportunityCount: topOpps.length,
+        totalPairsScanned: scannedPairs.size,
+        opportunities: topOpps,
+      });
+    } catch (err) {
+      handleError(err);
+    }
+  });
+
+// ─── scan-pair ──────────────────────────────────────────────────────────────
+
+program
+  .command("scan-pair")
+  .description("Deep route comparison for a specific token pair")
+  .requiredOption("--token-x <tokenId>", "Input token ID")
+  .requiredOption("--token-y <tokenId>", "Output token ID")
+  .requiredOption("--amount-in <decimal>", "Amount of input token")
+  .action(async (options) => {
+    try {
+      ensureMainnet();
+      const service = getBitflowService(NETWORK);
+      const { tokenX, tokenY, amountIn } = options;
+
+      const routes = await service.getUnifiedRouteQuotes(tokenX, tokenY, amountIn);
+
+      if (routes.length === 0) {
+        printJson({
+          network: NETWORK,
+          error: "no routes found",
+          tokenX,
+          tokenY,
+          amountIn,
+        });
+        return;
+      }
+
+      const routeBreakdowns = routes.map(routeToBreakdown);
+
+      // Sort by output descending
+      const sorted = [...routes].sort(
+        (a, b) => parseFloat(b.amountOutHuman) - parseFloat(a.amountOutHuman)
+      );
+      const best = sorted[0];
+      const worst = sorted[sorted.length - 1];
+
+      const bestOut = parseFloat(best.amountOutHuman);
+      const worstOut = parseFloat(worst.amountOutHuman);
+      const spreadPct = worstOut > 0 ? ((bestOut - worstOut) / worstOut) * 100 : 0;
+      const avgFeeBps = Math.round(
+        routes.reduce((sum, r) => sum + (r.priceImpact?.totalFeeBps ?? 0), 0) / routes.length
+      );
+      const netSpreadPct = Math.max(0, spreadPct - avgFeeBps / 100);
+
+      const xSymbol = tokenX.replace("token-", "").replace("-auto", "").toUpperCase();
+      const ySymbol = tokenY.replace("token-", "").replace("-auto", "").toUpperCase();
+
+      printJson({
+        network: NETWORK,
+        pair: `${xSymbol}/${ySymbol}`,
+        tokenX,
+        tokenY,
+        amountIn,
+        routes: routeBreakdowns,
+        bestRoute: {
+          source: best.source,
+          amountOut: best.amountOutHuman,
+        },
+        worstRoute: {
+          source: worst.source,
+          amountOut: worst.amountOutHuman,
+        },
+        spreadPct: spreadPct.toFixed(2),
+        netSpreadPct: netSpreadPct.toFixed(2),
+      });
+    } catch (err) {
+      handleError(err);
+    }
+  });
+
+// ─── scan-pools ─────────────────────────────────────────────────────────────
+
+program
+  .command("scan-pools")
+  .description("Scan HODLMM pools for internal bin pricing inefficiencies")
+  .option("--suggested", "Only scan suggested/featured pools")
+  .option("--min-spread <percent>", "Minimum spread % to report", "0.5")
+  .action(async (options) => {
+    try {
+      ensureMainnet();
+      const service = getBitflowService(NETWORK);
+      const minSpread = parseFloat(options.minSpread);
+
+      const pools = await service.getHodlmmPools(
+        options.suggested ? { suggested: true } : undefined
+      );
+
+      const opportunities: Array<{
+        poolId: string;
+        tokenX: string;
+        tokenY: string;
+        activeBin: number;
+        binStep: number;
+        spreadPct: string;
+        description: string;
+      }> = [];
+
+      for (const pool of pools) {
+        try {
+          const binsResponse = await service.getHodlmmPoolBins(pool.pool_id);
+          if (!binsResponse?.bins || binsResponse.bins.length < 3) continue;
+
+          const activeBinId = binsResponse.active_bin_id;
+          const bins = binsResponse.bins;
+
+          // Find active bin and nearby bins
+          const activeBin = bins.find((b: any) => b.bin_id === activeBinId);
+          if (!activeBin) continue;
+
+          // Calculate price deviation: compare active bin price to weighted average of nearby bins
+          const nearbyBins = bins.filter((b: any) => {
+            const diff = Math.abs(b.bin_id - activeBinId);
+            return diff > 0 && diff <= 3;
+          });
+
+          if (nearbyBins.length === 0) continue;
+
+          const activeBinPrice = parseFloat(activeBin.price || "0");
+          if (activeBinPrice <= 0) continue;
+
+          // Weighted average price of nearby bins by liquidity
+          let totalLiquidity = 0;
+          let weightedPriceSum = 0;
+
+          for (const bin of nearbyBins) {
+            const price = parseFloat(bin.price || "0");
+            const liq =
+              parseFloat(bin.reserve_x || "0") + parseFloat(bin.reserve_y || "0");
+            if (price > 0 && liq > 0) {
+              weightedPriceSum += price * liq;
+              totalLiquidity += liq;
+            }
+          }
+
+          if (totalLiquidity <= 0) continue;
+
+          const avgNearbyPrice = weightedPriceSum / totalLiquidity;
+          const deviation =
+            Math.abs(activeBinPrice - avgNearbyPrice) / avgNearbyPrice * 100;
+
+          if (deviation >= minSpread) {
+            opportunities.push({
+              poolId: pool.pool_id,
+              tokenX: pool.token_x,
+              tokenY: pool.token_y,
+              activeBin: activeBinId,
+              binStep: pool.bin_step,
+              spreadPct: deviation.toFixed(2),
+              description:
+                activeBinPrice > avgNearbyPrice
+                  ? "Active bin price above nearby bin weighted average"
+                  : "Active bin price below nearby bin weighted average",
+            });
+          }
+        } catch {
+          continue;
+        }
+      }
+
+      opportunities.sort(
+        (a, b) => parseFloat(b.spreadPct) - parseFloat(a.spreadPct)
+      );
+
+      printJson({
+        network: NETWORK,
+        poolCount: pools.length,
+        opportunityCount: opportunities.length,
+        minSpreadPct: minSpread,
+        opportunities,
+      });
+    } catch (err) {
+      handleError(err);
+    }
+  });
+
+// ─── watchlist ──────────────────────────────────────────────────────────────
+
+program
+  .command("watchlist")
+  .description("Monitor specific pairs for actionable arbitrage spreads")
+  .requiredOption("--pairs <json>", "JSON array of [tokenX, tokenY] pairs")
+  .option("--amount <decimal>", "Trade size for quotes", DEFAULT_AMOUNT)
+  .option("--min-spread <percent>", "Minimum spread % to alert", "0.5")
+  .action(async (options) => {
+    try {
+      ensureMainnet();
+      const service = getBitflowService(NETWORK);
+      const minSpread = parseFloat(options.minSpread);
+      const amount = options.amount;
+
+      let pairs: [string, string][];
+      try {
+        pairs = JSON.parse(options.pairs);
+      } catch {
+        throw new Error("--pairs must be a valid JSON array of [tokenX, tokenY] pairs");
+      }
+
+      if (!Array.isArray(pairs) || pairs.length === 0) {
+        throw new Error("--pairs must be a non-empty array");
+      }
+
+      const alerts: Array<{
+        pair: string;
+        spreadPct: string;
+        bestSource: string;
+        amountIn: string;
+        sdkOut: string;
+        hodlmmOut: string;
+      }> = [];
+
+      for (const [tokenX, tokenY] of pairs) {
+        try {
+          const routes = await service.getUnifiedRouteQuotes(tokenX, tokenY, amount);
+
+          const sdkRoutes = routes.filter((r) => r.source === "sdk");
+          const hodlmmRoutes = routes.filter((r) => r.source === "hodlmm");
+
+          if (sdkRoutes.length === 0 || hodlmmRoutes.length === 0) continue;
+
+          const opp = calculateSpread(sdkRoutes, hodlmmRoutes, tokenX, tokenY, amount);
+          if (opp && parseFloat(opp.spreadPct) >= minSpread) {
+            const xSymbol = tokenX.replace("token-", "").replace("-auto", "").toUpperCase();
+            const ySymbol = tokenY.replace("token-", "").replace("-auto", "").toUpperCase();
+            alerts.push({
+              pair: `${xSymbol}/${ySymbol}`,
+              spreadPct: opp.spreadPct,
+              bestSource: opp.bestSource,
+              amountIn: amount,
+              sdkOut: opp.sdkAmountOut,
+              hodlmmOut: opp.hodlmmAmountOut,
+            });
+          }
+        } catch {
+          continue;
+        }
+      }
+
+      alerts.sort((a, b) => parseFloat(b.spreadPct) - parseFloat(a.spreadPct));
+
+      printJson({
+        network: NETWORK,
+        scannedAt: new Date().toISOString(),
+        pairsScanned: pairs.length,
+        alertCount: alerts.length,
+        minSpreadPct: minSpread,
+        alerts,
+      });
+    } catch (err) {
+      handleError(err);
+    }
+  });
+
+// ─── Run ────────────────────────────────────────────────────────────────────
+
+program.parse();

--- a/bitflow-arb-scanner/bitflow-arb-scanner.ts
+++ b/bitflow-arb-scanner/bitflow-arb-scanner.ts
@@ -25,10 +25,11 @@ import { printJson, handleError } from "../src/lib/utils/cli.js";
 
 // ─── Constants ──────────────────────────────────────────────────────────────
 
-const HODLMM_API = "https://bff.bitflowapis.finance/api/quotes/v1";
 const DEFAULT_AMOUNT = "10.0";
 const DEFAULT_MIN_SPREAD = 0.1;
 const DEFAULT_TOP = 10;
+
+const SCAN_CONCURRENCY = 5;
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
@@ -36,6 +37,17 @@ function ensureMainnet(): void {
   if (NETWORK !== "mainnet") {
     throw new Error("Bitflow arbitrage scanner is mainnet only. Set NETWORK=mainnet.");
   }
+}
+
+function tokenSymbol(id: string): string {
+  return id.replace("token-", "").replace("-auto", "").toUpperCase();
+}
+
+interface BinEntry {
+  bin_id: number;
+  price?: string;
+  reserve_x?: string;
+  reserve_y?: string;
 }
 
 interface RouteBreakdown {
@@ -81,8 +93,16 @@ function calculateSpread(
   tokenY: string,
   amountIn: string
 ): ArbOpportunity | null {
-  const bestSdk = sdkRoutes[0];
-  const bestHodlmm = hodlmmRoutes[0];
+  // Sort each source by best output descending
+  const sortedSdk = [...sdkRoutes].sort(
+    (a, b) => parseFloat(b.amountOutHuman) - parseFloat(a.amountOutHuman)
+  );
+  const sortedHodlmm = [...hodlmmRoutes].sort(
+    (a, b) => parseFloat(b.amountOutHuman) - parseFloat(a.amountOutHuman)
+  );
+
+  const bestSdk = sortedSdk[0];
+  const bestHodlmm = sortedHodlmm[0];
 
   if (!bestSdk || !bestHodlmm) return null;
 
@@ -96,23 +116,17 @@ function calculateSpread(
   const spreadPct = ((maxOut - minOut) / minOut) * 100;
 
   const bestSource = hodlmmOut > sdkOut ? "hodlmm" : "sdk";
-  const avgFeeBps = Math.round(
-    ((bestSdk.priceImpact?.totalFeeBps ?? 0) +
-      (bestHodlmm.priceImpact?.totalFeeBps ?? 0)) /
-      2
-  );
-  const netSpreadPct = Math.max(0, spreadPct - avgFeeBps / 100);
 
-  // Extract labels
+  // Use the fee of the route you'd actually take (the better one)
+  const bestRoute = bestSource === "hodlmm" ? bestHodlmm : bestSdk;
+  const bestRouteFeeBps = bestRoute.priceImpact?.totalFeeBps ?? 0;
+  const netSpreadPct = Math.max(0, spreadPct - bestRouteFeeBps / 100);
+
   const sdkLabel = bestSdk.label || bestSdk.poolContracts?.[0] || "sdk";
   const hodlmmLabel = bestHodlmm.label || bestHodlmm.poolContracts?.[0] || "hodlmm";
 
-  // Extract token symbols from IDs
-  const xSymbol = tokenX.replace("token-", "").replace("-auto", "").toUpperCase();
-  const ySymbol = tokenY.replace("token-", "").replace("-auto", "").toUpperCase();
-
   return {
-    pair: `${xSymbol}/${ySymbol}`,
+    pair: `${tokenSymbol(tokenX)}/${tokenSymbol(tokenY)}`,
     tokenX,
     tokenY,
     amountIn,
@@ -120,7 +134,7 @@ function calculateSpread(
     hodlmmAmountOut: bestHodlmm.amountOutHuman,
     spreadPct: spreadPct.toFixed(2),
     bestSource,
-    estimatedFeeBps: avgFeeBps,
+    estimatedFeeBps: bestRouteFeeBps,
     netSpreadPct: netSpreadPct.toFixed(2),
     sdkRoute: sdkLabel,
     hodlmmPool: hodlmmLabel,
@@ -160,13 +174,16 @@ program
 
       const opportunities: ArbOpportunity[] = [];
       const scannedPairs = new Set<string>();
+      let skippedCount = 0;
 
-      // Scan each token pair
+      // Collect all unique pairs first
+      const pairQueue: [string, string][] = [];
       for (const tokenX of tokenIds) {
         let targets: string[];
         try {
           targets = await service.getPossibleSwapTargets(tokenX);
         } catch {
+          skippedCount++;
           continue;
         }
 
@@ -174,28 +191,36 @@ program
           const pairKey = [tokenX, tokenY].sort().join("|");
           if (scannedPairs.has(pairKey)) continue;
           scannedPairs.add(pairKey);
+          pairQueue.push([tokenX, tokenY]);
+        }
+      }
 
-          try {
+      // Scan pairs in batches for concurrency
+      for (let i = 0; i < pairQueue.length; i += SCAN_CONCURRENCY) {
+        const batch = pairQueue.slice(i, i + SCAN_CONCURRENCY);
+        const results = await Promise.allSettled(
+          batch.map(async ([tokenX, tokenY]) => {
             const routes = await service.getUnifiedRouteQuotes(tokenX, tokenY, amount);
-
             const sdkRoutes = routes.filter((r) => r.source === "sdk");
             const hodlmmRoutes = routes.filter((r) => r.source === "hodlmm");
+            if (sdkRoutes.length === 0 || hodlmmRoutes.length === 0) return null;
+            return calculateSpread(sdkRoutes, hodlmmRoutes, tokenX, tokenY, amount);
+          })
+        );
 
-            if (sdkRoutes.length === 0 || hodlmmRoutes.length === 0) continue;
-
-            const opp = calculateSpread(sdkRoutes, hodlmmRoutes, tokenX, tokenY, amount);
-            if (opp && parseFloat(opp.spreadPct) >= minSpread) {
-              opportunities.push(opp);
+        for (const result of results) {
+          if (result.status === "fulfilled" && result.value) {
+            if (parseFloat(result.value.spreadPct) >= minSpread) {
+              opportunities.push(result.value);
             }
-          } catch {
-            // Skip pairs that fail to quote
-            continue;
+          } else if (result.status === "rejected") {
+            skippedCount++;
           }
         }
       }
 
-      // Sort by spread descending, take top N
-      opportunities.sort((a, b) => parseFloat(b.spreadPct) - parseFloat(a.spreadPct));
+      // Sort by fee-adjusted spread descending, take top N
+      opportunities.sort((a, b) => parseFloat(b.netSpreadPct) - parseFloat(a.netSpreadPct));
       const topOpps = opportunities.slice(0, top);
 
       printJson({
@@ -205,6 +230,7 @@ program
         minSpreadPct: minSpread,
         opportunityCount: topOpps.length,
         totalPairsScanned: scannedPairs.size,
+        skippedCount,
         opportunities: topOpps,
       });
     } catch (err) {
@@ -251,17 +277,12 @@ program
       const bestOut = parseFloat(best.amountOutHuman);
       const worstOut = parseFloat(worst.amountOutHuman);
       const spreadPct = worstOut > 0 ? ((bestOut - worstOut) / worstOut) * 100 : 0;
-      const avgFeeBps = Math.round(
-        routes.reduce((sum, r) => sum + (r.priceImpact?.totalFeeBps ?? 0), 0) / routes.length
-      );
-      const netSpreadPct = Math.max(0, spreadPct - avgFeeBps / 100);
-
-      const xSymbol = tokenX.replace("token-", "").replace("-auto", "").toUpperCase();
-      const ySymbol = tokenY.replace("token-", "").replace("-auto", "").toUpperCase();
+      const bestFeeBps = best.priceImpact?.totalFeeBps ?? 0;
+      const netSpreadPct = Math.max(0, spreadPct - bestFeeBps / 100);
 
       printJson({
         network: NETWORK,
-        pair: `${xSymbol}/${ySymbol}`,
+        pair: `${tokenSymbol(tokenX)}/${tokenSymbol(tokenY)}`,
         tokenX,
         tokenY,
         amountIn,
@@ -318,11 +339,11 @@ program
           const bins = binsResponse.bins;
 
           // Find active bin and nearby bins
-          const activeBin = bins.find((b: any) => b.bin_id === activeBinId);
+          const activeBin = (bins as BinEntry[]).find((b) => b.bin_id === activeBinId);
           if (!activeBin) continue;
 
           // Calculate price deviation: compare active bin price to weighted average of nearby bins
-          const nearbyBins = bins.filter((b: any) => {
+          const nearbyBins = (bins as BinEntry[]).filter((b) => {
             const diff = Math.abs(b.bin_id - activeBinId);
             return diff > 0 && diff <= 3;
           });
@@ -433,10 +454,8 @@ program
 
           const opp = calculateSpread(sdkRoutes, hodlmmRoutes, tokenX, tokenY, amount);
           if (opp && parseFloat(opp.spreadPct) >= minSpread) {
-            const xSymbol = tokenX.replace("token-", "").replace("-auto", "").toUpperCase();
-            const ySymbol = tokenY.replace("token-", "").replace("-auto", "").toUpperCase();
             alerts.push({
-              pair: `${xSymbol}/${ySymbol}`,
+              pair: `${tokenSymbol(tokenX)}/${tokenSymbol(tokenY)}`,
               spreadPct: opp.spreadPct,
               bestSource: opp.bestSource,
               amountIn: amount,

--- a/skills.json
+++ b/skills.json
@@ -1,6 +1,6 @@
 {
-  "version": "0.37.0",
-  "generated": "2026-04-08T00:08:04.790Z",
+  "version": "0.38.1",
+  "generated": "2026-04-09T03:10:38.032Z",
   "skills": [
     {
       "name": "agent-lookup",
@@ -395,6 +395,29 @@
       "userInvocable": false,
       "author": "whoabuddy",
       "authorAgent": "Trustless Indra"
+    },
+    {
+      "name": "bitflow-arb-scanner",
+      "description": "Bitflow Arbitrage Scanner — detects price discrepancies between SDK routes and HODLMM quotes on Bitflow DEX, surfaces profitable arbitrage opportunities with spread analysis, fee-adjusted P&L estimation, and multi-pair scanning. All operations are read-only and mainnet-only. No API key required.",
+      "entry": "bitflow-arb-scanner/bitflow-arb-scanner.ts",
+      "arguments": [
+        "scan",
+        "scan-pair",
+        "scan-pools",
+        "watchlist"
+      ],
+      "requires": [
+        "wallet"
+      ],
+      "tags": [
+        "l2",
+        "defi",
+        "read-only",
+        "mainnet-only"
+      ],
+      "userInvocable": false,
+      "author": "vanhuy",
+      "authorAgent": "Arb Hunter"
     },
     {
       "name": "bns",

--- a/skills.json
+++ b/skills.json
@@ -1,6 +1,6 @@
 {
   "version": "0.38.1",
-  "generated": "2026-04-09T03:10:38.032Z",
+  "generated": "2026-04-09T03:31:17.750Z",
   "skills": [
     {
       "name": "agent-lookup",
@@ -406,9 +406,7 @@
         "scan-pools",
         "watchlist"
       ],
-      "requires": [
-        "wallet"
-      ],
+      "requires": [],
       "tags": [
         "l2",
         "defi",


### PR DESCRIPTION
## Summary
- Adds a new **read-only** skill that detects price discrepancies between Bitflow SDK (XYK AMM) routes and HODLMM (DLMM concentrated liquidity) quotes
- Four subcommands: `scan` (all pairs), `scan-pair` (single pair deep analysis), `scan-pools` (intra-pool bin pricing), `watchlist` (monitor specific pairs)
- Fee-adjusted spread calculation with net P&L estimation
- Mainnet-only, no wallet required for scanning

## Skill Structure
```
bitflow-arb-scanner/
├── SKILL.md                  # CLI interface docs
├── AGENT.md                  # Autonomous agent behavior rules
└── bitflow-arb-scanner.ts    # Commander CLI (read-only, JSON output)
```

## Test plan
- [x] `bun run typecheck` passes
- [x] `bun run validate` passes for both SKILL.md and AGENT.md
- [x] `bun run manifest` regenerates skills.json with new skill
- [x] `NETWORK=mainnet bun run bitflow-arb-scanner/bitflow-arb-scanner.ts scan --top 5` returns opportunities
- [x] `NETWORK=mainnet bun run bitflow-arb-scanner/bitflow-arb-scanner.ts scan-pair --token-x token-stx --token-y token-sbtc --amount-in 10` returns route comparison