### PR TITLE
docs: add LunarCrush manual retry policy

### DIFF
--- a/lunarcrush/AGENT.md
+++ b/lunarcrush/AGENT.md
@@ -50,6 +50,12 @@ Before calling `score`:
 | `400 invalid_symbol` | Did not consume payment. Symbol must be lowercase a-z + 0-9 only, max 16 chars. Check input. |
 | `5xx` from worker | Worker outage. Retry once after 30s. If persists, alert operator. |
 
+## Manual retry policy
+
+If you receive a `200` response with `galaxy_score: null` and believe the call consumed payment against an upstream failure, open a GitHub issue or mention the skill maintainer on the existing LunarCrush payment-vs-delivery thread with the payment txid and symbol queried.
+
+The maintainer can verify the on-chain payment, cross-check the server-side failure log, and honor a manual re-serve of the data. One retry per txid; caller-surfaced proof is required. This policy holds until an automated retry-with-proof endpoint ships.
+
 ## Safety checks
 
 - **No private key handling.** This skill never logs, prints, or transmits the wallet seed phrase. All signing happens via `getAccount()` returning a properly-scoped account object.

--- a/lunarcrush/AGENT.md
+++ b/lunarcrush/AGENT.md
@@ -52,7 +52,7 @@ Before calling `score`:
 
 ## Manual retry policy
 
-If you receive a `200` response with `galaxy_score: null` and believe the call consumed payment against an upstream failure, open a GitHub issue or mention the skill maintainer on the existing LunarCrush payment-vs-delivery thread with the payment txid and symbol queried.
+If a paid call returns `200` with `galaxy_score: null`, open a GitHub issue referencing the LunarCrush payment-vs-delivery thread with the payment txid and symbol queried.
 
 The maintainer can verify the on-chain payment, cross-check the server-side failure log, and honor a manual re-serve of the data. One retry per txid; caller-surfaced proof is required. This policy holds until an automated retry-with-proof endpoint ships.
 


### PR DESCRIPTION
Adds the interim manual retry policy discussed in #393 for the LunarCrush paid-call case where a request returns `200` with `galaxy_score: null` after payment consumption.

This is intentionally small and operational:
- caller provides payment txid + queried symbol;
- maintainer verifies on-chain payment and server-side failure log;
- one manual re-serve per txid until automated retry-with-proof exists.

References #393.