### PR TITLE
fix(x402): correct payment-status fallback URL to relay's /payment/{id} route

### DIFF
--- a/src/lib/services/x402.service.test.ts
+++ b/src/lib/services/x402.service.test.ts
@@ -4,6 +4,7 @@ import { once } from "node:events";
 import { getStacksChainId } from "../config/caip.js";
 import { NETWORK, type Network } from "../config/networks.js";
 import {
+  buildPaymentStatusCheckUrl,
   classifyCanonicalPaymentOutcome,
   createApiClient,
   extractPaymentIdentifierFromPaymentSignature,
@@ -171,7 +172,7 @@ describe("createApiClient canonical payment flow", () => {
         return;
       }
 
-      if (seen.paymentId && url.pathname === `/api/payment-status/${seen.paymentId}`) {
+      if (seen.paymentId && url.pathname === `/payment/${seen.paymentId}`) {
         seen.canonicalPolls += 1;
         res.statusCode = 200;
         res.setHeader("content-type", "application/json");
@@ -275,7 +276,7 @@ describe("createApiClient canonical payment flow", () => {
         return;
       }
 
-      if (seen.paymentId && url.pathname === `/api/payment-status/${seen.paymentId}`) {
+      if (seen.paymentId && url.pathname === `/payment/${seen.paymentId}`) {
         seen.canonicalPolls += 1;
         res.statusCode = 200;
         res.setHeader("content-type", "application/json");
@@ -365,7 +366,7 @@ describe("createApiClient canonical payment flow", () => {
         return;
       }
 
-      if (seen.paymentId && url.pathname === `/api/payment-status/${seen.paymentId}`) {
+      if (seen.paymentId && url.pathname === `/payment/${seen.paymentId}`) {
         res.statusCode = 500;
         res.end("boom");
         return;
@@ -537,6 +538,23 @@ describe("resolveCanonicalCheckStatusUrl", () => {
   });
 });
 
+describe("buildPaymentStatusCheckUrl", () => {
+  // Pin the URL contract so a future rename of the relay route surfaces here
+  // instead of as runtime `unknown_payment_identity` failures whenever the
+  // relay omits checkStatusUrl from its response.
+  test("constructs the relay's /payment/{id} route", () => {
+    expect(buildPaymentStatusCheckUrl("https://x402-relay.aibtc.com", "pay_abc")).toBe(
+      "https://x402-relay.aibtc.com/payment/pay_abc"
+    );
+  });
+
+  test("preserves the origin and ignores path/query on the input baseUrl", () => {
+    expect(
+      buildPaymentStatusCheckUrl("https://x402-relay.aibtc.com/inbox/send?x=1", "pay_abc")
+    ).toBe("https://x402-relay.aibtc.com/payment/pay_abc");
+  });
+});
+
 describe("fetchCanonicalPaymentStatus", () => {
   test("consumes an explicit canonical poll hint when provided", async () => {
     const seen = { hintHits: 0, localRouteHits: 0 };
@@ -556,7 +574,7 @@ describe("fetchCanonicalPaymentStatus", () => {
         return;
       }
 
-      if (url.pathname === "/api/payment-status/pay_123") {
+      if (url.pathname === "/payment/pay_123") {
         seen.localRouteHits += 1;
         res.statusCode = 500;
         res.end("should not be called");
@@ -596,7 +614,7 @@ describe("fetchCanonicalPaymentStatus", () => {
     const seen = { localRouteHits: 0 };
     const server = createServer((req: IncomingMessage, res: ServerResponse) => {
       const url = new URL(req.url ?? "/", "http://127.0.0.1");
-      if (url.pathname === "/api/payment-status/pay_123") {
+      if (url.pathname === "/payment/pay_123") {
         seen.localRouteHits += 1;
         res.statusCode = 200;
         res.setHeader("content-type", "application/json");
@@ -653,7 +671,7 @@ describe("fetchCanonicalPaymentStatus", () => {
         return;
       }
 
-      if (url.pathname === "/api/payment-status/pay_123") {
+      if (url.pathname === "/payment/pay_123") {
         seen.localRouteHits += 1;
         res.statusCode = 200;
         res.setHeader("content-type", "application/json");

--- a/src/lib/services/x402.service.test.ts
+++ b/src/lib/services/x402.service.test.ts
@@ -553,6 +553,18 @@ describe("buildPaymentStatusCheckUrl", () => {
       buildPaymentStatusCheckUrl("https://x402-relay.aibtc.com/inbox/send?x=1", "pay_abc")
     ).toBe("https://x402-relay.aibtc.com/payment/pay_abc");
   });
+
+  test("percent-encodes the paymentId path segment", () => {
+    // Defensive: paymentIds today are `pay_<hex>` and contain no reserved
+    // characters, but a future ID format change shouldn't be able to escape
+    // the `/payment/` segment and hit an unintended relay route.
+    expect(buildPaymentStatusCheckUrl("https://relay.example", "pay/../admin")).toBe(
+      "https://relay.example/payment/pay%2F..%2Fadmin"
+    );
+    expect(buildPaymentStatusCheckUrl("https://relay.example", "pay?x=1#frag")).toBe(
+      "https://relay.example/payment/pay%3Fx%3D1%23frag"
+    );
+  });
 });
 
 describe("fetchCanonicalPaymentStatus", () => {

--- a/src/lib/services/x402.service.ts
+++ b/src/lib/services/x402.service.ts
@@ -145,10 +145,18 @@ export function isInFlightPaymentStatus(
 /**
  * Local compatibility helper for inbox or other explicitly bounded first-party
  * flows. This is not a generic caller-facing x402 contract.
+ *
+ * The relay exposes payment status at `/payment/{paymentId}` (verified against
+ * x402-relay v1.32.x). The previous `/api/payment-status/{paymentId}` path
+ * 404s on the live relay; when the relay response omits `checkStatusUrl`,
+ * the fallback was synthesizing `{status: "not_found", terminalReason:
+ * "unknown_payment_identity"}` from those 404s, which the retry loop
+ * interpreted as a terminal payment-identity failure and burned the retry
+ * budget chasing phantom IDs.
  */
 export function buildPaymentStatusCheckUrl(baseUrl: string, paymentId: string): string {
   const origin = new URL(baseUrl).origin;
-  return `${origin}/api/payment-status/${paymentId}`;
+  return `${origin}/payment/${paymentId}`;
 }
 
 /**
@@ -157,7 +165,7 @@ export function buildPaymentStatusCheckUrl(baseUrl: string, paymentId: string): 
  * Currently a pass-through that returns the upstream-provided URL as-is.
  * The unused `_baseUrl` and `_paymentId` params are retained for forward
  * compatibility: when the relay omits `checkStatusUrl`, a future version
- * can construct a fallback from `{baseUrl}/api/payment-status/{paymentId}`.
+ * can construct a fallback via `buildPaymentStatusCheckUrl`.
  */
 export function resolveCanonicalCheckStatusUrl(
   _baseUrl: string,

--- a/src/lib/services/x402.service.ts
+++ b/src/lib/services/x402.service.ts
@@ -156,7 +156,7 @@ export function isInFlightPaymentStatus(
  */
 export function buildPaymentStatusCheckUrl(baseUrl: string, paymentId: string): string {
   const origin = new URL(baseUrl).origin;
-  return `${origin}/payment/${paymentId}`;
+  return `${origin}/payment/${encodeURIComponent(paymentId)}`;
 }
 
 /**


### PR DESCRIPTION
## Summary

`buildPaymentStatusCheckUrl` returns the wrong path. The relay serves payment status at `${origin}/payment/{id}`, but this helper synthesizes `${origin}/api/payment-status/{id}`, which 404s on the live relay (`x402-relay.aibtc.com` v1.32.x).

This is the no-hint fallback. When the relay's response includes `checkStatusUrl` in the body, `fetchCanonicalPaymentStatus` uses the canonical hint and everything works (#290 wired this up). When the response omits the hint — which still happens on some inbox flows — the SDK falls through to `buildPaymentStatusCheckUrl`, hits a dead route, and `fetchCanonicalPaymentStatus` synthesizes:

```ts
{ status: "not_found", terminalReason: "unknown_payment_identity" }
```

`x402-retry.ts` reads that terminal reason and triggers `restart` — generates a fresh `paymentIdentifier` and loops. Each iteration hits the same broken fallback. The retry budget burns chasing phantom IDs while the original payment never reaches the relay.

## How it surfaces in the wild

Reproduced on `arc skills run --name bitcoin-wallet -- x402 send-inbox-message` against a healthy relay:

```json
{"event":"payment.retry_decision","tool":"x402.send-inbox-message",
 "paymentId":"pay_98fb...","status":"not_found",
 "terminalReason":"unknown_payment_identity","action":"restart",
 "checkStatusUrl_present":false}
```

`checkStatusUrl_present: false` in every retry. The first call to a fresh identifier sometimes succeeds because the relay returns `checkStatusUrl` in that response; subsequent retries take the no-hint path and fall into the broken fallback. The relay itself is fine (`/health` healthy, sponsor nonce no gaps).

Direct verification:

```
GET https://x402-relay.aibtc.com/api/payment-status/pay_xxx  → 404
GET https://x402-relay.aibtc.com/payment/pay_xxx              → 200
```

## Changes

- `buildPaymentStatusCheckUrl`: `/api/payment-status/{id}` → `/payment/{id}`
- All 6 existing test mocks updated to the new path
- New `describe("buildPaymentStatusCheckUrl")` block pins the URL contract — if the relay route is renamed again, it surfaces as a unit-test failure instead of runtime `unknown_payment_identity` errors

Builds on #290, which introduced upstream-hint extraction but left this fallback pointing at the dead route.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun test src/lib/services/x402.service.test.ts` — 16/16 pass (2 new)
- [ ] Reviewer should confirm `/payment/{id}` is the canonical relay route (verified against v1.32.1; please confirm forward-compat)
- [ ] Manual: `arc skills run --name bitcoin-wallet -- x402 send-inbox-message` no longer falls into the `unknown_payment_identity` retry loop after merge + SDK pin bump in consumers

## Affected consumers

Any caller of `send-inbox-message` (welcome flows, agent-to-agent messaging) and any x402 paid call that lands in the no-hint response path. Symptom is 100% reproducible when the relay omits `checkStatusUrl`; intermittent across calls because some flows do return it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)