### PR TITLE
ci: auto-regenerate manifest on same-repo PRs to fix stale-after-interleave

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+
 jobs:
   ci:
     name: Typecheck, validate, and manifest freshness
@@ -16,6 +19,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -29,13 +37,29 @@ jobs:
       - name: Validate skill frontmatter
         run: bun run validate
 
-      - name: Check manifest freshness
+      - name: Auto-regenerate manifest (same-repo PRs)
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         run: |
-          # Save the committed skills array (excluding timestamp) for comparison
           jq '.skills' skills.json > /tmp/skills-before.json
-          # Regenerate the manifest
           bun run manifest
-          # Compare only the skills array — timestamp changes are expected and ignored
+          jq '.skills' skills.json > /tmp/skills-after.json
+          if ! diff -q /tmp/skills-before.json /tmp/skills-after.json > /dev/null 2>&1; then
+            echo "Manifest stale (likely from interleaved PR merges) — auto-regenerating and committing."
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git add skills.json
+            git commit -m "chore(ci): auto-regenerate manifest after merge interleaving"
+            git push origin HEAD:${{ github.event.pull_request.head.ref }}
+            echo "Manifest regenerated and pushed. CI will re-run on the new commit."
+            exit 0
+          fi
+          echo "Manifest up to date."
+
+      - name: Check manifest freshness (forks and main pushes)
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository
+        run: |
+          jq '.skills' skills.json > /tmp/skills-before.json
+          bun run manifest
           jq '.skills' skills.json > /tmp/skills-after.json
           if ! diff -q /tmp/skills-before.json /tmp/skills-after.json > /dev/null 2>&1; then
             echo "skills.json is stale — run 'bun run manifest' and commit the result."


### PR DESCRIPTION
## Summary

Makes the `Typecheck, validate, and manifest freshness` CI job self-healing for same-repo PRs. When the manifest is stale because another PR merged in between, the bot now regenerates `skills.json`, commits the fix to the PR branch, and exits — letting the next CI run find a fresh manifest.

Forks still get the original failure message; auto-pushing to fork branches is not safe.

## Why

The current manifest check fails any PR whose `skills.json` predated an interleaved merge. The contributor did nothing wrong — their fresh manifest just didn't include skills added by the other PR. This has been blocking arc0btc PRs (#341, #255, #312) and BFF-comp PR #356, and creates ongoing friction for any contributor caught between merges.

This is operator preference Theme 4e: "better manifest-staleness handling in skills repo... so the test stops false-flagging for everyone, not just arc0btc."

## How it works

```yaml
permissions:
  contents: write

steps:
  - Checkout (with PR branch ref + token)
  - Setup Bun, install, typecheck, validate (unchanged)
  - Auto-regen step (only on same-repo PRs):
    - Diff committed `skills.json` against fresh `bun run manifest` output
    - If different: bot commit + push to PR branch, exit 0
    - If same: continue
  - Manual freshness check (forks + main pushes):
    - Same diff, but exit 1 with helpful message
```

Loop avoidance: bot push only fires when diff is non-empty. After the push, next CI run sees fresh manifest and skips the regen.

## Test plan

- [x] CI green on this PR (no skills changed, no regen needed)
- [ ] After merge, the next contributor PR with stale manifest will receive an auto-fix commit instead of a CI failure
- [ ] arc0btc PRs (#341, #255, #312) and BFF #356 unblock once this lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)