### PR TITLE
fix(hodlmm-signal-allocator): declare requires: "wallet, signing, settings" on write-tagged skill (frontmatter only)

### DIFF
--- a/hodlmm-signal-allocator/SKILL.md
+++ b/hodlmm-signal-allocator/SKILL.md
@@ -7,7 +7,7 @@ metadata:
   user-invocable: "false"
   arguments: "doctor | scan --pool <id> --wallet <stx-addr> | run --pool <id> --wallet <stx-addr> --amount-stx <n> [--confirm] [--dry-run]"
   entry: "hodlmm-signal-allocator/hodlmm-signal-allocator.ts"
-  requires: ""
+  requires: "wallet, signing, settings"
   tags: "defi, write, mainnet-only, requires-funds, l2"
 ---
 


### PR DESCRIPTION
## Summary

Single-line frontmatter fix on `hodlmm-signal-allocator/SKILL.md` to declare `requires: "wallet, signing, settings"` on a write-tagged skill that previously shipped `requires: ""`.

## Defect

`hodlmm-signal-allocator` is tagged `defi, write, mainnet-only, requires-funds, l2` (`tags:` field) and contains real on-chain write paths (`PostConditionMode.Deny` + `broadcastTransaction` at line 445 of `hodlmm-signal-allocator.ts`). Per the composition convention in https://github.com/BitflowFinance/bff-skills/issues/483 Rule 2(b), write-tagged skills should declare their foundational dependencies in `metadata.requires` so the orchestrator loads `wallet`/`signing`/`settings` before the skill runs. The current empty `requires:` works at runtime today only because the ARC orchestrator implicitly injects those for write paths — explicit declaration is the convention the rest of the registry follows.

## Change

```diff
   entry: "hodlmm-signal-allocator/hodlmm-signal-allocator.ts"
-  requires: ""
+  requires: "wallet, signing, settings"
   tags: "defi, write, mainnet-only, requires-funds, l2"
```

## What this is NOT

- Not a code change. The `.ts` source is unchanged.
- Not a behavior change. Runtime semantics are identical (orchestrator already injects these for write paths).
- Not a postcondition or safety change. The skill ships with `PostConditionMode.Deny` already, and that stays.

## Verification

- `bun run scripts/validate-frontmatter.ts` should pass (comma-separated quoted-string format per #483 Rule 2(b)).
- `bun run scripts/generate-manifest.ts` should show `hodlmm-signal-allocator` with the populated `requires` field.

## Tracking

- META-P1 parent meta-issue: https://github.com/BitflowFinance/bff-skills/issues/590
- Track B P2 sub-issue (this fix-PR): https://github.com/BitflowFinance/bff-skills/issues/592
- Audit basis: independent line-level read of `hodlmm-signal-allocator.ts` (sender broadcast at line 445 with `PostConditionMode.Deny`, frontmatter `requires:` empty despite write-tagged classification)

## Read-only proof acknowledgement

This PR is a metadata-only frontmatter change. No on-chain transaction is broadcast as part of this PR's verification — the change does not affect runtime broadcast behavior. The skill's existing mainnet proof at https://github.com/aibtcdev/skills/pull/303 (Day 11 winner promotion) covers the runtime write path that is unchanged here.
