### PR TITLE
fix(stacking): add pox-5 support for Epoch 4.0 hard fork

### DIFF
--- a/src/lib/config/contracts.ts
+++ b/src/lib/config/contracts.ts
@@ -17,6 +17,12 @@ export const MAINNET_CONTRACTS = {
 
   // Stacking
   POX_4: "SP000000000000000000002Q6VF78.pox-4",
+  // Epoch 4.0 hard fork (stacks-core 4.0.1): pox-5 replaces pox-4 at the same
+  // boot-contract address, following the pox-2/pox-3/pox-4 deployment pattern.
+  // Prefer resolving the active PoX contract dynamically via
+  // StackingService.getActivePoxContract() (reads /v2/pox contract_id);
+  // this is the static fallback if that lookup fails.
+  POX_5: "SP000000000000000000002Q6VF78.pox-5",
 
   // ALEX DEX (SDK handles most operations, but we need pool contract for queries)
   ALEX_AMM_POOL: "SP3K8BC0PPEVCV7NZ6QSRWPQ2JE9E5B6N3PA0KBR9.amm-swap-pool-v1-1",
@@ -167,6 +173,7 @@ export const TESTNET_CONTRACTS = {
 
   // Stacking
   POX_4: "ST000000000000000000002AMW42H.pox-4",
+  POX_5: "ST000000000000000000002AMW42H.pox-5",
 
   // ERC-8004 Identity & Reputation
   IDENTITY_REGISTRY: "ST3YT0XW92E6T2FE59B2G5N2WNNFSBZ6MZKQS5D18.identity-registry-v2",

--- a/src/lib/services/stacking.service.ts
+++ b/src/lib/services/stacking.service.ts
@@ -39,13 +39,31 @@ export class StackingService {
   }
 
   /**
+   * Resolve the currently active PoX contract (e.g. pox-4, pox-5) from the
+   * node's /v2/pox response, instead of hardcoding a version. Falls back to
+   * the static POX_5 contract if the lookup fails, so stacking keeps working
+   * across future PoX version bumps without a code change.
+   */
+  private async getActivePoxContract(): Promise<string> {
+    try {
+      const poxInfo = await this.hiro.getPoxInfo();
+      if (poxInfo?.contract_id) {
+        return poxInfo.contract_id;
+      }
+    } catch {
+      // Fall through to static fallback
+    }
+    return this.contracts.POX_5;
+  }
+
+  /**
    * Get stacking status for an address
    * Note: Returns whether the address is stacking, but detailed amounts require proper CV parsing
    */
   async getStackingStatus(address: string): Promise<StackingStatus> {
     try {
       const result = await this.hiro.callReadOnlyFunction(
-        this.contracts.POX_4,
+        await this.getActivePoxContract(),
         "get-stacker-info",
         [{ type: "principal", value: address } as unknown as ClarityValue],
         address
@@ -87,7 +105,9 @@ export class StackingService {
     startBurnHeight: number,
     lockPeriod: number
   ): Promise<TransferResult> {
-    const { address: contractAddress, name: contractName } = parseContractId(this.contracts.POX_4);
+    const { address: contractAddress, name: contractName } = parseContractId(
+      await this.getActivePoxContract()
+    );
 
     const functionArgs: ClarityValue[] = [
       uintCV(amount),
@@ -123,7 +143,9 @@ export class StackingService {
     extendCount: number,
     poxAddress: { version: number; hashbytes: string }
   ): Promise<TransferResult> {
-    const { address: contractAddress, name: contractName } = parseContractId(this.contracts.POX_4);
+    const { address: contractAddress, name: contractName } = parseContractId(
+      await this.getActivePoxContract()
+    );
 
     const functionArgs: ClarityValue[] = [
       uintCV(extendCount),
@@ -150,7 +172,9 @@ export class StackingService {
     account: Account,
     increaseAmount: bigint
   ): Promise<TransferResult> {
-    const { address: contractAddress, name: contractName } = parseContractId(this.contracts.POX_4);
+    const { address: contractAddress, name: contractName } = parseContractId(
+      await this.getActivePoxContract()
+    );
 
     const functionArgs: ClarityValue[] = [uintCV(increaseAmount)];
 
@@ -180,7 +204,9 @@ export class StackingService {
     untilBurnHeight?: number,
     poxAddress?: { version: number; hashbytes: string }
   ): Promise<TransferResult> {
-    const { address: contractAddress, name: contractName } = parseContractId(this.contracts.POX_4);
+    const { address: contractAddress, name: contractName } = parseContractId(
+      await this.getActivePoxContract()
+    );
 
     const functionArgs: ClarityValue[] = [
       uintCV(amount),
@@ -208,7 +234,9 @@ export class StackingService {
    * Revoke delegation
    */
   async revokeDelegation(account: Account): Promise<TransferResult> {
-    const { address: contractAddress, name: contractName } = parseContractId(this.contracts.POX_4);
+    const { address: contractAddress, name: contractName } = parseContractId(
+      await this.getActivePoxContract()
+    );
 
     // No assets moved from sender (revokes delegation permission)
     return callContract(account, {


### PR DESCRIPTION
## Summary
- stacks-core 4.0.1 activates the Epoch 4.0 hard fork: pox-5 replaces pox-4, Clarity 6 added. `StackingService` hardcoded `POX_4` for `stack-stx`, `stack-extend`, `stack-increase`, `delegate-stx`, `revoke-delegate-stx`, and `get-stacker-info` — these will fail/no-op against an inactive contract post-activation.
- Added a `POX_5` contract constant (`src/lib/config/contracts.ts`, mainnet + testnet, same boot-contract address as pox-4 following the pox-2/3/4 pattern).
- `StackingService` now resolves the active PoX contract dynamically at call time via the node's `/v2/pox` `contract_id` field, falling back to the static `POX_5` constant if that lookup fails — avoids hardcoding either version and future-proofs against the next PoX bump.

## Investigation: stackspot.app pot contracts (read-only, no code change)
Checked the deployed `Genesis` pot contract (`SPT4SQP5RC1BFAJEQKBHZMXQ8NQ7G118F335BD85.Genesis`, used by `skills/stacks-stackspot`) via Hiro's contract-source endpoint:
```
(define-constant pox-data (contract-call? 'SP000000000000000000002Q6VF78.pox-4 get-pox-info))
(as-contract (contract-call? 'SP000000000000000000002Q6VF78.pox-4 allow-contract-caller 'SPMPMA1V6P430M8C91QS1G9XJ95S59JS1TZFZ4Q4.pox4-multi-pool-v1 none))
```
This pot contract hardcodes `pox-4` and calls `allow-contract-caller`, a function pox-5 removes entirely. Since it's already-deployed, immutable Clarity code, this can't be patched — stackspot.app would need to deploy a new pot contract against pox-5. **This repo's code can't fix that; filing a follow-up to watch for stackspot.app's migration and pause stackspot auto-join if it doesn't land before activation.**

## Test plan
- [x] `bun run typecheck` passes clean
- [ ] CI (existing test suite)
- [ ] Manual verification against a pox-5 testnet/mainnet activation once live (contract addresses in this PR are unverified — no deployed pox-5 exists yet per current release notes)

Note: not urgent — hard-fork activation height has not been reached yet per stacks-core 4.0.1 release notes, but this should land before activation to avoid silent stacking failures.