### PR TITLE
fix(bitflow-hodlmm-deposit): allow first-time deposit by handling BFF user-bins 404

### DIFF
--- a/bitflow-hodlmm-deposit/bitflow-hodlmm-deposit.ts
+++ b/bitflow-hodlmm-deposit/bitflow-hodlmm-deposit.ts
@@ -1126,8 +1126,14 @@ function contextData(context: Context): JsonMap {
       pendingDepth: context.pendingDepth,
       postConditionMode: "deny",
       activeBinTolerance: {
-        observedActiveBinId: context.bins.active_bin_id,
-        routerExpectedBinId: routerExpectedBinId(context.bins.active_bin_id),
+        // BFF reports the active bin in ABSOLUTE coordinates [0, 1000] (center = HODLMM_CENTER_BIN_ID).
+        // The on-chain pool/router use RELATIVE coordinates [MIN_BIN_ID -500, MAX_BIN_ID 500] (center = 0).
+        // The two always differ by HODLMM_CENTER_BIN_ID (500) BY DESIGN — this gap is the center
+        // offset, not active-bin drift. The router's ERR_ACTIVE_BIN_TOLERANCE assert compares its own
+        // on-chain get-active-bin-id against onChainExpectedBinId (both relative), so a synced pool
+        // yields delta 0 and passes even at maxDeviation 0.
+        bffActiveBinId: context.bins.active_bin_id,
+        onChainExpectedBinId: routerExpectedBinId(context.bins.active_bin_id),
         maxDeviation: context.selection.activeBinMaxDeviation,
       },
       postconditions: [

--- a/bitflow-hodlmm-deposit/bitflow-hodlmm-deposit.ts
+++ b/bitflow-hodlmm-deposit/bitflow-hodlmm-deposit.ts
@@ -492,9 +492,25 @@ async function getBins(poolId: string): Promise<BinsResponse> {
 }
 
 async function getUserBins(wallet: string, poolId: string): Promise<Array<{ binId: number; userLiquidity: bigint; price?: string | number }>> {
-  const response = await fetchJson<UserBinsResponse>(
-    `${BITFLOW_API}/api/app/v1/users/${wallet}/positions/${poolId}/bins?fresh=true`
-  );
+  let response: UserBinsResponse;
+  try {
+    response = await fetchJson<UserBinsResponse>(
+      `${BITFLOW_API}/api/app/v1/users/${wallet}/positions/${poolId}/bins?fresh=true`
+    );
+  } catch (error) {
+    // BFF returns HTTP 404 with detail "Pool {pool} not found or user {addr} has no pool bins"
+    // when a wallet has no existing LP positions in the pool. This is the normal first-time
+    // deposit case (explicitly supported per SKILL.md) — not an error. Return an empty bins
+    // array so downstream postcondition-plan adjustment treats the wallet as a new LP.
+    if (
+      error instanceof Error &&
+      error.message.startsWith("HTTP 404 from") &&
+      /has no pool bins/i.test(error.message)
+    ) {
+      return [];
+    }
+    throw error;
+  }
   const bins = Array.isArray(response.bins) ? response.bins : [];
   return bins
     .map((bin) => ({

--- a/bitflow-hodlmm-deposit/bitflow-hodlmm-deposit.ts
+++ b/bitflow-hodlmm-deposit/bitflow-hodlmm-deposit.ts
@@ -502,6 +502,10 @@ async function getUserBins(wallet: string, poolId: string): Promise<Array<{ binI
     // when a wallet has no existing LP positions in the pool. This is the normal first-time
     // deposit case (explicitly supported per SKILL.md) — not an error. Return an empty bins
     // array so downstream postcondition-plan adjustment treats the wallet as a new LP.
+    // NOTE: this catch is coupled to fetchJson's error message format ("HTTP 404 from ...").
+    // If fetchJson's error format changes, update the startsWith check below accordingly —
+    // otherwise the catch silently fails (404 propagates instead of returning []), which is
+    // safe (no data loss) but the fix stops working with no diagnostic signal.
     if (
       error instanceof Error &&
       error.message.startsWith("HTTP 404 from") &&


### PR DESCRIPTION
## Summary

`bitflow-hodlmm-deposit` is currently unusable for any wallet without
existing LP positions in the target pool — i.e., every first-time
depositor. The `doctor`, `status`, and `run` subcommands all crash before
any deposit logic runs because `getUserBins` does not handle the BFF
user-positions endpoint's empty-state 404.

This is the upstream port of [`BitflowFinance/bff-skills#583`](https://github.com/BitflowFinance/bff-skills/pull/583), which patches the same bug
in the staging copy. The staging PR has been awaiting review since
2026-05-05; this PR brings the fix to the live registry so agents using
the skill via `aibtcdev/skills` can deposit.

## Reproduction (any fresh wallet)

```bash
bun run bitflow-hodlmm-deposit/bitflow-hodlmm-deposit.ts doctor \
  --wallet SP3YWTZQQ7ZYHG1ECEG6AJAT4KX36W2NA7Q6TCKBG --pool-id dlmm_1
```

Returns:

```json
{
  \"error\": \"HTTP 404 from https://bff.bitflowapis.finance/api/app/v1/users/SP3YWTZQQ7ZYHG1ECEG6AJAT4KX36W2NA7Q6TCKBG/positions/dlmm_1/bins?fresh=true: {\\\"detail\\\":\\\"Pool dlmm_1 not found or user SP3YWTZQQ7ZYHG1ECEG6AJAT4KX36W2NA7Q6TCKBG has no pool bins\\\"}\"
}
```

This contradicts the skill's own SKILL.md which explicitly claims
first-time support:

> Selected bins may already have wallet LP position state or may be
> first-time wallet position targets ... It supports first-time deposits
> into valid selected bins and only uses existing wallet position state to
> adjust the postcondition plan.

## Root cause

`getUserBins` (around line 494) calls \`fetchJson\` with no try/catch. BFF
returns HTTP 404 with detail \`\"Pool {pool} not found or user {addr} has
no pool bins\"\` when a wallet has zero positions — a normal first-time
case. The throw bubbles up.

Downstream code at line 498+ already gracefully handles an empty \`bins\`
array via \`.filter(b => b.userLiquidity > 0n)\`. The fix is to catch the
specific 404 shape and return \`[]\`.

## API surface check

Live spec: https://bff.bitflowapis.finance/api/app/openapi.json

- \`/api/app/v1/users/{user_address}/positions/{pool_id}/bins\` (Get User
  Pool Bins) is the user-position state endpoint.
- Pool validity is established by separate \`/api/app/v1/pools/{pool_id}\`
  and \`/api/quotes/v1/bins/{pool_id}\` calls — those checks already run
  before this call in \`collectContext\`.
- A missing user-position row when pool metadata and protocol-bin data are
  valid means \"this wallet has no position yet,\" not \"the pool is
  unusable.\" That's the semantic this PR codifies.

## Change

Wrap the \`fetchJson\` in try/catch. Catch ONLY the specific
\`HTTP 404 from ... has no pool bins\` shape; let any other 404 or API
failure propagate.

\`\`\`typescript
async function getUserBins(...) {
  let response: UserBinsResponse;
  try {
    response = await fetchJson<UserBinsResponse>(
      \`\${BITFLOW_API}/api/app/v1/users/\${wallet}/positions/\${poolId}/bins?fresh=true\`
    );
  } catch (error) {
    if (
      error instanceof Error &&
      error.message.startsWith(\"HTTP 404 from\") &&
      /has no pool bins/i.test(error.message)
    ) {
      return [];
    }
    throw error;
  }
  // ... existing parsing logic unchanged
}
\`\`\`

- Selected protocol-bin validation, token balance checks, postconditions,
  and deny-mode transaction safety: all unchanged.
- All other 404s and API failures: propagated unchanged.

## Verification

\`bun run typecheck\` passes (mandatory per CONTRIBUTING.md).

End-to-end on Stacks mainnet across 3 wallet shapes:

| Scenario | Wallet | Pool | Result |
|---|---|---|---|
| Fresh wallet (was failing) | SP3YWTZQ... (0 cards) | dlmm_1 | ✅ doctor + status succeed |
| Wallet w/ positions (regression check) | SP2G6TM8... (3 cards) | dlmm_1 | ✅ no regression |
| Wallet w/ positions in OTHER pool | SP2G6TM8... (3 cards, none in dlmm_9) | dlmm_9 | ✅ first-time path correct |
| Status preview \`--offsets 0,1,2\` | SP3YWTZQ... | dlmm_1, 20k sats X | ✅ activeBin 648, 3-bin equal-split, slippage-protected minDlp, bounded postcondition |
| Status preview \`--plan-json\` | SP3YWTZQ... | dlmm_1 | ✅ explicit-plan path; \`hasExistingPosition: false\` correctly set |

Cross-pool variants: dlmm_1, dlmm_3, dlmm_7 — all pass.

## Active-bin tolerance — verified against the live contracts (not an open issue)

An earlier draft of this PR flagged the status preview's `activeBinTolerance`
block as a possible "router-vs-BFF sync" issue that would block first-time
broadcast at `maxDeviation: 0`. **Contract-level verification shows this is a
false alarm** — the apparent discrepancy is a coordinate-system difference, by
design, not active-bin drift.

Verified against the live router `SM1FKXGNZJWSTWDWXQZJNF7B5TV5ZB235JTCXYXKD.dlmm-liquidity-router-v-1-1`
(`add-relative-liquidity-same-multi`) and pool `dlmm-pool-sbtc-usdcx-v-1-bps-10`
(dlmm_1):

- BFF reports `active_bin_id` in **absolute** coordinates `[0, 1000]`, center 500
  (e.g. `646`).
- The on-chain pool/router use **relative** coordinates `[MIN_BIN_ID -500, MAX_BIN_ID 500]`,
  center 0. Live `get-active-bin-id` returned `(ok 146)`.
- The skill passes `expected-bin-id = active_bin_id - 500 = 146`.
- The router's `ERR_ACTIVE_BIN_TOLERANCE` assert computes
  `abs(get-active-bin-id - expected-bin-id) = abs(146 - 146) = 0`, which is
  `<= max-deviation (0)` → **passes**. First-time broadcast is **not** blocked.

The 500-bin gap the preview showed (`646` vs `146`) was just the absolute-vs-relative
center offset displayed without labels. A follow-up commit on this branch renames those
fields to `bffActiveBinId` / `onChainExpectedBinId` and documents the coordinate systems
so this is not misdiagnosed again.

The full first-time broadcast path (`run --confirm=DEPOSIT`) was still not exercised
end-to-end in this PR's test pass (read/preview paths were), but the contract logic
above confirms there is no active-bin-tolerance blocker on the happy path.

## Why this matters

Every new LP onboarding via this skill is currently blocked at the first
read. The skill on aibtc.com/skills serves the version in this repo, so
the live agent ecosystem is affected today. This is a targeted try/catch
that unblocks the entire happy path the SKILL.md already documents.
