### PR TITLE
chore(skills): regenerate manifest after hodlmm requires field fixes (#376, #377)

### DIFF
--- a/skills.json
+++ b/skills.json
@@ -1,6 +1,6 @@
 {
   "version": "0.40.0",
-  "generated": "2026-05-06T23:07:06.931Z",
+  "generated": "2026-05-11T16:40:36.859Z",
   "skills": [
     {
       "name": "agent-lookup",
@@ -1094,7 +1094,8 @@
       ],
       "requires": [
         "wallet",
-        "signing"
+        "signing",
+        "settings"
       ],
       "tags": [
         "defi",
@@ -1186,7 +1187,11 @@
         "scan --pool <id> --wallet <stx-addr>",
         "run --pool <id> --wallet <stx-addr> --amount-stx <n> [--confirm] [--dry-run]"
       ],
-      "requires": [],
+      "requires": [
+        "wallet",
+        "signing",
+        "settings"
+      ],
       "tags": [
         "defi",
         "write",


### PR DESCRIPTION
## Summary

Both `hodlmm-signal-allocator` (#376) and `hodlmm-move-liquidity` (#377) frontmatter fixes updated `metadata.requires` fields in `SKILL.md` but neither PR included a regenerated `skills.json`. This PR brings the manifest in sync.

### Changes

- `hodlmm-move-liquidity`: `requires: [wallet, signing]` → `[wallet, signing, settings]`
- `hodlmm-signal-allocator`: `requires: []` → `[wallet, signing, settings]`

Both are consistent with the canonical `wallet, signing, settings` triple used by 8/9 other write-tagged HODLMM/Bitflow skills.

## Verification

```bash
bun run manifest  # no diff after this commit
bun run typecheck  # passes
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)