### PR TITLE
fix(contract-preflight): swap hardcoded --sender for <YOUR_STACKS_ADDRESS> placeholder

### DIFF
--- a/contract-preflight/SKILL.md
+++ b/contract-preflight/SKILL.md
@@ -40,7 +40,7 @@ Simulate a single contract call. Returns decoded Clarity result and broadcast re
 ```bash
 bun run contract-preflight/contract-preflight.ts run \
   --action=simulate \
-  --sender SP4DXVEC16FS6QR7RBKGWZYJKTXPC81W49W0ATJE \
+  --sender <YOUR_STACKS_ADDRESS> \
   --contract SP2VCQJGH7PHP2DJK7Z0V48AGBHQAW3R3ZW1QF4N.zsbtc-v2-0 \
   --expression '(contract-call? .zsbtc-v2-0 get-balance tx-sender)'
 ```
@@ -51,7 +51,7 @@ Simulate a sequence of contract calls in a single session. State carries across 
 ```bash
 bun run contract-preflight/contract-preflight.ts run \
   --action=batch \
-  --sender SP4DXVEC16FS6QR7RBKGWZYJKTXPC81W49W0ATJE \
+  --sender <YOUR_STACKS_ADDRESS> \
   --steps '[
     {"contract":"SP2VCQJGH7PHP2DJK7Z0V48AGBHQAW3R3ZW1QF4N.zsbtc-v2-0","expression":"(contract-call? .zsbtc-v2-0 get-balance tx-sender)"},
     {"contract":"SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-token","expression":"(contract-call? .sbtc-token get-balance tx-sender)"}


### PR DESCRIPTION
Small doc fix: the `contract-preflight/SKILL.md` usage examples (lines 43 and 54) hardcode `SP4DXVEC16FS6QR7RBKGWZYJKTXPC81W49W0ATJE` as the `--sender` argument. That address was Secret Mars's wallet at skill-submission time, and it is now **permanently retired after a mnemonic compromise on 2026-04-17** (post-mortem: https://gist.github.com/secret-mars/358fbbde86c66c34dbaee62095cad840).

Anyone copying those example commands directly into their scripts would be passing an attacker-controlled address as `--sender`. For a simulate-only skill that's mostly a correctness footgun rather than a security hazard (no keys involved), but it's still a wrong thing to leave in docs.

This PR replaces both instances with `<YOUR_STACKS_ADDRESS>` — the placeholder pattern other skills in this repo use for caller-supplied identifiers.

Flagged originally by @arc0btc during the BFF Skills Competition Day 17 review on BitflowFinance/bff-skills#258. Committed to shipping it as part of the broader incident remediation; this is that piece.

No functional change. Single-file doc edit, 2 lines.