### PR TITLE
chore(deps): bump @aibtc/tx-schemas to ^1.1.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -4,7 +4,7 @@
     "": {
       "name": "@aibtc/skills",
       "dependencies": {
-        "@aibtc/tx-schemas": "^0.3.0",
+        "@aibtc/tx-schemas": "^1.1.0",
         "@bitflowlabs/core-sdk": "^3.0.0",
         "@faktoryfun/styx-sdk": "^1.3.5",
         "@noble/curves": "^2.0.1",
@@ -35,7 +35,7 @@
     },
   },
   "packages": {
-    "@aibtc/tx-schemas": ["@aibtc/tx-schemas@0.3.0", "", { "dependencies": { "zod": "^4.3.6" } }, "sha512-pXzW9TnmFR3uJMfajbUdAYiPKRkNlzWWL2WGZ554NAeVIPq9vWyL6x8nrYtaDohuHlZRmMj1tSVeFap9AA+adw=="],
+    "@aibtc/tx-schemas": ["@aibtc/tx-schemas@1.1.0", "", { "dependencies": { "zod": "^4.3.6" } }, "sha512-jCautY4s8xT6oYC6l5d5tR9pbKTIziyny3YFI77mcmkoCzZzw7oedARYARuw1DSyxcHpXVoRTL0VM6MlTYA3LQ=="],
 
     "@bitflowlabs/core-sdk": ["@bitflowlabs/core-sdk@3.0.0", "", { "dependencies": { "@stacks/connect": "^7.10.2", "@stacks/network": "^7.0.2", "@stacks/transactions": "^7.0.5", "dotenv": "^16.4.7" } }, "sha512-5+STFKWtJzIx7G3MuZLPkB1T1r8HZEQ04Qe9anPhD8WwqRymzA8Km7J6AVGtrXuuE6svgqL0ezUwZUgOcUK0QA=="],
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "author": "aibtcdev",
   "license": "MIT",
   "dependencies": {
-    "@aibtc/tx-schemas": "^0.3.0",
+    "@aibtc/tx-schemas": "^1.1.0",
     "@bitflowlabs/core-sdk": "^3.0.0",
     "@faktoryfun/styx-sdk": "^1.3.5",
     "@noble/curves": "^2.0.1",

--- a/skills.json
+++ b/skills.json
@@ -1,6 +1,6 @@
 {
   "version": "0.41.0",
-  "generated": "2026-05-11T17:12:53.906Z",
+  "generated": "2026-05-11T17:17:00.899Z",
   "skills": [
     {
       "name": "agent-lookup",
@@ -2210,7 +2210,7 @@
     },
     {
       "name": "sbtc-yield-maximizer",
-      "description": "Routes idle sBTC to the highest safe live yield path and executes capped Zest supply when Zest is the best current route.",
+      "description": "Routes idle sBTC to the highest safe live yield path and executes either capped Zest supply or a HODLMM rebalance when the winning route is safely executable.",
       "entry": "sbtc-yield-maximizer/sbtc-yield-maximizer.ts",
       "arguments": [
         "doctor",
@@ -2221,7 +2221,9 @@
       "requires": [
         "wallet",
         "signing",
-        "settings"
+        "settings",
+        "hodlmm-move-liquidity",
+        "bitflow"
       ],
       "tags": [
         "defi",


### PR DESCRIPTION
## Summary

- Bumps `@aibtc/tx-schemas` from `^0.3.0` to `^1.1.0` in `package.json`
- No type migration required — all import paths from `/http/schemas`, `/core/enums`, and `/terminal-reasons` resolve cleanly against 1.1.0
- Regenerates `skills.json` to pick up SKILL.md description/requires changes already present in the repo

## Test plan

- [ ] `bun run typecheck` passes (0 errors)
- [ ] CI: TypeScript typecheck passes
- [ ] CI: manifest freshness check passes
- [ ] Issue #366 auto-closes on merge

Closes #366

🤖 Generated with [Claude Code](https://claude.com/claude-code)