### PR TITLE
fix(bitflow-hodlmm-deposit): key NFT post-conditions on actual NFT ownership, not userLiquidity > 0

### DIFF
--- a/bitflow-hodlmm-deposit/SKILL.md
+++ b/bitflow-hodlmm-deposit/SKILL.md
@@ -143,3 +143,7 @@ Fatal error:
 Winner of AIBTC x Bitflow Skills Pay the Bills competition.
 Original author: @macbotmini-eng
 Competition PR: https://github.com/BitflowFinance/bff-skills/pull/556
+
+## Post-condition correctness update (2026-07-15 field audit F-7)
+
+Per-bin position-NFT post-conditions are keyed on **actual NFT ownership** (Hiro NFT holdings), not only `userLiquidity > 0`. Root cause: the pool's `tag-pool-token-id` burns and re-mints the bin NFT on every mint/burn where the wallet already owns it — and ownership **persists at zero liquidity**, so re-entering a previously fully-withdrawn bin moves the NFT even though the positions endpoint shows no liquidity. Without the PC, such a deposit aborts in Deny mode and burns the fee.

--- a/bitflow-hodlmm-deposit/bitflow-hodlmm-deposit.ts
+++ b/bitflow-hodlmm-deposit/bitflow-hodlmm-deposit.ts
@@ -550,11 +550,20 @@ async function getOwnedPositionNftBinIds(wallet: string, poolContract: string): 
     );
     const results = Array.isArray(page.results) ? page.results : [];
     for (const item of results) {
+      // repr shape verified against live Hiro data 2026-07-15 for dlmm pool
+      // NFTs: "(tuple (owner 'SP...) (token-id u5))". If the shape ever
+      // changes, the loud warning below prevents silently regressing to the
+      // old under-detection behavior.
       const match = /\(token-id u(\d+)\)/.exec(item.value?.repr ?? "");
       if (match) owned.add(Number(match[1]));
     }
     offset += results.length;
     if (results.length < limit || offset >= (page.total ?? 0)) break;
+  }
+  if (owned.size === 0 && offset > 0) {
+    console.error(
+      `WARNING: ${offset} ${assetId} holdings returned but no token-ids parsed — repr shape may have changed; NFT PC detection degraded to liquidity-only.`
+    );
   }
   return owned;
 }
@@ -1149,7 +1158,7 @@ function contextData(context: Context): JsonMap {
     },
     activeBin: context.bins.active_bin_id,
     selection: context.selection,
-    selectedBins: context.selectedBins.map(binData),
+    selectedBins: context.selectedBins.map((bin) => binData(bin, context.ownedNftBinIds)),
     skippedBins: context.skippedBins,
     totals: context.totals,
     tokens: {
@@ -1175,7 +1184,7 @@ function contextData(context: Context): JsonMap {
         context.totals.xAmount > 0n ? `wallet sends <= ${context.totals.xAmount} ${context.xAsset.symbol}` : null,
         context.totals.yAmount > 0n ? `wallet sends <= ${context.totals.yAmount} ${context.yAsset.symbol}` : null,
         ...context.selectedBins
-          .filter((bin) => bin.hasExistingPosition)
+          .filter((bin) => bin.hasExistingPosition || context.ownedNftBinIds.has(bin.binId))
           .map((bin) => `wallet sends existing ${context.pool.poolContract}::${DLP_TOKEN_ID_ASSET_NAME} token-id ${bin.binId}`),
       ].filter(Boolean),
       dlpNote: "Minimum DLP and max liquidity fee bounds are enforced by router arguments.",
@@ -1184,7 +1193,7 @@ function contextData(context: Context): JsonMap {
   };
 }
 
-function binData(bin: DepositCandidate) {
+function binData(bin: DepositCandidate, ownedNftBinIds?: Set<number>) {
   return {
     index: bin.index,
     binId: bin.binId,
@@ -1200,6 +1209,7 @@ function binData(bin: DepositCandidate) {
     maxXLiquidityFee: bin.maxXLiquidityFee,
     maxYLiquidityFee: bin.maxYLiquidityFee,
     hasExistingPosition: bin.hasExistingPosition,
+    willAttachNftPc: bin.hasExistingPosition || (ownedNftBinIds?.has(bin.binId) ?? false),
   };
 }
 

--- a/bitflow-hodlmm-deposit/bitflow-hodlmm-deposit.ts
+++ b/bitflow-hodlmm-deposit/bitflow-hodlmm-deposit.ts
@@ -252,6 +252,7 @@ interface Context {
   poolInterface: ContractInterface;
   xAsset: TokenAsset;
   yAsset: TokenAsset;
+  ownedNftBinIds: Set<number>;
 }
 
 interface SharedOptions {
@@ -528,6 +529,34 @@ async function getUserBins(wallet: string, poolId: string): Promise<Array<{ binI
 
 async function getBalances(wallet: string): Promise<HiroBalancesResponse> {
   return fetchJson<HiroBalancesResponse>(`${HIRO_API}/extended/v1/address/${wallet}/balances`);
+}
+
+// 2026-07-15 field audit F-7: the pool's tag-pool-token-id burns AND re-mints the
+// bin's position NFT on every pool-mint/pool-burn IF the wallet already owns it —
+// a sender asset movement that needs an NFT post-condition in Deny mode. For a
+// first-time bin only a mint occurs, so a declared "will send NFT" PC there aborts
+// the tx. Crucially, NFT ownership PERSISTS AT ZERO LIQUIDITY (tag re-mints on the
+// final burn too), so `userLiquidity > 0` under-detects: re-entering a previously
+// fully-withdrawn bin still moves the NFT and would abort in Deny mode without a
+// PC. Read actual NFT holdings instead.
+async function getOwnedPositionNftBinIds(wallet: string, poolContract: string): Promise<Set<number>> {
+  const owned = new Set<number>();
+  const assetId = `${poolContract}::${DLP_TOKEN_ID_ASSET_NAME}`;
+  let offset = 0;
+  const limit = 200;
+  for (;;) {
+    const page = await fetchJson<{ total?: number; results?: Array<{ value?: { repr?: string } }> }>(
+      `${HIRO_API}/extended/v1/tokens/nft/holdings?principal=${wallet}&asset_identifiers=${encodeURIComponent(assetId)}&limit=${limit}&offset=${offset}`
+    );
+    const results = Array.isArray(page.results) ? page.results : [];
+    for (const item of results) {
+      const match = /\(token-id u(\d+)\)/.exec(item.value?.repr ?? "");
+      if (match) owned.add(Number(match[1]));
+    }
+    offset += results.length;
+    if (results.length < limit || offset >= (page.total ?? 0)) break;
+  }
+  return owned;
 }
 
 async function getPendingTransactions(wallet: string): Promise<HiroMempoolResponse> {
@@ -929,8 +958,12 @@ function buildPostConditions(context: Context) {
     }
   }
 
+  // F-7: key the per-bin NFT PC on actual NFT OWNERSHIP (Hiro NFT holdings),
+  // not on userLiquidity > 0 — the position NFT persists at zero liquidity, so
+  // re-entering a previously fully-withdrawn bin still burns+re-mints the NFT
+  // and needs the PC in Deny mode.
   for (const bin of context.selectedBins) {
-    if (bin.hasExistingPosition) {
+    if (bin.hasExistingPosition || context.ownedNftBinIds.has(bin.binId)) {
       postConditions.push(Pc.principal(context.wallet)
         .willSendAsset()
         .nft(
@@ -967,12 +1000,13 @@ async function collectContext(opts: SharedOptions, requirePlan = true): Promise<
     getContract(HODLMM_LIQUIDITY_ROUTER),
   ]);
 
-  const [poolContract, routerInterface, poolInterface, xInterface, yInterface] = await Promise.all([
+  const [poolContract, routerInterface, poolInterface, xInterface, yInterface, ownedNftBinIds] = await Promise.all([
     getContract(pool.poolContract),
     getContractInterface(HODLMM_LIQUIDITY_ROUTER),
     getContractInterface(pool.poolContract),
     getContractInterface(pool.tokenX.contract),
     getContractInterface(pool.tokenY.contract),
+    getOwnedPositionNftBinIds(wallet, pool.poolContract),
   ]);
 
   if (!pool.status) {
@@ -1087,6 +1121,7 @@ async function collectContext(opts: SharedOptions, requirePlan = true): Promise<
     poolInterface,
     xAsset,
     yAsset,
+    ownedNftBinIds,
   };
 }
 


### PR DESCRIPTION
## Problem

The pool's `tag-pool-token-id` private function burns **and re-mints** the bin's position NFT on every `pool-mint`/`pool-burn` where the wallet already owns it — a sender asset movement that needs an NFT post-condition in Deny mode. The current `hasExistingPosition` check (`userLiquidity > 0n`) under-detects one case: **NFT ownership persists at zero liquidity** (the final burn's tag re-mints the NFT). Re-entering a bin the wallet previously fully withdrew from therefore burns+re-mints the NFT with no covering PC — the tx aborts in Deny mode and the fee is burned. This is the same failure shape as the abort class that cost us 0.25 STX in the field (and matches the event pattern in Bitflow's own 2026-07-13 dapp incident on this router).

## Change

- New `getOwnedPositionNftBinIds()`: reads the wallet's actual `pool-token-id` NFT holdings from Hiro (`/extended/v1/tokens/nft/holdings`, paginated) at context-collection time.
- The per-bin NFT PC is attached when `hasExistingPosition` **OR** the wallet owns the bin's NFT — covering the zero-liquidity re-entry case while still omitting the PC for genuinely first-time bins (pure mint, no sender movement).
- Deny mode throughout, unchanged. SKILL.md documents the root cause.

Basis: 2026-07-15 line-by-line audit vs BitflowFinance/bitflow-dlmm pool source. Full audit: https://github.com/k9dreamer-graphite-elan/guides-for-ai-bitcoin-agents (Handbook v0.10).

🤖 Generated with [Claude Code](https://claude.com/claude-code)