### PR TITLE
chore(validate): fix frontmatter on 3 pre-existing skills

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Quest planning (local only)
 .planning/
+.quests/
 
 # skills-ref Python venv (local only)
 .venv-skills-ref/

--- a/hermetica-yield-rotator/SKILL.md
+++ b/hermetica-yield-rotator/SKILL.md
@@ -4,11 +4,11 @@ description: "Cross-protocol yield rotator for Stacks mainnet. Monitors Hermetic
 metadata:
   author: cliqueengagements
   author-agent: "Micro Basilisk (Agent 77) — SP219TWC8G12CSX5AB093127NC82KYQWEH8ADD1AY | bc1qzh2z92dlvccxq5w756qppzz8fymhgrt2dv8cf5"
-  user-invocable: "true"
+  user-invocable: "false"
   arguments: "doctor | install-packs | run [--wallet <STX_ADDRESS>] [--action <assess|stake|initiate-unstake|complete-unstake|rotate>] [--amount <usdh>] [--confirm]"
   entry: "hermetica-yield-rotator/hermetica-yield-rotator.ts"
   requires: ""
-  tags: "defi, hermetica, usdh, staking, bitflow, yield, rotation, actions, mainnet-only, l2"
+  tags: "defi, write, mainnet-only, l2"
 ---
 
 # Hermetica Yield Rotator

--- a/jingswap-cycle-agent/SKILL.md
+++ b/jingswap-cycle-agent/SKILL.md
@@ -7,8 +7,8 @@ metadata:
   user-invocable: "false"
   arguments: "doctor | status | analyze | participate"
   entry: "jingswap-cycle-agent/jingswap-cycle-agent.ts"
-  requires: "jingswap_deposit_stx (aibtc MCP) for live execution"
-  tags: "jingswap, sbtc, stx, defi, execution, mainnet-only, stacks, bitflow"
+  requires: "wallet, jingswap"
+  tags: "defi, write, mainnet-only, l2"
 ---
 
 # jingswap-cycle-agent

--- a/sbtc-auto-funnel/SKILL.md
+++ b/sbtc-auto-funnel/SKILL.md
@@ -8,7 +8,7 @@ metadata:
   arguments: "doctor | run --action=check | run --action=funnel | install-packs"
   entry: "sbtc-auto-funnel/sbtc-auto-funnel.ts"
   requires: "wallet, signing"
-  tags: "defi, yield, sbtc, zest, automation"
+  tags: "defi, write, mainnet-only, requires-funds, l2"
 ---
 
 # sBTC Auto-Funnel

--- a/skills.json
+++ b/skills.json
@@ -1,6 +1,6 @@
 {
   "version": "0.38.1",
-  "generated": "2026-04-13T17:47:28.197Z",
+  "generated": "2026-04-15T19:23:04.474Z",
   "skills": [
     {
       "name": "agent-lookup",
@@ -826,17 +826,11 @@
       "requires": [],
       "tags": [
         "defi",
-        "hermetica",
-        "usdh",
-        "staking",
-        "bitflow",
-        "yield",
-        "rotation",
-        "actions",
+        "write",
         "mainnet-only",
         "l2"
       ],
-      "userInvocable": true,
+      "userInvocable": false,
       "author": "cliqueengagements",
       "authorAgent": "Micro Basilisk (Agent 77) — SP219TWC8G12CSX5AB093127NC82KYQWEH8ADD1AY | bc1qzh2z92dlvccxq5w756qppzz8fymhgrt2dv8cf5"
     },
@@ -1065,17 +1059,14 @@
         "participate"
       ],
       "requires": [
-        "jingswap_deposit_stx (aibtc MCP) for live execution"
+        "wallet",
+        "jingswap"
       ],
       "tags": [
-        "jingswap",
-        "sbtc",
-        "stx",
         "defi",
-        "execution",
+        "write",
         "mainnet-only",
-        "stacks",
-        "bitflow"
+        "l2"
       ],
       "userInvocable": false,
       "author": "teflonmusk",
@@ -1644,10 +1635,10 @@
       ],
       "tags": [
         "defi",
-        "yield",
-        "sbtc",
-        "zest",
-        "automation"
+        "write",
+        "mainnet-only",
+        "requires-funds",
+        "l2"
       ],
       "userInvocable": false,
       "author": "secret-mars",


### PR DESCRIPTION
## What broke and why

Three skills were admin-merged on **2026-04-08** with the CI job `Typecheck, validate, and manifest freshness` in **FAILURE** state. The Zod-tier frontmatter validation rules were tightened in **PR #135** (merged 2026-03-13), three weeks before these PRs landed. Branch protection on `main` is not currently requiring the CI job to pass, which allowed them through.

Running `bun run scripts/validate-frontmatter.ts --skip-spec` on clean `main` before this fix produced:

```
Results: 149 passed, 3 failed, 152 total
```

Failures were:

| Skill | Failure | Introduced by |
|-------|---------|---------------|
| `hermetica-yield-rotator/SKILL.md` | `user-invocable: "true"` — rule requires `"false"` | #273 |
| `jingswap-cycle-agent/SKILL.md` | `tags` outside controlled vocab; `requires` is an MCP tool name, not a skill dir | #294 |
| `sbtc-auto-funnel/SKILL.md` | `tags` outside controlled vocab | #278 |

Full investigation context: `.planning/2026-04-15-bff-comp-review-4/FINDINGS.md`

## Changes (frontmatter only — no code changes)

### `hermetica-yield-rotator/SKILL.md` (PR #273)
- `user-invocable: "true"` → `"false"` (skills are invoked by Claude Code, not end users)
- `tags`: trimmed to controlled vocab → `"defi, write, mainnet-only, l2"`

### `jingswap-cycle-agent/SKILL.md` (PR #294)
- `requires`: `"jingswap_deposit_stx (aibtc MCP) for live execution"` → `"wallet, jingswap"` (valid skill directory names)
- `tags`: trimmed to controlled vocab → `"defi, write, mainnet-only, l2"`

### `sbtc-auto-funnel/SKILL.md` (PR #278)
- `tags`: trimmed to controlled vocab → `"defi, write, mainnet-only, requires-funds, l2"`

### `skills.json`
Regenerated via `bun run manifest` to reflect the three frontmatter fixes.

## Verification

After this change:
```
bun run scripts/validate-frontmatter.ts --skip-spec
Results: 152 passed, 0 failed, 152 total

bun run typecheck
(no output — clean)
```

## Flag for repo owner

Branch protection on `main` should require the `Typecheck, validate, and manifest freshness` CI job to pass before merging. Without that requirement, future comp batches can admin-merge past red CI and introduce the same category of failures. This is a GitHub repository settings change and is not part of this PR — flagging here for awareness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)