### PR TITLE
test(stacks-alpha-engine): unit test for expectedSwapOutput output-units invariant

### DIFF
--- a/stacks-alpha-engine/expectedSwapOutput.test.ts
+++ b/stacks-alpha-engine/expectedSwapOutput.test.ts
@@ -1,0 +1,78 @@
+import { describe, test, expect } from "bun:test";
+import { expectedSwapOutput, TOKENS } from "./stacks-alpha-engine";
+
+// Regression guard for arc0btc's review suggestion on PR #345 (review 4216429448):
+// "a minimal test that constructs a swap instruction and asserts expectedSwapOutput
+// returns output-denomination units would guard against regression."
+//
+// The bug class this guards: deriving min-received in INPUT-token atomic units
+// instead of OUTPUT-token atomic units. Under stable-stable same-decimal pairs
+// the bug is invisible; it surfaces when token decimals differ (e.g. sBTC 8d vs
+// USDCx 6d). A regression that uses input decimals would over-pin min-received
+// by 10^(inputDecimals - outputDecimals) and either trade at terrible fills or
+// silently abort.
+
+const PRICES = { sbtc: 78000, stx: 1, usdcx: 1, usdh: 1, aeusdc: 1 };
+
+describe("expectedSwapOutput output-denomination units invariant", () => {
+  test("sBTC (8d) -> USDCx (6d): result is scaled by output decimals, not input", () => {
+    // 0.01 sBTC at $78,000 -> $780 USD -> 780 USDCx
+    // Correct (output 6d):  780 * 10^6 = 780_000_000
+    // Bug (input 8d):       780 * 10^8 = 78_000_000_000  (would NOT equal expected)
+    const got = expectedSwapOutput(1_000_000, "sbtc", "usdcx", PRICES);
+    expect(got).toBe(780_000_000);
+    expect(got).not.toBe(78_000_000_000);
+  });
+
+  test("sBTC (8d) -> USDh (8d): same-decimal pair total magnitude is correct", () => {
+    // Same-decimal pair cannot discriminate the input-vs-output bug class
+    // (per file header), but still guards against an unrelated scaling
+    // regression that would change the absolute magnitude.
+    // 0.01 sBTC at $78,000 -> $780 -> 780 USDh -> 780 * 10^8 = 78_000_000_000
+    const got = expectedSwapOutput(1_000_000, "sbtc", "usdh", PRICES);
+    expect(got).toBe(78_000_000_000);
+  });
+
+  test("USDCx (6d) -> aeUSDC (6d): stable-stable code path at 1:1 USD", () => {
+    // Same-decimal stable-stable; doesn't discriminate the bug class but
+    // guards the stable-stable code path against future divergence.
+    // 100 USDCx -> $100 -> 100 aeUSDC -> 100 * 10^6 = 100_000_000
+    const got = expectedSwapOutput(100_000_000, "usdcx", "aeusdc", PRICES);
+    expect(got).toBe(100_000_000);
+  });
+
+  test("unknown input token returns 0", () => {
+    const got = expectedSwapOutput(1_000_000, "doge" as string, "usdcx", PRICES);
+    expect(got).toBe(0);
+  });
+
+  test("unknown output token returns 0", () => {
+    const got = expectedSwapOutput(1_000_000, "sbtc", "ethereum" as string, PRICES);
+    expect(got).toBe(0);
+  });
+
+  test("stable not in priceMap defaults to $1", () => {
+    // Construct prices without aeusdc; expected: aeusdc defaults to $1
+    // because it is in the stable-symbol fallback list.
+    const partial = { sbtc: 78000, stx: 1, usdcx: 1, usdh: 1 } as unknown as typeof PRICES;
+    // 0.01 sBTC at $78,000 -> $780 -> 780 aeUSDC (6d) -> 780_000_000
+    const got = expectedSwapOutput(1_000_000, "sbtc", "aeusdc", partial);
+    expect(got).toBe(780_000_000);
+  });
+
+  test("non-stable input price <= 0 returns 0 (no zero-division)", () => {
+    const zeroSbtc = { ...PRICES, sbtc: 0 };
+    const got = expectedSwapOutput(1_000_000, "sbtc", "usdcx", zeroSbtc);
+    expect(got).toBe(0);
+  });
+
+  test("TOKENS export round-trips decimals for all pairs used above", () => {
+    // Defensive guard so a TOKENS-table edit (e.g. wrong sBTC decimals)
+    // surfaces as a separate failing assertion rather than silently
+    // skewing the math tests above.
+    expect(TOKENS.sbtc?.decimals).toBe(8);
+    expect(TOKENS.usdcx?.decimals).toBe(6);
+    expect(TOKENS.usdh?.decimals).toBe(8);
+    expect(TOKENS.aeusdc?.decimals).toBe(6);
+  });
+});

--- a/stacks-alpha-engine/stacks-alpha-engine.ts
+++ b/stacks-alpha-engine/stacks-alpha-engine.ts
@@ -101,7 +101,7 @@ const HODLMM_POOLS: PoolDef[] = [
 
 // Token metadata for yield calculations
 interface TokenMeta { symbol: string; contract: string; decimals: number; ftSuffix: string }
-const TOKENS: Record<string, TokenMeta> = {
+export const TOKENS: Record<string, TokenMeta> = {
   sbtc:   { symbol: "sBTC",   contract: SBTC_TOKEN,   decimals: 8, ftSuffix: "::sbtc-token" },
   stx:    { symbol: "STX",    contract: "stx",        decimals: 6, ftSuffix: "" },
   usdcx:  { symbol: "USDCx",  contract: USDCX_TOKEN,  decimals: 6, ftSuffix: "::usdcx-token" },
@@ -1160,7 +1160,7 @@ function inferTargetPoolId(command: string, opts: Record<string, string>): strin
 
 // Estimate expected swap output in output-token atomic units, given input amount + scout prices.
 // Used by callers of buildDlmmSwapInstruction to derive the min-received guard correctly.
-function expectedSwapOutput(
+export function expectedSwapOutput(
   inputAmount: number,
   inputSymbol: string,
   outputSymbol: string,


### PR DESCRIPTION
## Summary

Regression-guard test responding to @arc0btc's `[suggestion]` on [PR #345 review](https://github.com/aibtcdev/skills/pull/345#pullrequestreview-4216429448):

> a minimal test that constructs a swap instruction and asserts `expectedSwapOutput` returns output-denomination units would guard against regression.

The bug class this guards: deriving `min-received` in **input-token** atomic units instead of **output-token** atomic units. Same-decimal stable-stable pairs hide the bug; it surfaces when token decimals differ (e.g. sBTC 8d → USDCx 6d). A regression that uses input decimals would over-pin `min-received` by `10^(inputDecimals - outputDecimals)` and either trade at terrible fills or silently abort.

## Changes

- `stacks-alpha-engine/stacks-alpha-engine.ts`: add `export` to `expectedSwapOutput` (line 1163) and `TOKENS` (line 104). Two single-keyword changes; no logic touched. `import.meta.main` guard at the bottom of the file already prevents CLI parse on test import.
- `stacks-alpha-engine/expectedSwapOutput.test.ts` (new, 79 lines, 8 cases):
  - **sBTC (8d) → USDCx (6d)** — load-bearing discriminator: asserts `not.toBe(78_000_000_000)` so an input-decimals regression fails this test
  - sBTC (8d) → USDh (8d) — same-decimal magnitude check
  - USDCx (6d) → aeUSDC (6d) — stable-stable code path
  - unknown input/output token returns 0
  - stable not in priceMap defaults to \$1
  - non-stable input price ≤ 0 returns 0 (no zero-division)
  - `TOKENS` decimals sanity guard

## Verification

- `bun test stacks-alpha-engine/expectedSwapOutput.test.ts` → 8 pass, 0 fail
- `bun typecheck` → clean
- `bun run validate` → 186/186 pass
- `bun run manifest` → no `.skills` delta (timestamp-only diff, not committed)
- Pre-existing test failures in `src/lib/services/x402.service.test.ts` confirmed unrelated by stash + re-run on origin/main

## Test plan

- [x] `bun test stacks-alpha-engine/expectedSwapOutput.test.ts` passes locally
- [x] `bun typecheck` clean
- [x] `bun run validate` 186/186 pass
- [ ] CI typecheck + manifest freshness pass
- [ ] CI test run picks up the 8 new tests

cc @arc0btc — addressing your suggestion from #345 review

🤖 Generated with [Claude Code](https://claude.com/claude-code)