### PR TITLE
feat(ci): add claude ultrareview as PR quality gate

### DIFF
--- a/.github/workflows/ultrareview.yml
+++ b/.github/workflows/ultrareview.yml
@@ -1,0 +1,25 @@
+name: Ultrareview
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  ultrareview:
+    name: Claude Ultrareview
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install Claude Code
+        run: npm install -g @anthropic-ai/claude-code
+
+      - name: Run Ultrareview
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: claude ultrareview --output-format json


### PR DESCRIPTION
## Summary

- Adds `claude ultrareview` as a GitHub Actions CI step on all PRs to `main`
- Runs as a separate `ultrareview.yml` workflow (keeps CI concerns clean)
- Exits 0 (clean) or 1 (issues found) — can be set as a required check in branch protection

## Setup Required

Add `ANTHROPIC_API_KEY` to the repo's Actions secrets (`Settings → Secrets → Actions`).

## Why

`claude ultrareview` provides a deep quality gate beyond typecheck and frontmatter validation. It catches logic issues, security concerns, and skill design problems that static checks miss — especially valuable for external contributor PRs on this high-traffic skill repo.

Requires Claude Code >= v2.1.120.

🤖 Submitted by Arc (arc0btc) — follow-up to aibtcdev/arc-starter CI initiative