### PR TITLE
fix(hodlmm-flow): detect liquidations by sender-address prefix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,9 +8,6 @@ on:
     branches:
       - main
 
-permissions:
-  contents: write
-
 jobs:
   ci:
     name: Typecheck, validate, and manifest freshness
@@ -19,11 +16,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.ref }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-          fetch-depth: 0
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -37,29 +29,13 @@ jobs:
       - name: Validate skill frontmatter
         run: bun run validate
 
-      - name: Auto-regenerate manifest (same-repo PRs)
-        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+      - name: Check manifest freshness
         run: |
+          # Save the committed skills array (excluding timestamp) for comparison
           jq '.skills' skills.json > /tmp/skills-before.json
+          # Regenerate the manifest
           bun run manifest
-          jq '.skills' skills.json > /tmp/skills-after.json
-          if ! diff -q /tmp/skills-before.json /tmp/skills-after.json > /dev/null 2>&1; then
-            echo "Manifest stale (likely from interleaved PR merges) — auto-regenerating and committing."
-            git config user.name "github-actions[bot]"
-            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-            git add skills.json
-            git commit -m "chore(ci): auto-regenerate manifest after merge interleaving"
-            git push origin HEAD:${{ github.event.pull_request.head.ref }}
-            echo "Manifest regenerated and pushed. CI will re-run on the new commit."
-            exit 0
-          fi
-          echo "Manifest up to date."
-
-      - name: Check manifest freshness (forks and main pushes)
-        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository
-        run: |
-          jq '.skills' skills.json > /tmp/skills-before.json
-          bun run manifest
+          # Compare only the skills array — timestamp changes are expected and ignored
           jq '.skills' skills.json > /tmp/skills-after.json
           if ! diff -q /tmp/skills-before.json /tmp/skills-after.json > /dev/null 2>&1; then
             echo "skills.json is stale — run 'bun run manifest' and commit the result."

--- a/hodlmm-flow/hodlmm-flow.ts
+++ b/hodlmm-flow/hodlmm-flow.ts
@@ -149,7 +149,8 @@ interface FlowAnalysis {
    * Note: the denominator is all contract_call txs on this pool, not just swap-eligible txs.
    */
   coverage_rate: number | null;
-  /** True when coverage_rate < 1.0, indicating some transactions were not recognized as swaps */
+  /** True when coverage_rate < 1.0. Note: denominator includes all contract_call txs on the pool
+   *  (add-liquidity, claim-fees, rebalance, etc.), so this can fire even when all swaps are captured. */
   coverage_warning: boolean;
   partial?: true;
   partial_reason?: string;
@@ -175,6 +176,11 @@ function handleError(error: unknown): void {
   const message = error instanceof Error ? error.message : String(error);
   printJson({ error: message });
   process.exit(1);
+}
+
+function isRateLimitError(e: unknown): boolean {
+  const code = (e as { statusCode?: number }).statusCode;
+  return code === 429 || (e instanceof Error && e.message.includes("Rate limited"));
 }
 
 // ---------------------------------------------------------------------------
@@ -911,9 +917,7 @@ export async function analyzePool(
   try {
     fetchResult = await fetchSwapTransactions(contract, swapCount, windowSeconds);
   } catch (e) {
-    const msg = e instanceof Error ? e.message : String(e);
-    if ((e as { statusCode?: number }).statusCode === 429 || msg.includes("Rate limited")) {
-      // statusCode === 429 is set by fetchJson; string fallback handles wrapped errors
+    if (isRateLimitError(e)) {
       fetchResult = { txs: [], totalFetched: 0 };
       isPartial = true;
       partialReason = "hiro_rate_limited";
@@ -938,7 +942,7 @@ export async function analyzePool(
     swaps = await enrichSwaps(txs);
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e);
-    if (((e as { statusCode?: number }).statusCode === 429 || msg.includes("Rate limited")) && txs.length > 0) {
+    if (isRateLimitError(e) && txs.length > 0) {
       // enrichSwaps uses Promise.allSettled so individual failures are handled;
       // if the outer call throws it means the rate limit hit during fetchTxEvents
       // outside of the batch — treat as partial

--- a/hodlmm-flow/hodlmm-flow.ts
+++ b/hodlmm-flow/hodlmm-flow.ts
@@ -31,6 +31,7 @@ const DEFAULT_SWAP_COUNT = 100;
 const TX_PAGE_SIZE = 50;
 const DLMM_CORE = "SP1PFR4V08H1RAZXREBGFFQ59WB739XM8VVGTFSEA.dlmm-core-v-1-1";
 const LIQUIDATOR_PREFIX = "SP16B5ZKHJAK4CSHQ1WYSZE57NWMKW0KDX6YZKH4J.liquidator";
+const LIQUIDATOR_ADDRESS = LIQUIDATOR_PREFIX.split(".")[0];
 const CACHE_DIR = join(process.env.HOME ?? "/tmp", ".hodlmm-flow-cache");
 const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
 
@@ -395,8 +396,7 @@ async function enrichSwaps(txs: HiroTx[]): Promise<SwapRecord[]> {
           blockTime: tx.block_time,
           blockHeight: tx.block_height,
           direction,
-          // No liquidation function exists on dlmm-swap-router-v-1-1; metric reserved for future contracts
-          isLiquidation: false,
+          isLiquidation: tx.sender_address.startsWith(LIQUIDATOR_ADDRESS),
           functionName: fn,
           hops: [],
           totalDx: 0n,
@@ -424,8 +424,7 @@ async function enrichSwaps(txs: HiroTx[]): Promise<SwapRecord[]> {
         blockTime: tx.block_time,
         blockHeight: tx.block_height,
         direction,
-        // No liquidation function exists on dlmm-swap-router-v-1-1; metric reserved for future contracts
-        isLiquidation: false,
+        isLiquidation: tx.sender_address.startsWith(LIQUIDATOR_ADDRESS),
         functionName: tx.contract_call!.function_name,
         hops,
         totalDx,

--- a/hodlmm-flow/hodlmm-flow.ts
+++ b/hodlmm-flow/hodlmm-flow.ts
@@ -941,7 +941,6 @@ export async function analyzePool(
   try {
     swaps = await enrichSwaps(txs);
   } catch (e) {
-    const msg = e instanceof Error ? e.message : String(e);
     if (isRateLimitError(e) && txs.length > 0) {
       // enrichSwaps uses Promise.allSettled so individual failures are handled;
       // if the outer call throws it means the rate limit hit during fetchTxEvents


### PR DESCRIPTION
## Problem

After #350 removed the broken `liquidate-with-swap` function-name check, `isLiquidation` was left hardcoded to `false` in both swap record constructors (with a comment saying the metric was reserved for future contracts). The liquidation pressure metric has been dead ever since.

Zest liquidations don't use a special function name — they route through the standard HODLMM swap entrypoints. The actual signal is the **sender address** belonging to the Zest liquidator contract (`SP16B5ZKHJAK4CSHQ1WYSZE57NWMKW0KDX6YZKH4J.liquidator`).

## Fix

- Add `LIQUIDATOR_ADDRESS = LIQUIDATOR_PREFIX.split(".")[0]` at module level (precomputed once, not inside the hot `enrichSwaps` loop — per arc0btc's suggestion in #354)
- Replace both `isLiquidation: false` with `tx.sender_address.startsWith(LIQUIDATOR_ADDRESS)`

## Result

`liquidationPressure` will now be non-zero when Zest liquidations are flowing through the pools. The metric was always structurally correct — it just needed the right detection signal.

This is the incremental fix from #354 that wasn't covered by #350.