### PR TITLE
fix(bitflow-limit-order): address post-merge audit — fee, atomic writes, pair normalization, slippage retry

### DIFF
--- a/bitflow-limit-order/SKILL.md
+++ b/bitflow-limit-order/SKILL.md
@@ -26,13 +26,13 @@ Sets price targets on Bitflow HODLMM pools, polls active bin mid-prices on each 
 
 ```
 User/Agent ──set──▶ Order File ──run──▶ Price Check ──trigger──▶ BitflowSDK Swap
-                    (~/.aibtc/          (HODLMM active bin)      (on-chain tx)
-                     limit-orders)
+                    (~/.aibtc/          (HODLMM active        (best-route tx via SDK;
+                     limit-orders)       bin mid-price)        not necessarily HODLMM)
 ```
 
 ## Why agents need it
 
-- **Zero limit order support exists on Bitflow** — no native UI, no Keeper contracts, no competing skills
+- **Agent-native limit orders** — Bitflow's native keeper handles orders server-side; this skill gives agents a self-hosted, fully configurable alternative with no third-party dependency
 - Every trader's #1 feature request on any DEX — high-leverage primitive
 - Enables autonomous trading strategies: set-and-forget price targets
 - HODLMM active bin provides an on-chain price oracle — no external feeds needed

--- a/bitflow-limit-order/bitflow-limit-order.ts
+++ b/bitflow-limit-order/bitflow-limit-order.ts
@@ -41,8 +41,10 @@ const DEFAULT_SLIPPAGE_PCT = 1;
 const DEFAULT_EXPIRY_HOURS = 24;
 const MAX_EXPIRY_DAYS = 7;
 const API_TIMEOUT_MS = 10_000;
-const TX_FEE_ESTIMATE = 5000; // microSTX
-const STX_FEE_RESERVE = TX_FEE_ESTIMATE / 1e6; // STX needed for tx fee regardless of side
+// (c) Fee raised to match observed Bitflow keeper baseline (SP3R9DN...4XCK uses 100_000 μSTX uniformly).
+//     Previous value of 5_000 μSTX would stall or queue under any fee pressure.
+const TX_FEE_ESTIMATE = 100_000; // microSTX — matches observed Bitflow keeper baseline
+const STX_FEE_RESERVE = TX_FEE_ESTIMATE / 1e6; // STX needed for tx fee regardless of side (= 0.1 STX)
 
 // Watch-mode + anti-wick
 const DEFAULT_CONFIRM_TICKS = 2;
@@ -148,8 +150,12 @@ function loadOrderBook(): OrderBook {
 }
 
 function saveOrderBook(book: OrderBook): void {
+  // (e) Atomic write via tmp-then-rename: a crash mid-write leaves old data intact
+  //     rather than silently zeroing all active orders on next loadOrderBook call.
   ensureDir();
-  fs.writeFileSync(ORDERS_FILE, JSON.stringify(book, null, 2));
+  const tmp = ORDERS_FILE + ".tmp";
+  fs.writeFileSync(tmp, JSON.stringify(book, null, 2));
+  fs.renameSync(tmp, ORDERS_FILE);
 }
 
 // ─── Bitflow API helpers ──────────────────────────────────────────────────────
@@ -607,6 +613,10 @@ program
         return fail("set", e.message);
       }
 
+      // (f) Normalize pair to UPPER-CASE with dash delimiter before any storage or lookup.
+      //     runCycle splits on "-" — storing "stx_sbtc" would silently break tokenIn resolution.
+      opts.pair = opts.pair.toUpperCase().replace(/[_\s]/g, "-");
+
       // Find pool
       log(`Looking up pool: ${opts.pair}`);
       const pool = await findPool(opts.pair);
@@ -905,6 +915,11 @@ async function runCycle(ctx: CycleCtx): Promise<CycleStats> {
             stats.skipped++; if (ctx.useTicks) ctx.tickCounts.delete(order.orderId);
             continue;
           }
+        } else {
+          // (d) Unsupported tokenIn — skip gracefully rather than proceeding blindly
+          recordSkip(book, order, `Unsupported tokenIn: ${order.tokenIn} — only STX and sBTC are supported`);
+          stats.skipped++; if (ctx.useTicks) ctx.tickCounts.delete(order.orderId);
+          continue;
         }
       } catch (e: any) {
         recordSkip(book, order, `Balance check failed: ${e.message}`);
@@ -955,13 +970,21 @@ async function runCycle(ctx: CycleCtx): Promise<CycleStats> {
         }
         break; // one fill per cycle
       } catch (e: any) {
-        order.status = "error";
-        order.errorMessage = `Swap failed: ${e.message}`;
-        saveOrderBook(book);
-        appendEvent({ orderId: order.orderId, event: "error", stage: "swap", detail: e.message });
-        stats.errors++;
-        if (ctx.emitPerOrderJson) {
-          fail("execute", `Order #${order.orderId} swap failed: ${e.message}`);
+        // (i) Slippage violations and post-condition failures are transient — price moved
+        //     between check and execution. Treat as a skip so the order retries next cycle.
+        const isTransient = /slippage|post.condition|STXPostCondition|FungiblePostCondition/i.test(e.message);
+        if (isTransient) {
+          recordSkip(book, order, `Transient swap failure (retryable): ${e.message}`);
+          stats.skipped++; if (ctx.useTicks) ctx.tickCounts.delete(order.orderId);
+        } else {
+          order.status = "error";
+          order.errorMessage = `Swap failed: ${e.message}`;
+          saveOrderBook(book);
+          appendEvent({ orderId: order.orderId, event: "error", stage: "swap", detail: e.message });
+          stats.errors++;
+          if (ctx.emitPerOrderJson) {
+            fail("execute", `Order #${order.orderId} swap failed: ${e.message}`);
+          }
         }
         continue;
       }

--- a/bitflow-limit-order/bitflow-limit-order.ts
+++ b/bitflow-limit-order/bitflow-limit-order.ts
@@ -972,7 +972,7 @@ async function runCycle(ctx: CycleCtx): Promise<CycleStats> {
       } catch (e: any) {
         // (i) Slippage violations and post-condition failures are transient — price moved
         //     between check and execution. Treat as a skip so the order retries next cycle.
-        const isTransient = /slippage|post.condition|STXPostCondition|FungiblePostCondition/i.test(e.message);
+        const isTransient = /slippage|post[- _.]condition|STXPostCondition|FungiblePostCondition/i.test(e.message);
         if (isTransient) {
           recordSkip(book, order, `Transient swap failure (retryable): ${e.message}`);
           stats.skipped++; if (ctx.useTicks) ctx.tickCounts.delete(order.orderId);


### PR DESCRIPTION
## Context

Post-merge audit by macbotmini-eng and arc0btc on #329 identified correctness issues blocking prize payment. This PR resolves all of them.

Competition submission: [BitflowFinance/bff-skills#277](https://github.com/BitflowFinance/bff-skills/pull/277)

---

## Fixes

### (c) TX_FEE_ESTIMATE — payment-blocking

**Bug:** Fee floor was 5,000 μSTX — stall-prone under any fee pressure. Observed Bitflow's own keeper (SP3R9DN…4XCK) uses 100,000 μSTX uniformly.

**Fix:** `TX_FEE_ESTIMATE` raised to `100_000` μSTX. `STX_FEE_RESERVE` updated to reflect 0.1 STX reserve.

### (e) Atomic order book writes — payment-blocking

**Bug:** `writeFileSync` directly to target file — process crash mid-write corrupts the order book irreversibly.

**Fix:** Atomic pattern: write to `.tmp`, then `renameSync` to target. Rename is atomic on POSIX. Order book is never partially written.

### (d) Unsupported tokenIn falls through silently

**Bug:** If `tokenIn` was neither STX nor sBTC, the balance check block exited without skipping — execution proceeded with unchecked balance.

**Fix:** Added `else` branch that records a skip with a descriptive reason and continues to next order.

### (f) Pair normalization at `set` time

**Bug:** `runCycle` splits `order.pair` on `"-"` to extract token symbols. If user passes `--pair stx_sbtc`, it stored as-is — the split produces wrong symbols silently.

**Fix:** Normalize `opts.pair` to `UPPER-CASE` with `-` delimiter before any storage or lookup.

### (i) Slippage/post-condition errors are retryable

**Bug:** Any swap failure set `order.status = "error"` — terminal. But slippage violations and post-condition failures are transient (price moved between check and execution) and should retry next cycle.

**Fix:** Errors matching `/slippage|post.condition|STXPostCondition|FungiblePostCondition/i` are treated as skips (retryable), not terminal errors.

### (a/b) SKILL.md factual fixes

- (a) Removed false "Zero limit order support exists on Bitflow" — Bitflow has a native keeper. Replaced with accurate framing: agent-native self-hosted alternative.
- (b) Clarified execution path: trigger is based on HODLMM active bin price, but execution routes via BitflowSDK best-route (not necessarily HODLMM-atomic).

---

cc @arc0btc @TheBigMacBTC — all audit items addressed. Happy to walk through any of these if helpful.