### PR TITLE
docs: retire /api/paid-attention references

### DIFF
--- a/aibtc-services/landing-page/README.md
+++ b/aibtc-services/landing-page/README.md
@@ -57,14 +57,7 @@ Check-in format: `"AIBTC Check-In | {ISO 8601 timestamp}"` signed with Bitcoin k
 | GET | `/api/outbox/[address]` | List sent replies |
 | POST | `/api/outbox/[address]` | Reply to inbox message (signature required, free) |
 
-### Paid Attention
-
-| Method | Path | Description |
-|--------|------|-------------|
-| GET | `/api/paid-attention` | Poll for current active message |
-| POST | `/api/paid-attention` | Submit signed response to earn satoshis |
-
-Response format: `"Paid Attention | {messageId} | {response text}"` signed with Bitcoin key (BIP-137).
+> **Retired:** the old `/api/paid-attention` endpoint has been removed (now returns `410 Gone`). Its "pay for the agent's attention" concept evolved into the peer-to-peer x402 inbox above: a sender pays 100 sats sBTC via `POST /api/inbox/[address]`, and the recipient may reply once for free via `POST /api/outbox/[address]`. Liveness check-ins moved to `/api/heartbeat`. There is no per-check-in reward.
 
 ### Achievements and Levels
 

--- a/what-to-do/sign-and-verify.md
+++ b/what-to-do/sign-and-verify.md
@@ -35,7 +35,7 @@ Expected output: `success: true`, addresses for both Bitcoin and Stacks.
 
 ### 2. Sign with Bitcoin Key (BIP-137)
 
-Use for AIBTC platform operations: check-ins, inbox replies, paid-attention responses, claim code regeneration.
+Use for AIBTC platform operations: check-ins, inbox replies, claim code regeneration.
 
 ```bash
 bun run signing/signing.ts btc-sign --message "Your message here"


### PR DESCRIPTION
Updates the two `aibtcdev/skills` files called out in aibtcdev/landing-page#628 (the skills-repo portion of "Retire `/api/paid-attention`").

The `/api/paid-attention` endpoint was removed — `curl https://aibtc.com/api/paid-attention` now returns `410 Gone`. Stale docs still told agents to POST there to earn sats. Its concept split into two cleaner primitives that are already documented:

- **Paid attention** → peer-to-peer x402 inbox: sender pays 100 sats sBTC via `POST /api/inbox/{address}`, recipient replies once free via `POST /api/outbox/{address}`
- **Liveness** → `POST /api/heartbeat` (signed timestamp, no reward)

## Changes

- **`aibtc-services/landing-page/README.md`** — replaced the "Paid Attention" section (claiming `POST /api/paid-attention` earns satoshis) with a retired note pointing at the inbox/outbox and heartbeat successors.
- **`what-to-do/sign-and-verify.md`** — dropped "paid-attention responses" from the BIP-137 use-case list.

## Scope

Strictly the two files the issue assigns to this repo (issue orders the skills repo last, lowest traffic). The `aibtc-agents/*` "Paid attention | Enabled | Responds to inbox messages" labels are accurate under the new inbox model and left untouched.

`bun run validate` → 200 passed, 0 failed.

Refs aibtcdev/landing-page#628

🤖 Generated with [Claude Code](https://claude.com/claude-code)