### PR TITLE
fix(src): bind INBOX_BASE to NETWORK + clarify HODLMM_API_BASE (closes #365)

### DIFF
--- a/inbox/inbox.ts
+++ b/inbox/inbox.ts
@@ -7,14 +7,12 @@
  */
 
 import { Command } from "commander";
-import { NETWORK } from "../src/lib/config/networks.js";
+import { NETWORK, getInboxBase } from "../src/lib/config/networks.js";
 import {
   getAccount,
   getWalletAddress,
 } from "../src/lib/services/x402.service.js";
 import { printJson, handleError } from "../src/lib/utils/cli.js";
-
-const INBOX_BASE = "https://aibtc.com/api/inbox";
 
 // ---------------------------------------------------------------------------
 // Program
@@ -62,7 +60,7 @@ program
 
         const account = await getAccount();
 
-        const inboxUrl = `${INBOX_BASE}/${opts.recipientStxAddress}`;
+        const inboxUrl = `${getInboxBase()}/${opts.recipientStxAddress}`;
         const body = {
           toBtcAddress: opts.recipientBtcAddress,
           toStxAddress: opts.recipientStxAddress,
@@ -251,7 +249,7 @@ program
     try {
       const address = await getWalletAddress();
 
-      const url = `${INBOX_BASE}/${address}${opts.status !== "all" ? `?status=${opts.status}` : ""}`;
+      const url = `${getInboxBase()}/${address}${opts.status !== "all" ? `?status=${opts.status}` : ""}`;
 
       const res = await fetch(url, {
         method: "GET",
@@ -306,7 +304,7 @@ program
       const address = await getWalletAddress();
 
       // Single fetch — the API returns unreadCount and totalCount in one call
-      const res = await fetch(`${INBOX_BASE}/${address}`, {
+      const res = await fetch(`${getInboxBase()}/${address}`, {
         method: "GET",
       });
 

--- a/skills.json
+++ b/skills.json
@@ -1,6 +1,6 @@
 {
   "version": "0.40.0",
-  "generated": "2026-04-30T09:38:31.981Z",
+  "generated": "2026-04-30T11:23:44.648Z",
   "skills": [
     {
       "name": "agent-lookup",

--- a/src/lib/config/networks.ts
+++ b/src/lib/config/networks.ts
@@ -22,6 +22,14 @@ export function getApiBaseUrl(network: Network): string {
     : "https://api.testnet.hiro.so";
 }
 
+// Inbox API base. mainnet → aibtc.com, testnet → aibtc.dev. Override with AIBTC_INBOX_BASE.
+export function getInboxBase(): string {
+  if (process.env.AIBTC_INBOX_BASE) return process.env.AIBTC_INBOX_BASE;
+  return NETWORK === "mainnet"
+    ? "https://aibtc.com/api/inbox"
+    : "https://aibtc.dev/api/inbox";
+}
+
 export const EXPLORER_URL = "https://explorer.hiro.so";
 
 export function getExplorerTxUrl(txid: string, network: Network): string {

--- a/src/lib/services/bitflow.service.ts
+++ b/src/lib/services/bitflow.service.ts
@@ -275,6 +275,9 @@ interface PreparedRelativeWithdrawalBin extends HodlmmRelativeWithdrawalInput {
   binId: number;
 }
 
+// Default HODLMM API base. Read via getHodlmmApiBase() (line ~382), which checks
+// process.env.BITFLOW_HODLMM_API_HOST first — same env-override pattern as the
+// other Bitflow URL constants in this file.
 const HODLMM_API_BASE = "https://bff.bitflowapis.finance";
 const HODLMM_LIQUIDITY_ROUTER = "SM1FKXGNZJWSTWDWXQZJNF7B5TV5ZB235JTCXYXKD.dlmm-liquidity-router-v-1-1";
 const HODLMM_CORE_CONTRACT = "SP1PFR4V08H1RAZXREBGFFQ59WB739XM8VVGTFSEA.dlmm-core-v-1-1";

--- a/src/lib/utils/x402-retry.ts
+++ b/src/lib/utils/x402-retry.ts
@@ -45,7 +45,7 @@ import {
   resolveCanonicalCheckStatusUrl,
   type CanonicalPaymentAction,
 } from "../services/x402.service.js";
-import { type Network, getStacksNetwork } from "../config/networks.js";
+import { type Network, getInboxBase, getStacksNetwork } from "../config/networks.js";
 import { getContracts, parseContractId } from "../config/contracts.js";
 import {
   emitPaymentDiagnostic,
@@ -109,8 +109,6 @@ const DEFAULT_RETRY_DELAY_MS = 2_000;
 const MAX_RETRY_AFTER_CAP_S = 60;
 /** Keep retry-loop canonical polling bounded so a slow status endpoint does not stall retries. */
 const RETRY_LOOP_CANONICAL_POLL_TIMEOUT_MS = 5_000;
-/** Inbox API base URL. */
-const INBOX_BASE = "https://aibtc.com/api/inbox";
 
 // ============================================================================
 // Retry Classifier
@@ -445,7 +443,7 @@ async function submitWithPaymentTxid(
   content: string,
   txid: string
 ): Promise<{ ok: boolean; status: number; body: string }> {
-  const url = `${INBOX_BASE}/${recipientBtcAddress}`;
+  const url = `${getInboxBase()}/${recipientBtcAddress}`;
   const res = await fetch(url, {
     method: "POST",
     headers: { "Content-Type": "application/json" },

--- a/x402/x402.ts
+++ b/x402/x402.ts
@@ -7,7 +7,7 @@
  */
 
 import { Command } from "commander";
-import { NETWORK, API_URL } from "../src/lib/config/networks.js";
+import { NETWORK, API_URL, getInboxBase } from "../src/lib/config/networks.js";
 import {
   classifyCanonicalPaymentOutcome,
   createApiClient,
@@ -425,8 +425,7 @@ program
 
         const account = await getAccount();
 
-        const INBOX_BASE = "https://aibtc.com/api/inbox";
-        const inboxUrl = `${INBOX_BASE}/${opts.recipientBtcAddress}`;
+        const inboxUrl = `${getInboxBase()}/${opts.recipientBtcAddress}`;
         const body = {
           toBtcAddress: opts.recipientBtcAddress,
           toStxAddress: opts.recipientStxAddress,


### PR DESCRIPTION
## Summary

Closes #365 (RPC-binding audit).

## Finding 1 — INBOX_BASE leak

`INBOX_BASE` was hardcoded to `https://aibtc.com/api/inbox` in **three** sites with no env override and no testnet pair. The audit found it in `x402-retry.ts:113` (lib helper), and a quick grep showed two more identical literals in `x402/x402.ts:428` and `inbox/inbox.ts:17`. Testnet runs would post inbox messages to the production aibtc.com service.

**Fix:** New `getInboxBase()` helper in `src/lib/config/networks.ts`:
- env override: `AIBTC_INBOX_BASE`
- otherwise: mainnet → `https://aibtc.com/api/inbox`, testnet → `https://aibtc.dev/api/inbox`
- matches the mainnet/testnet pair pattern used by the other helpers in that file (Hiro API, etc.)

All 3 sites now call `getInboxBase()` per request.

## Finding 2 — HODLMM_API_BASE (audit was off-base; added clarifying comment)

The audit flagged this as missing env override, but a few lines below the const there's already a `getHodlmmApiBase()` getter at line 381:

```ts
private getHodlmmApiBase(): string {
  return process.env.BITFLOW_HODLMM_API_HOST || HODLMM_API_BASE;
}
```

So the env-override path *does* exist — it's just one indirection away. Added an inline comment at the const declaration pointing readers at the getter so the next audit doesn't get confused the same way.

## Test plan

- [x] `bun run typecheck` passes
- [x] `bun run manifest` regenerates clean (95 skills)
- [ ] When merged: `NETWORK=testnet bun run inbox/inbox.ts ...` would route to `aibtc.dev` instead of mainnet

## Files changed

| File | Change |
|---|---|
| `src/lib/config/networks.ts` | + `getInboxBase()` helper |
| `src/lib/utils/x402-retry.ts` | drop literal, use helper (1 site) |
| `x402/x402.ts` | drop literal, use helper (1 site) |
| `inbox/inbox.ts` | drop literal, use helper (3 sites) |
| `src/lib/services/bitflow.service.ts` | inline comment on HODLMM_API_BASE |
| `skills.json` | manifest regen (timestamp) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)