### PR TITLE
fix(aibtc-news): inherit process.env in signing subprocess + support signatureBase64

### DIFF
--- a/aibtc-news/aibtc-news.ts
+++ b/aibtc-news/aibtc-news.ts
@@ -50,6 +50,7 @@ async function signMessage(message: string): Promise<{ signature: string; signer
       cwd: new URL("..", import.meta.url).pathname,
       stdout: "pipe",
       stderr: "pipe",
+      env: { ...process.env },
     }
   );
 
@@ -68,11 +69,13 @@ async function signMessage(message: string): Promise<{ signature: string; signer
     throw new Error(`btc-sign returned invalid JSON: ${stdout}`);
   }
 
-  if (!result.success || !result.signature || !result.signer) {
+  // Support both `signature` (legacy) and `signatureBase64` (current signing skill output)
+  const sig = result.signature ?? (result as Record<string, unknown>).signatureBase64 as string | undefined;
+  if (!result.success || !sig || !result.signer) {
     throw new Error(`btc-sign error: ${result.error || "missing signature or signer in output"}`);
   }
 
-  return { signature: result.signature, signer: result.signer };
+  return { signature: sig, signer: result.signer };
 }
 
 /**


### PR DESCRIPTION
## Problem

The `signMessage()` function in `aibtc-news.ts` spawns `signing.ts btc-sign` as a subprocess without inheriting `process.env`. This means `AIBTC_WALLET_PASSWORD` (and other env vars) never reach the subprocess, causing signing to fail with an unlocked-wallet error even when the wallet is unlocked in the parent process.

A second independent failure: even when signing succeeds, the response parser checked only for `signature` — but the current `signing.ts` outputs `signatureBase64`. Both bugs compound on the same call path, making authenticated news API calls silently fail.

## Changes

1. **`env: { ...process.env }`** added to `Bun.spawn` options — ensures `AIBTC_WALLET_PASSWORD`, `AIBTC_MNEMONIC`, and `NETWORK` are available in the signing subprocess.
2. **`signatureBase64` fallback** — the result check now reads `result.signature ?? result.signatureBase64`, maintaining backward compatibility while supporting current signing skill output.

## Testing

Before this fix, `aibtc-news file-signal` would fail with `"btc-sign error: missing signature or signer in output"` even with a valid unlocked wallet. After this fix, the subprocess receives the wallet credentials and the response is correctly parsed.

## Previous PR

This is a clean rebase of the fix originally in PR #256 (closed due to merge conflicts + no response). The hodlmm-risk and paperboy skill additions from that PR are excluded — those were already merged by other contributors.