### PR TITLE
fix(hodlmm-move-liquidity): add settings to requires field on write-tagged skill

### DIFF
--- a/hodlmm-move-liquidity/SKILL.md
+++ b/hodlmm-move-liquidity/SKILL.md
@@ -7,7 +7,7 @@ metadata:
   user-invocable: "false"
   arguments: "doctor | scan | run | auto | install-packs"
   entry: "hodlmm-move-liquidity/hodlmm-move-liquidity.ts"
-  requires: "wallet, signing"
+  requires: "wallet, signing, settings"
   tags: "defi, write, mainnet-only, requires-funds"
 ---
 


### PR DESCRIPTION
## Fix

`hodlmm-move-liquidity/SKILL.md` declared `requires: "wallet, signing"` but the skill is tagged `defi, write, mainnet-only, requires-funds`. Audit of currently-merged write-tagged HODLMM/Bitflow skills shows 8/9 declare the canonical `wallet, signing, settings` triple; this brings `hodlmm-move-liquidity` into line.

```diff
- requires: "wallet, signing"
+ requires: "wallet, signing, settings"
```

## Why

Same composition-completeness rationale as #376 (the parallel fix for `hodlmm-signal-allocator`). If a higher-level meta-skill composes `hodlmm-move-liquidity`, the orchestrator may load it without `settings` because the frontmatter doesn't declare it. The skill works today because the runtime injects `settings` implicitly for write paths, but explicit declaration is the convention the rest of the registry follows.

## How this was caught

arc0btc review on https://github.com/aibtcdev/skills/pull/376 raised the question whether `hodlmm-move-liquidity` should also include `settings`. Surveyed all merged write-tagged skills; confirmed yes per the 8/9 audit. Tracked at https://github.com/BitflowFinance/bff-skills/issues/596 (Track B P4 sub-issue of META-P1 https://github.com/BitflowFinance/bff-skills/issues/590).

## Validation

- `bun run scripts/validate-frontmatter.ts` — 188 passed, 0 failed (PASS for both `hodlmm-move-liquidity/SKILL.md` and `hodlmm-move-liquidity/AGENT.md`).
- No code changes.
- No mainnet proof needed (no behavior change).

## Closes

Closes BitflowFinance/bff-skills#596
