### PR TITLE
fix(hodlmm-signal-allocator): validated configurable swap fee (was hardcoded 5000 µSTX)

### DIFF
--- a/hodlmm-signal-allocator/hodlmm-signal-allocator.ts
+++ b/hodlmm-signal-allocator/hodlmm-signal-allocator.ts
@@ -19,6 +19,24 @@ import * as crypto from "crypto";
 
 // ─── Constants ─────────────────────────────────────────────────────────────────
 
+// Swap fee in micro-STX (F-14 pattern, same as aibtcdev/skills#410): a
+// hardcoded 5000 uSTX was 10-50x below peer skills and an underpriced fee is
+// a stuck-head-nonce seed. Strictly validated: an empty or malformed env var
+// errors loudly instead of silently broadcasting a zero-fee tx (BigInt("")
+// is 0n).
+const DEFAULT_ALLOCATOR_FEE_USTX = 50_000n;
+const MAX_ALLOCATOR_FEE_USTX = 1_000_000n; // 1 STX sanity cap
+
+function resolveAllocatorFeeUstx(): bigint {
+  const raw = process.env.ALLOCATOR_FEE_USTX;
+  if (raw === undefined || raw === "") return DEFAULT_ALLOCATOR_FEE_USTX;
+  if (!/^\d+$/.test(raw)) throw new Error(`ALLOCATOR_FEE_USTX must be a whole number of micro-STX, got "${raw}"`);
+  const fee = BigInt(raw);
+  if (fee === 0n) throw new Error("ALLOCATOR_FEE_USTX must be > 0 (a zero-fee tx strands the head nonce)");
+  if (fee > MAX_ALLOCATOR_FEE_USTX) throw new Error(`ALLOCATOR_FEE_USTX ${raw} exceeds the ${MAX_ALLOCATOR_FEE_USTX} uSTX sanity cap`);
+  return fee;
+}
+
 const STATE_FILE = path.join(os.homedir(), ".hodlmm-signal-allocator-state.json");
 const WALLETS_FILE = path.join(os.homedir(), ".aibtc", "wallets.json");
 const WALLETS_DIR = path.join(os.homedir(), ".aibtc", "wallets");
@@ -439,7 +457,7 @@ async function executeSwap(opts: {
     network: STACKS_MAINNET,
     senderKey: opts.stxPrivateKey,
     anchorMode: AnchorMode.Any,
-    fee: 5000n,
+    fee: resolveAllocatorFeeUstx(),
   });
 
   const broadcastRes = await broadcastTransaction({ transaction: tx, network: STACKS_MAINNET });


### PR DESCRIPTION
Follow-up to [#410](https://github.com/aibtcdev/skills/pull/410), where review (biwasxyz) flagged this file's identical `fee: 5000n` — the same F-14 underpriced-fee pattern: 10–50× below peer skill defaults (deposit/withdraw 50k, zest/swap-aggregator 70k, limit-order 100k, move-liquidity 250k), and an underpriced fee strands the signer's head nonce.

Same validated pattern as the revised #410: `ALLOCATOR_FEE_USTX` (env), strict `^\d+$` parse with labeled errors (empty env ≠ silent `BigInt("") = 0n` zero-fee broadcast; decimals error loudly), default 50000 µSTX, 1 STX sanity cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)