### PR TITLE
feat(sbtc-yield-maximizer): complete HODLMM routing leg

### DIFF
--- a/sbtc-yield-maximizer/AGENT.md
+++ b/sbtc-yield-maximizer/AGENT.md
@@ -1,14 +1,14 @@
 ---
 name: sbtc-yield-maximizer-agent
 skill: sbtc-yield-maximizer
-description: "Routes idle sBTC to the highest safe current yield path and only executes a capped Zest supply when Zest is the winning executable route."
+description: "Routes idle sBTC to the highest safe current yield path and executes either Zest supply or a HODLMM rebalance when the winning route is safely executable."
 ---
 
 # sBTC Yield Maximizer Agent
 
 ## Purpose
 
-Use this skill to deploy idle sBTC only when the highest safe live yield route is clear and executable.
+Use this skill to deploy or reposition sBTC only when the highest safe live yield route is clear and executable.
 
 ## Decision order
 
@@ -16,36 +16,47 @@ Use this skill to deploy idle sBTC only when the highest safe live yield route i
 2. Run `status` to inspect current balances, route scores, cooldown state, and the winning route.
 3. Only use `run` when:
    - the selected wallet is on mainnet
-   - the cooldown has expired
+   - the router cooldown has expired
+   - sender mempool depth is within the configured limit
    - idle sBTC remains above `--reserve-sats`
    - post-transaction STX reserve remains above `--min-gas-reserve-ustx`
-   - Zest is the winning executable route
+   - the winning route leads by at least `--min-apy-diff-bps`
+   - Zest and HODLMM APY reads are fresh within `--max-data-age-seconds`
    - explicit operator approval has been given
-4. Require `--confirm=MAXIMIZE` before broadcasting.
-5. Re-lock the wallet after the write attempt, regardless of success or failure.
+4. If Zest wins, execute the Zest write path.
+5. If HODLMM wins, call `hodlmm-move-liquidity run` via CLI rather than importing its source.
+6. Use `hodlmm-move-liquidity scan` as the no-broadcast HODLMM preflight check, then respect `hodlmm-move-liquidity`'s per-pool cooldown before delegated execution.
+7. Serialize writes so only one leg is active at a time.
+8. Require `--confirm=MAXIMIZE` before broadcasting.
+9. Re-lock the wallet after the write attempt, regardless of success or failure.
 
 ## Guardrails
 
 - Never execute without `AIBTC_WALLET_PASSWORD`.
 - Never deploy more than `--max-deploy-sats`.
 - Never deploy below the retained `--reserve-sats`.
-- Never execute while cooldown is active.
+- Never execute while the router cooldown is active.
+- Never execute while pending mempool depth exceeds `--mempool-depth-limit`.
 - Never let a HODLMM pool win when it fails volume, TVL, or price-divergence safety gates.
-- Never claim the HODLMM path is executable in this skill version.
-- Never execute when Zest is not the winning route.
+- Never let a route win when its APY data is stale.
+- Never rotate when the winning APY edge is below `--min-apy-diff-bps`.
+- Never bypass `hodlmm-move-liquidity` for the HODLMM write path.
+- Never expose the wallet password through subprocess CLI arguments.
 - Never execute when STX reserve would fall below `--min-gas-reserve-ustx`.
-- no AIBTC wallet can be resolved
-- the wallet is not on mainnet
-- no idle sBTC is available above reserve
-- cooldown is active
-- no safe route is available
-- HODLMM wins but direct HODLMM deposit is not enabled in this version
-- operator confirmation is missing
-- wallet unlock fails
+- Refuse when no AIBTC wallet can be resolved.
+- Refuse when the wallet is not on mainnet.
+- Refuse when no idle sBTC is available above reserve.
+- Refuse when cooldown is active.
+- Refuse when mempool depth is non-zero and execution is configured to wait for a clear lane.
+- Refuse when no safe route is available.
+- Refuse when `hodlmm-move-liquidity` is unavailable but HODLMM is the winning route.
+- Refuse when operator confirmation is missing.
+- Refuse when wallet unlock fails.
 - Treat the Zest service-layer call as post-condition protected. Execution assumes the underlying service uses `PostConditionMode.Deny`.
+- Treat the HODLMM leg as protected by `hodlmm-move-liquidity`'s contract-level min-DLP and max-liquidity-fee guards.
 
 ## Operational notes
 
-- This is a write skill and will broadcast a real Zest supply transaction when Zest wins.
-- HODLMM is used as a live competing route in the decision function, including stale-price and liquidity vetoes.
-- This skill is designed to be standalone and truthful about execution boundaries.
+- This is a write skill and will broadcast a real Zest supply transaction or a real HODLMM rebalance when the winning route passes all gates.
+- HODLMM is used as a live competing route in the decision function, including stale-price, liquidity, freshness, and LP-position checks.
+- This skill is designed to remain a single self-contained directory while composing with upstream primitives through CLI orchestration.

--- a/sbtc-yield-maximizer/SKILL.md
+++ b/sbtc-yield-maximizer/SKILL.md
@@ -124,3 +124,4 @@ All outputs are JSON to stdout.
 - Zest sBTC yield is derived from live on-chain Zest vault reads and interpreted as a basis-points-style supply signal. This was verified against the live `v0-vault-sbtc` source, which defines `BPS u10000` and applies rate math in basis points.
 - HODLMM opportunity is derived from live Bitflow app and quote APIs using APR, fee run-rate, volume, TVL, stale-price checks, and whether the wallet already has an out-of-range LP position that can be rebalanced.
 - Requires enough sBTC to exceed reserve and enough STX to preserve gas reserve.
+- Wallet-scoped state now lives under `~/.aibtc/`. This intentionally starts fresh on upgrade rather than migrating the previous shared `~/.sbtc-yield-maximizer-state.json` cooldown file.

--- a/sbtc-yield-maximizer/SKILL.md
+++ b/sbtc-yield-maximizer/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: sbtc-yield-maximizer
-description: "Routes idle sBTC to the highest safe live yield path and executes capped Zest supply when Zest is the best current route."
+description: "Routes idle sBTC to the highest safe live yield path and executes either capped Zest supply or a HODLMM rebalance when the winning route is safely executable."
 metadata:
   author: "Ololadestephen"
   author-agent: "Wide Eden"
   user-invocable: "false"
   arguments: "doctor | install-packs | status | run"
   entry: "sbtc-yield-maximizer/sbtc-yield-maximizer.ts"
-  requires: "wallet, signing, settings"
+  requires: "wallet, signing, settings, hodlmm-move-liquidity, bitflow"
   tags: "defi, write, mainnet-only, requires-funds, l2"
 ---
 
@@ -15,7 +15,7 @@ metadata:
 
 ## What it does
 
-Compares live Zest sBTC yield against current Bitflow sBTC HODLMM opportunity and routes idle sBTC to the highest safe path. This version executes a real Zest sBTC supply transaction when Zest is the winning route and blocks when HODLMM is better but not safely executable by this standalone skill version.
+Compares live Zest sBTC yield against current Bitflow sBTC HODLMM opportunity and routes idle sBTC to the highest safe path. This version executes a real Zest sBTC supply transaction when Zest is the winning route and executes the HODLMM leg by orchestrating `hodlmm-move-liquidity` via CLI when HODLMM is the winning safe executable route.
 
 ## Why agents need it
 
@@ -23,23 +23,26 @@ Agents should not deploy sBTC based on static assumptions. They need a real deci
 
 ## Safety notes
 
-- Writes to chain. `run` signs and broadcasts a real Zest sBTC supply transaction when Zest is the winning route.
+- Writes to chain. `run` signs and broadcasts a real Zest sBTC supply transaction when Zest is the winning route, or a real HODLMM rebalance when HODLMM wins.
 - Mainnet only. Routing data and write execution target live mainnet protocols.
 - Wallet password required. The skill unlocks the local AIBTC wallet at execution time using `AIBTC_WALLET_PASSWORD`.
 - Reserve enforced. The wallet retains at least `--reserve-sats` after the write path.
 - Deploy cap enforced. The routed amount is capped by `--max-deploy-sats`.
 - Gas reserve enforced. The wallet must keep at least `--min-gas-reserve-ustx`.
 - Post-conditions enforced. The Zest service-layer write path uses `PostConditionMode.Deny`.
-- HODLMM stale-price gate enforced. Pools with price divergence above `--max-price-divergence-pct` are disqualified from winning.
+- HODLMM stale-price gate enforced. HODLMM reads older than `--max-data-age-seconds` or pools with price divergence above `--max-price-divergence-pct` are disqualified.
 - HODLMM liquidity gates enforced. Pools below the configured TVL or 24h volume floors are disqualified.
-- Cooldown enforced. Repeated route execution is blocked until `--cooldown-hours` has elapsed.
+- APY edge gate enforced. The route only rotates when the winning venue leads by at least `--min-apy-diff-bps`.
+- Meta-cooldown enforced. Repeated route execution is blocked until `--cooldown-hours` has elapsed.
+- Mempool-depth guard enforced. Execution is blocked when pending sender depth exceeds `--mempool-depth-limit`.
+- HODLMM execution delegates to `hodlmm-move-liquidity` via CLI, keeps the wallet password in environment scope rather than subprocess CLI args, and respects the upstream per-pool cooldown/state.
 - Explicit confirmation required. `run` refuses to execute unless `--confirm=MAXIMIZE` is provided.
 - Wallet is re-locked after the attempted write path.
 
 ## Commands
 
 ### doctor
-Checks wallet resolution, STX and sBTC balances, Zest vault reads, Bitflow pool reads, and whether the current configuration can execute the winning route safely.
+Checks wallet resolution, STX and sBTC balances, Zest vault reads, Bitflow pool reads, mempool depth, and whether the current configuration can execute the winning route safely.
 
 ```bash
 bun run sbtc-yield-maximizer/sbtc-yield-maximizer.ts doctor
@@ -60,7 +63,9 @@ bun run sbtc-yield-maximizer/sbtc-yield-maximizer.ts status
 ```
 
 ### run
-Unlocks the wallet, re-checks the route decision, and executes a real Zest sBTC supply when Zest is the winning safe route.
+Unlocks the wallet, re-checks the route decision, and executes the winning safe route:
+- Zest sBTC supply when Zest wins
+- HODLMM rebalance via `hodlmm-move-liquidity` when HODLMM wins and the current position is out of range
 
 ```bash
 AIBTC_WALLET_PASSWORD='your-password' bun run sbtc-yield-maximizer/sbtc-yield-maximizer.ts run --confirm=MAXIMIZE
@@ -69,7 +74,7 @@ AIBTC_WALLET_PASSWORD='your-password' bun run sbtc-yield-maximizer/sbtc-yield-ma
 Example tuned run:
 
 ```bash
-AIBTC_WALLET_PASSWORD='your-password' bun run sbtc-yield-maximizer/sbtc-yield-maximizer.ts run --wallet-id=b4d575f8-0865-4d6f-b1d6-5627b645a03c --max-deploy-sats=100 --reserve-sats=100 --min-gas-reserve-ustx=100000 --min-hodlmm-volume-usd=1000 --min-hodlmm-tvl-usd=1000 --max-price-divergence-pct=0.5 --confirm=MAXIMIZE
+AIBTC_WALLET_PASSWORD='your-password' HODLMM_MOVE_LIQUIDITY_CMD='bun run /path/to/hodlmm-move-liquidity.ts' bun run sbtc-yield-maximizer/sbtc-yield-maximizer.ts run --wallet-id=b4d575f8-0865-4d6f-b1d6-5627b645a03c --max-deploy-sats=10000 --reserve-sats=100 --min-gas-reserve-ustx=100000 --min-hodlmm-volume-usd=1000 --min-hodlmm-tvl-usd=1000 --max-price-divergence-pct=0.5 --min-apy-diff-bps=50 --max-data-age-seconds=30 --mempool-depth-limit=0 --confirm=MAXIMIZE
 ```
 
 ## Output contract
@@ -81,7 +86,7 @@ All outputs are JSON to stdout.
 ```json
 {
   "status": "success",
-  "action": "Supplied sBTC to Zest because it was the highest safe executable yield route",
+  "action": "Executed the highest safe yield route",
   "data": {
     "operation": "maximize-yield",
     "txid": "0x...",
@@ -114,13 +119,8 @@ All outputs are JSON to stdout.
 
 ## Known constraints
 
-- This version executes the Zest route when Zest is the winning route. When HODLMM wins, the skill reports that outcome but does not attempt a direct HODLMM LP deposit.
+- This version composes with `hodlmm-move-liquidity` by CLI rather than source imports. That upstream primitive remains the source of truth for the HODLMM write path.
+- The HODLMM preflight path uses `hodlmm-move-liquidity scan`, which is a no-broadcast command. Actual HODLMM execution only happens on the delegated `run --confirm` path.
 - Zest sBTC yield is derived from live on-chain Zest vault reads and interpreted as a basis-points-style supply signal. This was verified against the live `v0-vault-sbtc` source, which defines `BPS u10000` and applies rate math in basis points.
-- HODLMM opportunity is derived from live Bitflow app and quote APIs using APR, fee run-rate, volume, TVL, and stale-price checks.
+- HODLMM opportunity is derived from live Bitflow app and quote APIs using APR, fee run-rate, volume, TVL, stale-price checks, and whether the wallet already has an out-of-range LP position that can be rebalanced.
 - Requires enough sBTC to exceed reserve and enough STX to preserve gas reserve.
-
-## Origin
-
-Winner of AIBTC x Bitflow Skills Pay the Bills competition.
-Original author: @Ololadestephen
-Competition PR: https://github.com/BitflowFinance/bff-skills/pull/243

--- a/sbtc-yield-maximizer/sbtc-yield-maximizer.ts
+++ b/sbtc-yield-maximizer/sbtc-yield-maximizer.ts
@@ -1,8 +1,9 @@
 #!/usr/bin/env bun
 
 import { Command } from "commander";
-import { homedir } from "os";
-import { join } from "path";
+import { homedir, tmpdir } from "os";
+import { extname, isAbsolute, join, resolve as resolvePath } from "path";
+import { closeSync, openSync, statSync, unlinkSync } from "fs";
 import { cvToJSON, hexToCV } from "@stacks/transactions";
 import { getWalletManager } from "../src/lib/services/wallet-manager.js";
 import { getExplorerTxUrl } from "../src/lib/config/networks.js";
@@ -14,6 +15,7 @@ const HIRO_API = "https://api.mainnet.hiro.so";
 const BITFLOW_APP_API = "https://bff.bitflowapis.finance/api/app/v1/pools";
 const BITFLOW_QUOTES_API = "https://bff.bitflowapis.finance/api/quotes/v1/pools";
 const BITFLOW_BINS_API = "https://bff.bitflowapis.finance/api/quotes/v1/bins";
+const BITFLOW_APP_USER_POSITIONS_API = "https://bff.bitflowapis.finance/api/app/v1/users";
 const SBTC_CONTRACT = "SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-token";
 const ZEST_SBTC_VAULT = "SP1A27KFY4XERQCCRCARCYD1CC5N7M6688BSYADJ7.v0-vault-sbtc";
 const FETCH_TIMEOUT_MS = 30_000;
@@ -24,10 +26,20 @@ const DEFAULT_MIN_GAS_RESERVE_USTX = 100_000n;
 const DEFAULT_MIN_HODLMM_VOLUME_USD = 250;
 const DEFAULT_MIN_HODLMM_TVL_USD = 1_000;
 const DEFAULT_MAX_PRICE_DIVERGENCE_PCT = 1;
-const DEFAULT_ROUTE_EDGE_BPS = 25;
-const DEFAULT_COOLDOWN_HOURS = 4;
+const DEFAULT_MIN_APY_DIFF_BPS = 50;
+const DEFAULT_MAX_DATA_AGE_SECONDS = 30;
+const DEFAULT_META_COOLDOWN_HOURS = 1;
+const DEFAULT_MEMPOOL_DEPTH_LIMIT = 0;
+const DEFAULT_HODLMM_SPREAD = 5;
+const MAX_HODLMM_FALLBACK_POOLS = 3;
 const CONFIRM_TOKEN = "MAXIMIZE";
-const STATE_FILE = join(homedir(), ".sbtc-yield-maximizer-state.json");
+const STATE_DIR = join(homedir(), ".aibtc");
+const HODLMM_EXTERNAL_COOLDOWN_HOURS = 4;
+const EXECUTION_LOCK_MAX_AGE_MS = 15 * 60_000;
+const HODLMM_MOVE_STATE_CANDIDATES = [
+  join(STATE_DIR, "hodlmm-move-liquidity-state.json"),
+  join(homedir(), ".hodlmm-move-liquidity-state.json"),
+];
 
 type SkillStatus = "success" | "error" | "blocked";
 type RouteName = "hold" | "lend-to-zest" | "deploy-to-hodlmm";
@@ -100,7 +112,23 @@ interface BinsResponse {
   bins?: BinRecord[];
 }
 
-interface ZestSignal {
+interface UserPositionBin {
+  bin_id: number;
+  userLiquidity?: string | number;
+  user_liquidity?: string;
+  liquidity?: string;
+}
+
+interface UserPositionBinsResponse {
+  bins?: UserPositionBin[];
+}
+
+interface FreshRead {
+  fetchedAt: string;
+  ageSeconds: number;
+}
+
+interface ZestSignal extends FreshRead {
   rawInterestRate: bigint;
   utilization: bigint;
   totalAssets: bigint;
@@ -109,7 +137,14 @@ interface ZestSignal {
   inferredApyPct: number;
 }
 
-interface HodlmmCandidate {
+interface HodlmmMoveHealth {
+  hasPosition: boolean;
+  inRange: boolean;
+  drift: number;
+  userBins: number[];
+}
+
+interface HodlmmCandidate extends FreshRead {
   poolId: string;
   pair: string;
   apr24h: number;
@@ -121,6 +156,7 @@ interface HodlmmCandidate {
   divergencePct: number;
   safe: boolean;
   reasons: string[];
+  moveHealth: HodlmmMoveHealth;
 }
 
 interface RouteDecision {
@@ -130,6 +166,8 @@ interface RouteDecision {
   zest: ZestSignal;
   topHodlmm: HodlmmCandidate | null;
   executable: boolean;
+  winnerApyBps: number;
+  apyDiffBps: number;
 }
 
 interface MaximizerState {
@@ -144,6 +182,15 @@ interface CooldownResult {
   lastDecisionAt: string | null;
 }
 
+interface ExternalCooldownState {
+  [poolId: string]: { last_move_at: string };
+}
+
+interface MempoolResponse {
+  total?: number;
+  results?: unknown[];
+}
+
 interface RunOptions {
   walletId?: string;
   maxDeploySats: bigint;
@@ -152,8 +199,11 @@ interface RunOptions {
   minHodlmmVolumeUsd: number;
   minHodlmmTvlUsd: number;
   maxPriceDivergencePct: number;
-  routeEdgeBps: number;
+  minApyDiffBps: number;
+  maxDataAgeSeconds: number;
   cooldownHours: number;
+  mempoolDepthLimit: number;
+  hodlmmSpread: number;
   confirm?: string;
 }
 
@@ -162,9 +212,27 @@ interface Context {
   stxUstx: bigint;
   sbtcSats: bigint;
   cooldown: CooldownResult;
+  mempoolDepth: number;
   decision: RouteDecision;
   blockers: string[];
   zestPosition: Record<string, unknown> | null;
+  hodlmmCandidates: HodlmmCandidate[];
+  stateFile: string;
+  hodlmmStateFile: string | null;
+}
+
+interface ExternalCommandResult {
+  status?: string;
+  action?: string;
+  error?: string | null;
+  data?: Record<string, unknown>;
+}
+
+interface HodlmmScanPosition {
+  pool_id?: string;
+  poolId?: string;
+  in_range?: boolean;
+  inRange?: boolean;
 }
 
 const REQUIRED_PACKS = [
@@ -172,6 +240,14 @@ const REQUIRED_PACKS = [
   "@stacks/transactions",
   "commander",
 ] as const;
+
+function getStateFile(walletId: string): string {
+  return join(STATE_DIR, `sbtc-yield-maximizer-${walletId}.json`);
+}
+
+function getLockFile(walletId: string): string {
+  return join(STATE_DIR, `sbtc-yield-maximizer-${walletId}.lock`);
+}
 
 function serializeZestSignal(signal: ZestSignal): Record<string, unknown> {
   return {
@@ -181,6 +257,8 @@ function serializeZestSignal(signal: ZestSignal): Record<string, unknown> {
     totalSupply: signal.totalSupply.toString(),
     inferredApyBps: signal.inferredApyBps,
     inferredApyPct: signal.inferredApyPct,
+    fetchedAt: signal.fetchedAt,
+    ageSeconds: signal.ageSeconds,
   };
 }
 
@@ -234,7 +312,7 @@ async function fetchJson<T>(url: string): Promise<T> {
       signal: controller.signal,
       headers: {
         Accept: "application/json",
-        "User-Agent": "bff-skills/sbtc-yield-maximizer",
+        "User-Agent": "aibtc-skills/sbtc-yield-maximizer",
       },
     });
     if (!response.ok) throw new Error(`HTTP ${response.status} from ${url}`);
@@ -282,9 +360,9 @@ async function getSbtcBalance(address: string): Promise<bigint> {
   return toBigInt(key ? data.fungible_tokens?.[key]?.balance : "0");
 }
 
-async function readState(): Promise<MaximizerState> {
+async function readState(walletId: string): Promise<MaximizerState> {
   try {
-    const file = Bun.file(STATE_FILE);
+    const file = Bun.file(getStateFile(walletId));
     if (!(await file.exists())) return {};
     return JSON.parse(await file.text()) as MaximizerState;
   } catch {
@@ -292,12 +370,12 @@ async function readState(): Promise<MaximizerState> {
   }
 }
 
-async function writeState(state: MaximizerState): Promise<void> {
-  await Bun.write(STATE_FILE, JSON.stringify(state, null, 2));
+async function writeState(walletId: string, state: MaximizerState): Promise<void> {
+  await Bun.write(getStateFile(walletId), JSON.stringify(state, null, 2));
 }
 
-async function checkCooldown(cooldownHours: number): Promise<CooldownResult> {
-  const state = await readState();
+async function checkCooldown(walletId: string, cooldownHours: number): Promise<CooldownResult> {
+  const state = await readState(walletId);
   if (!state.lastDecisionAt) return { ok: true, remainingHours: 0, lastDecisionAt: null };
   const elapsed = (Date.now() - new Date(state.lastDecisionAt).getTime()) / 3_600_000;
   const remaining = Math.max(0, cooldownHours - elapsed);
@@ -308,7 +386,13 @@ async function checkCooldown(cooldownHours: number): Promise<CooldownResult> {
   };
 }
 
+async function getMempoolDepth(address: string): Promise<number> {
+  const data = await fetchJson<MempoolResponse>(`${HIRO_API}/extended/v1/address/${address}/mempool?limit=1`);
+  return Number(data.total || data.results?.length || 0);
+}
+
 async function getZestSignal(senderAddress: string): Promise<ZestSignal> {
+  const fetchedAt = new Date().toISOString();
   const hiro = getHiroApi(NETWORK);
   const readUint = async (fn: string): Promise<bigint> => {
     const result = await hiro.callReadOnlyFunction(ZEST_SBTC_VAULT, fn, [], senderAddress);
@@ -323,9 +407,6 @@ async function getZestSignal(senderAddress: string): Promise<ZestSignal> {
     readUint("get-total-assets"),
     readUint("get-total-supply"),
   ]);
-  // Verified against the live v0-vault-sbtc source:
-  // the contract defines `BPS u10000` and applies interest math in basis points,
-  // so `get-interest-rate` already returns a bps-style integer.
   const inferredApyBps = Number(rawInterestRate);
   return {
     rawInterestRate,
@@ -334,6 +415,8 @@ async function getZestSignal(senderAddress: string): Promise<ZestSignal> {
     totalSupply,
     inferredApyBps,
     inferredApyPct: inferredApyBps / 100,
+    fetchedAt,
+    ageSeconds: Math.max(0, Math.round((Date.now() - new Date(fetchedAt).getTime()) / 1000)),
   };
 }
 
@@ -342,56 +425,122 @@ async function getZestPosition(address: string): Promise<Record<string, unknown>
   return (await service.getUserPosition("sBTC", address)) as unknown as Record<string, unknown> | null;
 }
 
-async function fetchHodlmmCandidates(options: RunOptions): Promise<HodlmmCandidate[]> {
+async function fetchUserPositionBins(address: string, poolId: string): Promise<number[]> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    const response = await fetch(`${BITFLOW_APP_USER_POSITIONS_API}/${address}/positions/${poolId}/bins`, {
+      signal: controller.signal,
+      headers: {
+        Accept: "application/json",
+        "User-Agent": "aibtc-skills/sbtc-yield-maximizer",
+      },
+    });
+    if (response.status === 404) return [];
+    if (!response.ok) throw new Error(`HTTP ${response.status} from ${BITFLOW_APP_USER_POSITIONS_API}/${address}/positions/${poolId}/bins`);
+    const data = (await response.json()) as UserPositionBinsResponse;
+    return (data.bins || [])
+      .filter((bin) => toBigInt(bin.userLiquidity ?? bin.user_liquidity ?? bin.liquidity ?? "0") > 0n)
+      .map((bin) => Number(bin.bin_id))
+      .sort((a, b) => a - b);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function assessMoveHealth(activeBin: number, userBins: number[]): HodlmmMoveHealth {
+  if (userBins.length === 0) {
+    return {
+      hasPosition: false,
+      inRange: false,
+      drift: 0,
+      userBins: [],
+    };
+  }
+  const inRange = activeBin >= userBins[0] && activeBin <= userBins[userBins.length - 1];
+  const center = Math.round((userBins[0] + userBins[userBins.length - 1]) / 2);
+  return {
+    hasPosition: true,
+    inRange,
+    drift: Math.abs(activeBin - center),
+    userBins,
+  };
+}
+
+async function fetchHodlmmCandidates(options: RunOptions, walletAddress: string): Promise<HodlmmCandidate[]> {
   const [quotePoolsData, appPoolsData] = await Promise.all([
     fetchJson<{ pools?: QuotePool[] }>(BITFLOW_QUOTES_API),
     fetchJson<AppPoolsResponse>(BITFLOW_APP_API),
   ]);
-  const quotePools = (quotePoolsData.pools || []).filter(
-    (pool) => pool.token_x === SBTC_CONTRACT || pool.token_y === SBTC_CONTRACT
+  const quotePools = (quotePoolsData.pools || [])
+    .filter((pool) => pool.token_x === SBTC_CONTRACT || pool.token_y === SBTC_CONTRACT);
+  const appPools = (appPoolsData.data || []).filter(
+    (pool) => pool.tokens.tokenX.contract === SBTC_CONTRACT || pool.tokens.tokenY.contract === SBTC_CONTRACT
   );
-  const appMap = new Map((appPoolsData.data || []).map((pool) => [pool.poolId, pool]));
+  const appMap = new Map(appPools.map((pool) => [pool.poolId, pool]));
+  const matchedPools = quotePools
+    .map((pool) => ({ quote: pool, app: appMap.get(pool.pool_id) || null }))
+    .filter((entry): entry is { quote: QuotePool; app: AppPool } => Boolean(entry.app));
+  const candidatePools = matchedPools.filter(
+    ({ app }) => app.volumeUsd1d >= options.minHodlmmVolumeUsd && app.tvlUsd >= options.minHodlmmTvlUsd
+  );
+  const poolsToEvaluate = candidatePools.length > 0
+    ? candidatePools
+    : matchedPools
+        .sort((a, b) => (b.app.tvlUsd + b.app.volumeUsd1d) - (a.app.tvlUsd + a.app.volumeUsd1d))
+        .slice(0, MAX_HODLMM_FALLBACK_POOLS);
 
   const candidates = await Promise.all(
-    quotePools.map(async (pool): Promise<HodlmmCandidate | null> => {
-      const appPool = appMap.get(pool.pool_id);
-      if (!appPool) return null;
-      const bins = (await fetchJson<BinsResponse>(`${BITFLOW_BINS_API}/${pool.pool_id}`)).bins || [];
-      const activeBin = bins.find((bin) => bin.bin_id === pool.active_bin);
-      const tokenXIsSbtc = appPool.tokens.tokenX.contract === SBTC_CONTRACT;
-      const sbtcPriceUsd = tokenXIsSbtc ? appPool.tokens.tokenX.priceUsd : appPool.tokens.tokenY.priceUsd;
-      const pairedPriceUsd = tokenXIsSbtc ? appPool.tokens.tokenY.priceUsd : appPool.tokens.tokenX.priceUsd;
+    poolsToEvaluate.map(async ({ quote, app }): Promise<HodlmmCandidate | null> => {
+      const fetchedAt = new Date().toISOString();
+      const [binsData, userBins] = await Promise.all([
+        fetchJson<BinsResponse>(`${BITFLOW_BINS_API}/${quote.pool_id}`),
+        fetchUserPositionBins(walletAddress, quote.pool_id),
+      ]);
+      const bins = binsData.bins || [];
+      const activeBin = bins.find((bin) => bin.bin_id === quote.active_bin);
+      const tokenXIsSbtc = app.tokens.tokenX.contract === SBTC_CONTRACT;
+      const sbtcPriceUsd = tokenXIsSbtc ? app.tokens.tokenX.priceUsd : app.tokens.tokenY.priceUsd;
+      const pairedPriceUsd = tokenXIsSbtc ? app.tokens.tokenY.priceUsd : app.tokens.tokenX.priceUsd;
       let divergencePct = 0;
       if (activeBin && sbtcPriceUsd > 0) {
         const normalized = (Number(activeBin.price) / PRICE_SCALE) *
-          Math.pow(10, appPool.tokens.tokenX.decimals - appPool.tokens.tokenY.decimals);
+          Math.pow(10, app.tokens.tokenX.decimals - app.tokens.tokenY.decimals);
         const activeSbtcPriceUsd = tokenXIsSbtc
           ? normalized * pairedPriceUsd
           : normalized > 0
-          ? appPool.tokens.tokenX.priceUsd / normalized
+          ? app.tokens.tokenX.priceUsd / normalized
           : 0;
         if (activeSbtcPriceUsd > 0) {
-          divergencePct = Math.abs(activeSbtcPriceUsd - sbtcPriceUsd) / sbtcPriceUsd * 100;
+          divergencePct = (Math.abs(activeSbtcPriceUsd - sbtcPriceUsd) / sbtcPriceUsd) * 100;
         }
       }
-      const feeRunRatePct = appPool.tvlUsd > 0 ? (appPool.feesUsd1d / appPool.tvlUsd) * 365 * 100 : 0;
-      const effectiveYieldPct = Math.max(appPool.apr24h, feeRunRatePct);
+
+      const feeRunRatePct = app.tvlUsd > 0 ? (app.feesUsd1d / app.tvlUsd) * 365 * 100 : 0;
+      const effectiveYieldPct = Math.max(app.apr24h, feeRunRatePct);
       const reasons: string[] = [];
-      if (appPool.volumeUsd1d < options.minHodlmmVolumeUsd) reasons.push(`24h volume ${appPool.volumeUsd1d.toFixed(2)} < ${options.minHodlmmVolumeUsd}`);
-      if (appPool.tvlUsd < options.minHodlmmTvlUsd) reasons.push(`TVL ${appPool.tvlUsd.toFixed(2)} < ${options.minHodlmmTvlUsd}`);
+      if (app.volumeUsd1d < options.minHodlmmVolumeUsd) reasons.push(`24h volume ${app.volumeUsd1d.toFixed(2)} < ${options.minHodlmmVolumeUsd}`);
+      if (app.tvlUsd < options.minHodlmmTvlUsd) reasons.push(`TVL ${app.tvlUsd.toFixed(2)} < ${options.minHodlmmTvlUsd}`);
       if (divergencePct > options.maxPriceDivergencePct) reasons.push(`price divergence ${divergencePct.toFixed(2)}% > ${options.maxPriceDivergencePct}%`);
+
+      const moveHealth = assessMoveHealth(quote.active_bin, userBins);
+      if (!moveHealth.hasPosition) reasons.push("no active LP position is available for move-liquidity");
+
       return {
-        poolId: pool.pool_id,
-        pair: tokenXIsSbtc ? `sBTC-${appPool.tokens.tokenY.symbol}` : `${appPool.tokens.tokenX.symbol}-sBTC`,
-        apr24h: appPool.apr24h,
+        poolId: quote.pool_id,
+        pair: tokenXIsSbtc ? `sBTC-${app.tokens.tokenY.symbol}` : `${app.tokens.tokenX.symbol}-sBTC`,
+        apr24h: app.apr24h,
         feeRunRatePct: Number(feeRunRatePct.toFixed(4)),
         effectiveYieldPct: Number(effectiveYieldPct.toFixed(4)),
         effectiveYieldBps: Math.round(effectiveYieldPct * 100),
-        volumeUsd1d: appPool.volumeUsd1d,
-        tvlUsd: appPool.tvlUsd,
+        volumeUsd1d: app.volumeUsd1d,
+        tvlUsd: app.tvlUsd,
         divergencePct: Number(divergencePct.toFixed(4)),
         safe: reasons.length === 0,
         reasons,
+        moveHealth,
+        fetchedAt,
+        ageSeconds: Math.max(0, Math.round((Date.now() - new Date(fetchedAt).getTime()) / 1000)),
       };
     })
   );
@@ -404,6 +553,7 @@ async function fetchHodlmmCandidates(options: RunOptions): Promise<HodlmmCandida
 function decideRoute(
   sbtcSats: bigint,
   stxUstx: bigint,
+  mempoolDepth: number,
   zest: ZestSignal,
   hodlmmCandidates: HodlmmCandidate[],
   options: RunOptions,
@@ -415,63 +565,287 @@ function decideRoute(
   const rationale: string[] = [];
 
   if (!cooldown.ok) {
-    rationale.push(`Cooldown active for another ${cooldown.remainingHours} hours`);
-    return { route: "hold", deploySats, rationale, zest, topHodlmm, executable: false };
+    rationale.push(`Router cooldown active for another ${cooldown.remainingHours} hours`);
+    return { route: "hold", deploySats, rationale, zest, topHodlmm, executable: false, winnerApyBps: 0, apyDiffBps: 0 };
+  }
+  if (mempoolDepth > options.mempoolDepthLimit) {
+    rationale.push(`Pending mempool depth ${mempoolDepth} exceeds allowed limit ${options.mempoolDepthLimit}`);
+    return { route: "hold", deploySats, rationale, zest, topHodlmm, executable: false, winnerApyBps: 0, apyDiffBps: 0 };
   }
   if (stxUstx < options.minGasReserveUstx) {
     rationale.push(`STX reserve ${stxUstx.toString()} uSTX is below required ${options.minGasReserveUstx.toString()} uSTX`);
-    return { route: "hold", deploySats, rationale, zest, topHodlmm, executable: false };
+    return { route: "hold", deploySats, rationale, zest, topHodlmm, executable: false, winnerApyBps: 0, apyDiffBps: 0 };
   }
   if (deploySats <= 0n) {
     rationale.push("No idle sBTC remains above reserve");
-    return { route: "hold", deploySats, rationale, zest, topHodlmm, executable: false };
+    return { route: "hold", deploySats, rationale, zest, topHodlmm, executable: false, winnerApyBps: 0, apyDiffBps: 0 };
+  }
+  if (zest.ageSeconds > options.maxDataAgeSeconds) {
+    rationale.push(`Zest rate age ${zest.ageSeconds}s exceeds max data age ${options.maxDataAgeSeconds}s`);
+    return { route: "hold", deploySats, rationale, zest, topHodlmm, executable: false, winnerApyBps: 0, apyDiffBps: 0 };
+  }
+  if (topHodlmm && topHodlmm.ageSeconds > options.maxDataAgeSeconds) {
+    rationale.push(`HODLMM data age ${topHodlmm.ageSeconds}s exceeds max data age ${options.maxDataAgeSeconds}s`);
+    return { route: "hold", deploySats, rationale, zest, topHodlmm, executable: false, winnerApyBps: 0, apyDiffBps: 0 };
   }
 
   const zestBps = zest.inferredApyBps;
   const hodlmmBps = topHodlmm?.effectiveYieldBps || 0;
-  if (topHodlmm && hodlmmBps > zestBps + options.routeEdgeBps) {
-    rationale.push(`HODLMM leads Zest by ${hodlmmBps - zestBps} bps`);
-    rationale.push(`Top HODLMM pool ${topHodlmm.poolId} passed stale-price and liquidity gates`);
-    return { route: "deploy-to-hodlmm", deploySats, rationale, zest, topHodlmm, executable: false };
+  const apyDiffBps = Math.abs(hodlmmBps - zestBps);
+
+  if (topHodlmm && hodlmmBps > zestBps) {
+    if (apyDiffBps < options.minApyDiffBps) {
+      rationale.push(`HODLMM only leads Zest by ${apyDiffBps} bps, below the ${options.minApyDiffBps} bps minimum edge`);
+      return { route: "hold", deploySats, rationale, zest, topHodlmm, executable: false, winnerApyBps: hodlmmBps, apyDiffBps };
+    }
+    if (topHodlmm.moveHealth.inRange) {
+      rationale.push(`HODLMM pool ${topHodlmm.poolId} leads by ${apyDiffBps} bps and the current position is already in range`);
+      return { route: "hold", deploySats, rationale, zest, topHodlmm, executable: false, winnerApyBps: hodlmmBps, apyDiffBps };
+    }
+    rationale.push(`HODLMM leads Zest by ${apyDiffBps} bps`);
+    rationale.push(`Pool ${topHodlmm.poolId} has an out-of-range LP position with drift ${topHodlmm.moveHealth.drift}`);
+    return { route: "deploy-to-hodlmm", deploySats, rationale, zest, topHodlmm, executable: true, winnerApyBps: hodlmmBps, apyDiffBps };
   }
 
   if (zestBps > 0) {
-    rationale.push(`Zest inferred yield ${zest.inferredApyPct.toFixed(2)}% is the best safe executable route`);
-    if (topHodlmm && !topHodlmm.safe) {
-      rationale.push(`Top HODLMM pool failed safety gates: ${topHodlmm.reasons.join("; ")}`);
+    if (topHodlmm && zestBps - hodlmmBps < options.minApyDiffBps) {
+      rationale.push(`Zest only leads HODLMM by ${zestBps - hodlmmBps} bps, below the ${options.minApyDiffBps} bps minimum edge`);
+      return { route: "hold", deploySats, rationale, zest, topHodlmm, executable: false, winnerApyBps: zestBps, apyDiffBps: zestBps - hodlmmBps };
     }
-    return { route: "lend-to-zest", deploySats, rationale, zest, topHodlmm, executable: true };
+    rationale.push(`Zest inferred yield ${zest.inferredApyPct.toFixed(2)}% is the best safe executable route`);
+    if (topHodlmm && !topHodlmm.safe) rationale.push(`Top HODLMM pool failed safety gates: ${topHodlmm.reasons.join("; ")}`);
+    return { route: "lend-to-zest", deploySats, rationale, zest, topHodlmm, executable: true, winnerApyBps: zestBps, apyDiffBps: Math.max(0, zestBps - hodlmmBps) };
   }
 
   rationale.push("No positive executable yield route is currently available");
-  return { route: "hold", deploySats, rationale, zest, topHodlmm, executable: false };
+  return { route: "hold", deploySats, rationale, zest, topHodlmm, executable: false, winnerApyBps: 0, apyDiffBps: 0 };
+}
+
+async function readExternalCooldown(poolId: string): Promise<{ active: boolean; remainingHours: number; stateFile: string | null }> {
+  for (const stateFile of HODLMM_MOVE_STATE_CANDIDATES) {
+    try {
+      const file = Bun.file(stateFile);
+      if (!(await file.exists())) continue;
+      const state = JSON.parse(await file.text()) as ExternalCooldownState;
+      const entry = state[poolId];
+      if (!entry) return { active: false, remainingHours: 0, stateFile };
+      const elapsedHours = (Date.now() - new Date(entry.last_move_at).getTime()) / 3_600_000;
+      const remainingHours = Math.max(0, HODLMM_EXTERNAL_COOLDOWN_HOURS - elapsedHours);
+      return { active: remainingHours > 0, remainingHours: Number(remainingHours.toFixed(2)), stateFile };
+    } catch {
+      continue;
+    }
+  }
+  return { active: false, remainingHours: 0, stateFile: null };
+}
+
+function acquireExecutionLock(walletId: string): () => void {
+  const lockFile = getLockFile(walletId);
+  const existing = statSync(lockFile, { throwIfNoEntry: false });
+  if (existing && Date.now() - existing.mtimeMs > EXECUTION_LOCK_MAX_AGE_MS) {
+    try {
+      unlinkSync(lockFile);
+    } catch {}
+  }
+  const fd = openSync(lockFile, "wx");
+  return () => {
+    try {
+      closeSync(fd);
+    } catch {}
+    try {
+      unlinkSync(lockFile);
+    } catch {}
+  };
+}
+
+function resolveHodlmmCommand(): string[] {
+  const env = process.env.HODLMM_MOVE_LIQUIDITY_CMD?.trim();
+  if (env) return env.split(/\s+/);
+  const direct = Bun.which("hodlmm-move-liquidity");
+  if (direct) return [direct];
+  throw new Error("HODLMM_MOVE_LIQUIDITY_CMD is not set and hodlmm-move-liquidity is not installed in PATH");
+}
+
+function resolveHodlmmScriptTarget(command: string[]): string | null {
+  let candidate: string | null = null;
+  if (command[0] === "bun" && command[1] === "run" && command[2]) {
+    candidate = command[2];
+  } else if (command.length === 1) {
+    candidate = command[0];
+  }
+  if (!candidate) return null;
+  const resolved = isAbsolute(candidate) ? candidate : resolvePath(process.cwd(), candidate);
+  const extension = extname(resolved).toLowerCase();
+  return [".ts", ".tsx", ".js", ".mjs", ".cjs"].includes(extension) ? resolved : null;
+}
+
+async function runExternalJsonCommand(command: string[], args: string[], extraEnv: Record<string, string> = {}): Promise<ExternalCommandResult> {
+  const proc = Bun.spawn({
+    cmd: [...command, ...args],
+    stdout: "pipe",
+    stderr: "pipe",
+    env: { ...process.env, ...extraEnv },
+  });
+  const stdout = await new Response(proc.stdout).text();
+  const stderr = await new Response(proc.stderr).text();
+  const exitCode = await proc.exited;
+  if (exitCode !== 0) {
+    throw new Error(stderr.trim() || stdout.trim() || `External command failed with exit code ${exitCode}`);
+  }
+  let parsed: ExternalCommandResult;
+  try {
+    parsed = JSON.parse(stdout.trim()) as ExternalCommandResult;
+  } catch {
+    throw new Error(`Could not parse external JSON output: ${stdout.trim() || stderr.trim()}`);
+  }
+  if (parsed.status === "error") {
+    throw new Error(parsed.error || "External command reported an error");
+  }
+  return parsed;
+}
+
+async function runHodlmmJsonCommand(
+  command: string[],
+  args: string[],
+  extraEnv: Record<string, string> = {},
+  requirePasswordBridge = false
+): Promise<ExternalCommandResult> {
+  const scriptTarget = resolveHodlmmScriptTarget(command);
+  if (!scriptTarget) {
+    if (requirePasswordBridge) {
+      throw new Error("Secure HODLMM execution requires HODLMM_MOVE_LIQUIDITY_CMD to resolve to a Bun-runnable script path");
+    }
+    return runExternalJsonCommand(command, args, extraEnv);
+  }
+
+  const wrapperPath = join(
+    tmpdir(),
+    `sbtc-yield-maximizer-hodlmm-wrapper-${process.pid}-${Date.now()}.mjs`
+  );
+  const wrapperSource = [
+    `process.argv = ["bun", ${JSON.stringify(scriptTarget)}, ...JSON.parse(process.env.HODLMM_WRAPPER_ARGS || "[]"), ...(process.env.AIBTC_WALLET_PASSWORD ? ["--password", process.env.AIBTC_WALLET_PASSWORD] : [])];`,
+    `await import(${JSON.stringify(scriptTarget)});`,
+  ].join("\n");
+
+  await Bun.write(wrapperPath, wrapperSource);
+  try {
+    return await runExternalJsonCommand(["bun", wrapperPath], [], {
+      ...extraEnv,
+      HODLMM_WRAPPER_ARGS: JSON.stringify(args),
+    });
+  } finally {
+    try {
+      unlinkSync(wrapperPath);
+    } catch {}
+  }
+}
+
+async function preflightHodlmmMove(context: Context, options: RunOptions, extraEnv: Record<string, string> = {}): Promise<ExternalCommandResult> {
+  const top = context.decision.topHodlmm;
+  if (!top) throw new Error("No HODLMM pool selected for preflight");
+  const command = resolveHodlmmCommand();
+  const result = await runHodlmmJsonCommand(command, [
+    "scan",
+    "--wallet",
+    context.wallet.address,
+  ], extraEnv);
+  const positions = ((result.data as Record<string, unknown> | undefined)?.positions || []) as HodlmmScanPosition[];
+  const selected = positions.find((position) => (position.pool_id || position.poolId) === top.poolId);
+  if (!selected) {
+    throw new Error(`HODLMM preflight did not find a position for pool ${top.poolId}`);
+  }
+  const inRange = selected.in_range ?? selected.inRange ?? false;
+  if (inRange) {
+    throw new Error(`HODLMM preflight found pool ${top.poolId} already in range`);
+  }
+  return result;
+}
+
+async function executeHodlmmMove(context: Context, options: RunOptions, password: string): Promise<{ txid: string; explorerUrl: string; command: string[]; preflight: ExternalCommandResult }> {
+  const top = context.decision.topHodlmm;
+  if (!top) throw new Error("No HODLMM pool selected for execution");
+  const externalCooldown = await readExternalCooldown(top.poolId);
+  if (externalCooldown.active) {
+    throw new Error(`hodlmm-move-liquidity cooldown is active for another ${externalCooldown.remainingHours} hours`);
+  }
+
+  const walletManager = getWalletManager();
+  const account = await walletManager.unlock(context.wallet.id, password);
+  const privateKey = String(
+    (account as Record<string, unknown>).stxPrivateKey ||
+    (account as Record<string, unknown>).privateKey ||
+    ""
+  );
+  if (!privateKey) {
+    await walletManager.lock().catch(() => undefined);
+    throw new Error("Selected wallet did not expose stxPrivateKey for delegated HODLMM execution");
+  }
+
+  const command = resolveHodlmmCommand();
+  const extraEnv = {
+    STACKS_PRIVATE_KEY: privateKey,
+    STACKS_ADDRESS: context.wallet.address,
+  };
+
+  try {
+    const preflight = await preflightHodlmmMove(context, options, extraEnv);
+    const result = await runHodlmmJsonCommand(command, [
+      "run",
+      "--wallet",
+      context.wallet.address,
+      "--pool",
+      top.poolId,
+      "--spread",
+      String(options.hodlmmSpread),
+      "--confirm",
+    ], extraEnv, true);
+
+    const transaction = ((result.data as Record<string, unknown> | undefined)?.transaction || null) as Record<string, unknown> | null;
+    const txid = String(transaction?.txid || "");
+    const explorerUrl = String(transaction?.explorer || "");
+    if (!txid) throw new Error("HODLMM execution succeeded but returned no txid");
+    return { txid, explorerUrl, command, preflight };
+  } finally {
+    await walletManager.lock().catch(() => undefined);
+  }
 }
 
 async function collectContext(options: RunOptions): Promise<Context> {
   const wallet = await resolveWallet(options.walletId);
-  const [stxUstx, sbtcSats, cooldown, zest, hodlmmCandidates, zestPosition] = await Promise.all([
+  const stateFile = getStateFile(wallet.id);
+  const hodlmmStateFile = (
+    await Promise.all(
+      HODLMM_MOVE_STATE_CANDIDATES.map(async (file) => ((await Bun.file(file).exists()) ? file : null))
+    )
+  ).find((file): file is string => Boolean(file)) || null;
+  const [stxUstx, sbtcSats, cooldown, mempoolDepth, zest, hodlmmCandidates, zestPosition] = await Promise.all([
     getStxBalance(wallet.address),
     getSbtcBalance(wallet.address),
-    checkCooldown(options.cooldownHours),
+    checkCooldown(wallet.id, options.cooldownHours),
+    getMempoolDepth(wallet.address),
     getZestSignal(wallet.address),
-    fetchHodlmmCandidates(options),
+    fetchHodlmmCandidates(options, wallet.address),
     getZestPosition(wallet.address),
   ]);
 
-  const decision = decideRoute(sbtcSats, stxUstx, zest, hodlmmCandidates, options, cooldown);
+  const decision = decideRoute(sbtcSats, stxUstx, mempoolDepth, zest, hodlmmCandidates, options, cooldown);
   const blockers: string[] = [];
   if (wallet.network !== NETWORK) blockers.push(`Wallet network ${wallet.network || "unknown"} is not ${NETWORK}`);
   if (decision.route === "hold") blockers.push(...decision.rationale);
-  if (decision.route === "deploy-to-hodlmm") blockers.push("Direct HODLMM deposit is not enabled in this skill version");
+  if (decision.route === "deploy-to-hodlmm" && !decision.executable) blockers.push(...decision.rationale);
 
   return {
     wallet,
     stxUstx,
     sbtcSats,
     cooldown,
+    mempoolDepth,
     decision,
     blockers,
     zestPosition,
+    hodlmmCandidates,
+    stateFile,
+    hodlmmStateFile,
   };
 }
 
@@ -481,10 +855,28 @@ async function runDoctor(options: RunOptions): Promise<void> {
     const context = await collectContext(options);
     checks.wallet = { ok: true, detail: `${context.wallet.address} (${context.wallet.btcAddress || "no btc"})` };
     checks.balances = { ok: true, detail: `stx=${context.stxUstx.toString()} uSTX, sbtc=${context.sbtcSats.toString()} sats` };
-    checks.zest = { ok: context.decision.zest.inferredApyBps > 0, detail: `interest-rate=${context.decision.zest.rawInterestRate.toString()} inferredApy=${context.decision.zest.inferredApyPct.toFixed(2)}%` };
-    checks.hodlmm = { ok: true, detail: context.decision.topHodlmm ? `${context.decision.topHodlmm.poolId} safe=${context.decision.topHodlmm.safe} yield=${context.decision.topHodlmm.effectiveYieldPct.toFixed(2)}%` : "No sBTC HODLMM pool found" };
-    checks.cooldown = { ok: context.cooldown.ok, detail: context.cooldown.ok ? "No active route cooldown" : `Cooldown active for ${context.cooldown.remainingHours} more hours` };
+    checks.zest = {
+      ok: context.decision.zest.inferredApyBps > 0 && context.decision.zest.ageSeconds <= options.maxDataAgeSeconds,
+      detail: `interest-rate=${context.decision.zest.rawInterestRate.toString()} inferredApy=${context.decision.zest.inferredApyPct.toFixed(2)}% age=${context.decision.zest.ageSeconds}s`,
+    };
+    checks.hodlmm = {
+      ok: Boolean(context.decision.topHodlmm && context.decision.topHodlmm.ageSeconds <= options.maxDataAgeSeconds),
+      detail: context.decision.topHodlmm
+        ? `${context.decision.topHodlmm.poolId} safe=${context.decision.topHodlmm.safe} yield=${context.decision.topHodlmm.effectiveYieldPct.toFixed(2)}% age=${context.decision.topHodlmm.ageSeconds}s`
+        : context.hodlmmCandidates[0]
+        ? `${context.hodlmmCandidates[0].poolId} unavailable: ${context.hodlmmCandidates[0].reasons.join("; ")}`
+        : "No sBTC HODLMM pool found",
+    };
+    checks.cooldown = { ok: context.cooldown.ok, detail: context.cooldown.ok ? "No active router cooldown" : `Cooldown active for ${context.cooldown.remainingHours} more hours` };
+    checks.mempool = { ok: context.mempoolDepth <= options.mempoolDepthLimit, detail: `depth=${context.mempoolDepth} limit=${options.mempoolDepthLimit}` };
+    try {
+      const command = resolveHodlmmCommand();
+      checks.hodlmm_executor = { ok: true, detail: command.join(" ") };
+    } catch (error) {
+      checks.hodlmm_executor = { ok: false, detail: error instanceof Error ? error.message : String(error) };
+    }
     checks.password_env = { ok: Boolean(process.env.AIBTC_WALLET_PASSWORD), detail: process.env.AIBTC_WALLET_PASSWORD ? "AIBTC_WALLET_PASSWORD is set" : "AIBTC_WALLET_PASSWORD not set (required only for run)" };
+    checks.state_file = { ok: true, detail: context.stateFile };
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     checks.context = { ok: false, detail: message };
@@ -511,7 +903,7 @@ async function runInstallPacks(): Promise<void> {
     action: "Required runtime packages listed for sbtc-yield-maximizer.",
     data: {
       packages: REQUIRED_PACKS,
-      note: "This skill expects these packages to be available in the execution environment.",
+      note: "This skill expects these packages plus installed dependent skills declared in metadata.requires.",
     },
     error: null,
   });
@@ -522,7 +914,7 @@ async function runStatus(options: RunOptions): Promise<void> {
   const actionMap: Record<RouteName, string> = {
     hold: "Hold idle sBTC until a safer executable route is available.",
     "lend-to-zest": `Route ${context.decision.deploySats.toString()} sats to Zest because it is the highest safe executable yield path.`,
-    "deploy-to-hodlmm": "HODLMM is currently the highest-yield route, but this standalone version does not execute direct HODLMM deposits.",
+    "deploy-to-hodlmm": `Rebalance HODLMM liquidity in ${context.decision.topHodlmm?.poolId || "the winning pool"} because it is the highest safe executable route.`,
   };
 
   printResult({
@@ -535,16 +927,22 @@ async function runStatus(options: RunOptions): Promise<void> {
         sbtcSats: context.sbtcSats.toString(),
       },
       cooldown: context.cooldown,
+      mempoolDepth: context.mempoolDepth,
       routeDecision: {
         route: context.decision.route,
         executable: context.decision.executable,
         deploySats: context.decision.deploySats.toString(),
         rationale: context.decision.rationale,
+        winnerApyBps: context.decision.winnerApyBps,
+        apyDiffBps: context.decision.apyDiffBps,
       },
       zest: serializeZestSignal(context.decision.zest),
       zestPosition: context.zestPosition,
       topHodlmm: context.decision.topHodlmm,
+      hodlmmCandidates: context.hodlmmCandidates,
       blockers: context.blockers,
+      stateFile: context.stateFile,
+      hodlmmStateFile: context.hodlmmStateFile,
     },
     error: null,
   });
@@ -581,10 +979,10 @@ async function runMaximize(options: RunOptions): Promise<void> {
   }
 
   const context = await collectContext(options);
-  if (context.decision.route !== "lend-to-zest" || !context.decision.executable) {
+  if (!context.decision.executable || context.decision.route === "hold") {
     printResult({
       status: "blocked",
-      action: "Yield maximizer did not select an executable Zest route.",
+      action: "Yield maximizer did not select an executable route.",
       data: {
         route: context.decision.route,
         rationale: context.decision.rationale,
@@ -598,38 +996,77 @@ async function runMaximize(options: RunOptions): Promise<void> {
     return;
   }
 
-  const walletManager = getWalletManager();
-  const zest = getZestProtocolService(NETWORK);
-
+  let releaseLock: (() => void) | null = null;
   try {
-    const account = await walletManager.unlock(context.wallet.id, password);
-    const result = await zest.supply(account, "sBTC", context.decision.deploySats);
-    await writeState({
-      lastDecisionAt: new Date().toISOString(),
-      lastRoute: context.decision.route,
-      lastTxid: result.txid,
-    });
-    printResult({
-      status: "success",
-      action: "Supplied sBTC to Zest because it was the highest safe executable yield route",
-      data: {
-        operation: "maximize-yield",
-        wallet: {
-          id: context.wallet.id,
-          address: context.wallet.address,
-          name: context.wallet.name || "aibtc-wallet",
+    releaseLock = acquireExecutionLock(context.wallet.id);
+
+    if (context.decision.route === "deploy-to-hodlmm") {
+      const execution = await executeHodlmmMove(context, options, password);
+      await writeState(context.wallet.id, {
+        lastDecisionAt: new Date().toISOString(),
+        lastRoute: context.decision.route,
+        lastTxid: execution.txid,
+      });
+      printResult({
+        status: "success",
+        action: "Moved HODLMM liquidity because it was the highest safe executable yield route",
+        data: {
+          operation: "maximize-yield",
+          wallet: {
+            id: context.wallet.id,
+            address: context.wallet.address,
+            name: context.wallet.name || "aibtc-wallet",
+          },
+          route: context.decision.route,
+          deploySats: context.decision.deploySats.toString(),
+          rationale: context.decision.rationale,
+          zest: serializeZestSignal(context.decision.zest),
+          topHodlmm: context.decision.topHodlmm,
+          txid: execution.txid,
+          explorerUrl: execution.explorerUrl || getExplorerTxUrl(execution.txid, NETWORK),
+          stateFile: context.stateFile,
+          hodlmmCommand: execution.command.join(" "),
+          hodlmmPreflight: execution.preflight,
         },
-        route: context.decision.route,
-        deploySats: context.decision.deploySats.toString(),
-        rationale: context.decision.rationale,
-        zest: serializeZestSignal(context.decision.zest),
-        topHodlmm: context.decision.topHodlmm,
-        txid: result.txid,
-        explorerUrl: getExplorerTxUrl(result.txid, NETWORK),
-        stateFile: STATE_FILE,
-      },
-      error: null,
-    });
+        error: null,
+      });
+      return;
+    }
+
+    const walletManager = getWalletManager();
+    const zest = getZestProtocolService(NETWORK);
+    try {
+      const account = await walletManager.unlock(context.wallet.id, password);
+      const result = await zest.supply(account, "sBTC", context.decision.deploySats);
+      await writeState(context.wallet.id, {
+        lastDecisionAt: new Date().toISOString(),
+        lastRoute: context.decision.route,
+        lastTxid: result.txid,
+      });
+      printResult({
+        status: "success",
+        action: "Supplied sBTC to Zest because it was the highest safe executable yield route",
+        data: {
+          operation: "maximize-yield",
+          wallet: {
+            id: context.wallet.id,
+            address: context.wallet.address,
+            name: context.wallet.name || "aibtc-wallet",
+          },
+          route: context.decision.route,
+          deploySats: context.decision.deploySats.toString(),
+          rationale: context.decision.rationale,
+          zest: serializeZestSignal(context.decision.zest),
+          topHodlmm: context.decision.topHodlmm,
+          txid: result.txid,
+          explorerUrl: getExplorerTxUrl(result.txid, NETWORK),
+          stateFile: context.stateFile,
+        },
+        error: null,
+      });
+    } finally {
+      await walletManager.lock().catch(() => undefined);
+    }
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     printResult({
@@ -638,15 +1075,16 @@ async function runMaximize(options: RunOptions): Promise<void> {
       data: {
         wallet: { id: context.wallet.id, address: context.wallet.address },
         attemptedDeploySats: context.decision.deploySats.toString(),
+        route: context.decision.route,
       },
       error: {
         code: "MAXIMIZER_FAILED",
         message,
-        next: "Verify password, balances, and route conditions before retrying",
+        next: "Verify password, balances, route conditions, and dependent skill availability before retrying",
       },
     });
   } finally {
-    await walletManager.lock().catch(() => undefined);
+    releaseLock?.();
   }
 }
 
@@ -659,8 +1097,11 @@ function parseOptions(rawOptions: Record<string, string | undefined>): RunOption
     minHodlmmVolumeUsd: parseNumberOption(rawOptions.minHodlmmVolumeUsd || rawOptions["min-hodlmm-volume-usd"], DEFAULT_MIN_HODLMM_VOLUME_USD, "min-hodlmm-volume-usd"),
     minHodlmmTvlUsd: parseNumberOption(rawOptions.minHodlmmTvlUsd || rawOptions["min-hodlmm-tvl-usd"], DEFAULT_MIN_HODLMM_TVL_USD, "min-hodlmm-tvl-usd"),
     maxPriceDivergencePct: parseNumberOption(rawOptions.maxPriceDivergencePct || rawOptions["max-price-divergence-pct"], DEFAULT_MAX_PRICE_DIVERGENCE_PCT, "max-price-divergence-pct"),
-    routeEdgeBps: parseNumberOption(rawOptions.routeEdgeBps || rawOptions["route-edge-bps"], DEFAULT_ROUTE_EDGE_BPS, "route-edge-bps"),
-    cooldownHours: parseNumberOption(rawOptions.cooldownHours || rawOptions["cooldown-hours"], DEFAULT_COOLDOWN_HOURS, "cooldown-hours"),
+    minApyDiffBps: parseNumberOption(rawOptions.minApyDiffBps || rawOptions["min-apy-diff-bps"], DEFAULT_MIN_APY_DIFF_BPS, "min-apy-diff-bps"),
+    maxDataAgeSeconds: parseNumberOption(rawOptions.maxDataAgeSeconds || rawOptions["max-data-age-seconds"], DEFAULT_MAX_DATA_AGE_SECONDS, "max-data-age-seconds"),
+    cooldownHours: parseNumberOption(rawOptions.cooldownHours || rawOptions["cooldown-hours"], DEFAULT_META_COOLDOWN_HOURS, "cooldown-hours"),
+    mempoolDepthLimit: parseNumberOption(rawOptions.mempoolDepthLimit || rawOptions["mempool-depth-limit"], DEFAULT_MEMPOOL_DEPTH_LIMIT, "mempool-depth-limit"),
+    hodlmmSpread: parseNumberOption(rawOptions.hodlmmSpread || rawOptions["hodlmm-spread"], DEFAULT_HODLMM_SPREAD, "hodlmm-spread"),
     confirm: rawOptions.confirm,
   };
 
@@ -671,8 +1112,11 @@ function parseOptions(rawOptions: Record<string, string | undefined>): RunOption
     parsed.minHodlmmVolumeUsd < 0 ||
     parsed.minHodlmmTvlUsd < 0 ||
     parsed.maxPriceDivergencePct < 0 ||
-    parsed.routeEdgeBps < 0 ||
-    parsed.cooldownHours < 0
+    parsed.minApyDiffBps < 0 ||
+    parsed.maxDataAgeSeconds < 0 ||
+    parsed.cooldownHours < 0 ||
+    parsed.mempoolDepthLimit < 0 ||
+    parsed.hodlmmSpread < 0
   ) {
     printFlatError("All numeric options must be non-negative");
   }
@@ -697,8 +1141,11 @@ for (const command of ["doctor", "install-packs", "status", "run"]) {
     .option("--min-hodlmm-volume-usd <usd>", "Minimum HODLMM 24h volume required for a pool to win", String(DEFAULT_MIN_HODLMM_VOLUME_USD))
     .option("--min-hodlmm-tvl-usd <usd>", "Minimum HODLMM TVL required for a pool to win", String(DEFAULT_MIN_HODLMM_TVL_USD))
     .option("--max-price-divergence-pct <pct>", "Maximum HODLMM price divergence allowed before a pool is disqualified", String(DEFAULT_MAX_PRICE_DIVERGENCE_PCT))
-    .option("--route-edge-bps <bps>", "Minimum HODLMM edge over Zest required for HODLMM to win", String(DEFAULT_ROUTE_EDGE_BPS))
-    .option("--cooldown-hours <hours>", "Cooldown window between write executions", String(DEFAULT_COOLDOWN_HOURS))
+    .option("--min-apy-diff-bps <bps>", "Minimum APY edge required before rotating between Zest and HODLMM", String(DEFAULT_MIN_APY_DIFF_BPS))
+    .option("--max-data-age-seconds <seconds>", "Maximum freshness age allowed for APY reads", String(DEFAULT_MAX_DATA_AGE_SECONDS))
+    .option("--cooldown-hours <hours>", "Router-level cooldown window between write executions", String(DEFAULT_META_COOLDOWN_HOURS))
+    .option("--mempool-depth-limit <count>", "Maximum allowed pending tx count before execution is blocked", String(DEFAULT_MEMPOOL_DEPTH_LIMIT))
+    .option("--hodlmm-spread <bins>", "Bin spread passed through to hodlmm-move-liquidity", String(DEFAULT_HODLMM_SPREAD))
     .option("--confirm <token>", "Required only for run: set to MAXIMIZE to allow broadcast")
     .action(async (rawOptions) => {
       if (command === "install-packs") return runInstallPacks();

--- a/sbtc-yield-maximizer/sbtc-yield-maximizer.ts
+++ b/sbtc-yield-maximizer/sbtc-yield-maximizer.ts
@@ -886,7 +886,12 @@ async function runDoctor(options: RunOptions): Promise<void> {
     } catch (error) {
       checks.hodlmm_executor = { ok: false, detail: error instanceof Error ? error.message : String(error) };
     }
-    checks.password_env = { ok: Boolean(process.env.AIBTC_WALLET_PASSWORD), detail: process.env.AIBTC_WALLET_PASSWORD ? "AIBTC_WALLET_PASSWORD is set" : "AIBTC_WALLET_PASSWORD not set (required only for run)" };
+    checks.password_env = {
+      ok: true,
+      detail: process.env.AIBTC_WALLET_PASSWORD
+        ? "AIBTC_WALLET_PASSWORD is set"
+        : "AIBTC_WALLET_PASSWORD not set (required only for run)",
+    };
     checks.state_file = { ok: true, detail: context.stateFile };
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);

--- a/sbtc-yield-maximizer/sbtc-yield-maximizer.ts
+++ b/sbtc-yield-maximizer/sbtc-yield-maximizer.ts
@@ -690,6 +690,10 @@ function resolveHodlmmScriptTarget(command: string[]): string | null {
   return [".ts", ".tsx", ".js", ".mjs", ".cjs"].includes(extension) ? resolved : null;
 }
 
+function getHodlmmSecureExecutionError(): string {
+  return "Secure HODLMM execution requires HODLMM_MOVE_LIQUIDITY_CMD to resolve to a Bun-runnable script path";
+}
+
 async function runExternalJsonCommand(command: string[], args: string[], extraEnv: Record<string, string> = {}): Promise<ExternalCommandResult> {
   const proc = Bun.spawn({
     cmd: [...command, ...args],
@@ -724,7 +728,7 @@ async function runHodlmmJsonCommand(
   const scriptTarget = resolveHodlmmScriptTarget(command);
   if (!scriptTarget) {
     if (requirePasswordBridge) {
-      throw new Error("Secure HODLMM execution requires HODLMM_MOVE_LIQUIDITY_CMD to resolve to a Bun-runnable script path");
+      throw new Error(getHodlmmSecureExecutionError());
     }
     return runExternalJsonCommand(command, args, extraEnv);
   }
@@ -882,7 +886,10 @@ async function runDoctor(options: RunOptions): Promise<void> {
     checks.mempool = { ok: context.mempoolDepth <= options.mempoolDepthLimit, detail: `depth=${context.mempoolDepth} limit=${options.mempoolDepthLimit}` };
     try {
       const command = resolveHodlmmCommand();
-      checks.hodlmm_executor = { ok: true, detail: command.join(" ") };
+      const scriptTarget = resolveHodlmmScriptTarget(command);
+      checks.hodlmm_executor = scriptTarget
+        ? { ok: true, detail: command.join(" ") }
+        : { ok: false, detail: getHodlmmSecureExecutionError() };
     } catch (error) {
       checks.hodlmm_executor = { ok: false, detail: error instanceof Error ? error.message : String(error) };
     }

--- a/sbtc-yield-maximizer/sbtc-yield-maximizer.ts
+++ b/sbtc-yield-maximizer/sbtc-yield-maximizer.ts
@@ -407,6 +407,7 @@ async function getZestSignal(senderAddress: string): Promise<ZestSignal> {
     readUint("get-total-assets"),
     readUint("get-total-supply"),
   ]);
+  // Verified against the live v0-vault-sbtc source, which defines BPS u10000.
   const inferredApyBps = Number(rawInterestRate);
   return {
     rawInterestRate,
@@ -484,6 +485,9 @@ async function fetchHodlmmCandidates(options: RunOptions, walletAddress: string)
   const candidatePools = matchedPools.filter(
     ({ app }) => app.volumeUsd1d >= options.minHodlmmVolumeUsd && app.tvlUsd >= options.minHodlmmTvlUsd
   );
+  // If no pool clears the configured liquidity floors, still surface a bounded
+  // fallback set for status visibility. These fallback candidates may remain
+  // unsafe and must still pass the downstream `safe` gate before execution.
   const poolsToEvaluate = candidatePools.length > 0
     ? candidatePools
     : matchedPools
@@ -561,7 +565,7 @@ function decideRoute(
 ): RouteDecision {
   const idleSats = sbtcSats > options.reserveSats ? sbtcSats - options.reserveSats : 0n;
   const deploySats = idleSats > options.maxDeploySats ? options.maxDeploySats : idleSats;
-  const topHodlmm = hodlmmCandidates.find((candidate) => candidate.safe) || null;
+  const topHodlmm = hodlmmCandidates[0] || null;
   const rationale: string[] = [];
 
   if (!cooldown.ok) {
@@ -580,6 +584,9 @@ function decideRoute(
     rationale.push("No idle sBTC remains above reserve");
     return { route: "hold", deploySats, rationale, zest, topHodlmm, executable: false, winnerApyBps: 0, apyDiffBps: 0 };
   }
+  // ageSeconds is most useful once these reads are cached or reused across
+  // cycles; today it mainly captures fetch duration and leaves the stale-data
+  // gate ready for future cached reads.
   if (zest.ageSeconds > options.maxDataAgeSeconds) {
     rationale.push(`Zest rate age ${zest.ageSeconds}s exceeds max data age ${options.maxDataAgeSeconds}s`);
     return { route: "hold", deploySats, rationale, zest, topHodlmm, executable: false, winnerApyBps: 0, apyDiffBps: 0 };
@@ -594,6 +601,10 @@ function decideRoute(
   const apyDiffBps = Math.abs(hodlmmBps - zestBps);
 
   if (topHodlmm && hodlmmBps > zestBps) {
+    if (!topHodlmm.safe) {
+      rationale.push(`Top HODLMM pool failed safety gates: ${topHodlmm.reasons.join("; ")}`);
+      return { route: "hold", deploySats, rationale, zest, topHodlmm, executable: false, winnerApyBps: hodlmmBps, apyDiffBps };
+    }
     if (apyDiffBps < options.minApyDiffBps) {
       rationale.push(`HODLMM only leads Zest by ${apyDiffBps} bps, below the ${options.minApyDiffBps} bps minimum edge`);
       return { route: "hold", deploySats, rationale, zest, topHodlmm, executable: false, winnerApyBps: hodlmmBps, apyDiffBps };


### PR DESCRIPTION

## Summary

Completes the HODLMM routing leg for `sbtc-yield-maximizer`.

The live upstream version could compare Zest vs HODLMM, but still stopped at the HODLMM path with `executable: false`. This update makes that branch real: when HODLMM is the highest safe executable route and the wallet has an out-of-range LP position, the skill now executes the HODLMM rebalance through `hodlmm-move-liquidity` via CLI.

## What Changed

- added executable HODLMM route orchestration via `hodlmm-move-liquidity`
- added matched-freshness / stale-data gating for Zest and HODLMM reads
- added `--min-apy-diff-bps`
- added router-level cooldown
- added mempool-depth guard
- added wallet-scoped state
- added explicit no-broadcast HODLMM preflight via `hodlmm-move-liquidity scan`
- removed subprocess password exposure
- hardened execution lock handling
- updated HODLMM candidate evaluation so qualifying pools are not prematurely excluded by liquidity-first slicing

## Why

This closes the main capability gap in the current upstream skill:
- HODLMM could win in the decision function
- but the skill could not actually execute the HODLMM leg

After this change, `sbtc-yield-maximizer` becomes a true two-route write skill for existing sBTC capital:
- Zest supply when Zest wins
- HODLMM rebalance when HODLMM wins and the position is out of range

## Composition

This keeps the skill aligned with the composition rules:
- no bundled skill directories
- no cross-skill source imports
- HODLMM execution delegated via CLI to `hodlmm-move-liquidity`
- the owning skill remains `sbtc-yield-maximizer`

## Mainnet Proof

HODLMM-leg proof tx from the reviewed implementation:

- Tx: `0xbed1b7131689f5e45095a53ba8bc47f34f53b67e5b494698fe72c075566634ec`
- Sender: `SP3FY9BQ6NZ85XT9PBXQVKP47WJAEMZZ7K6KF7TSS`
- Contract: `SM1FKXGNZJWSTWDWXQZJNF7B5TV5ZB235JTCXYXKD.dlmm-liquidity-router-v-1-1`
- Function: `move-relative-liquidity-multi`

Hiro verification:

```bash
curl -s https://api.hiro.so/extended/v1/tx/0xbed1b7131689f5e45095a53ba8bc47f34f53b67e5b494698fe72c075566634ec | jq '{status:.tx_status, sender:.sender_address, contract:.contract_call.contract_id, function:.contract_call.function_name}'
```

```json
{
  "status": "success",
  "sender": "SP3FY9BQ6NZ85XT9PBXQVKP47WJAEMZZ7K6KF7TSS",
  "contract": "SM1FKXGNZJWSTWDWXQZJNF7B5TV5ZB235JTCXYXKD.dlmm-liquidity-router-v-1-1",
  "function": "move-relative-liquidity-multi"
}
```

## Scope Notes

This PR is specifically the HODLMM-leg completion for `sbtc-yield-maximizer`.

It is not claiming full `DCA + HODLMM + Zest` completion. STX -> sBTC normalization / DCA remains out of scope for this version.
